### PR TITLE
Protect Redis credentials from argv and files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Revision history for redis-client
 
+## Unreleased
+
+*   **Breaking credential handling**
+    *   Removed `-a/--password`; use `REDIS_CLIENT_PASSWORD_FILE` (preferred) or `REDIS_CLIENT_PASSWORD`.
+    *   Credential files take precedence over direct environment values.
+    *   Parallel fill children and the Azure helper no longer carry live credentials in argv.
+    *   Saved Azure command files contain no live credential and are created with owner-only permissions.
+    *   Subprocess failures no longer format credential-bearing command arguments.
+
 ## 0.6.0.0 -- 2026-02-13
 
 *   **Multiplexing Now Default**

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,11 @@ endif
 
 test-credentials:
 	python3 -m unittest scripts/test_azure_redis_connect.py
-	cabal build redis-client
+ifeq ($(HAS_NIX),yes)
+	nix-shell --run "cabal build redis-client && cabal test CredentialSpec"
+else
+	cabal build redis-client && cabal test CredentialSpec
+endif
 	./scripts/test-credential-handling.sh
 
 # Validate ephemeral TLS credential generation without starting Docker.

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Detect if nix-shell is available
 HAS_NIX := $(shell command -v nix-shell >/dev/null 2>&1 && echo yes || echo no)
 
-.PHONY: help build test test-unit test-tls-fixtures test-e2e test-cluster-e2e test-library-e2e clean redis-start redis-stop redis-cluster-start redis-cluster-stop profile setup
+.PHONY: help build test test-unit test-credentials test-tls-fixtures test-e2e test-cluster-e2e test-library-e2e clean redis-start redis-stop redis-cluster-start redis-cluster-stop profile setup
 
 # Default target
 help:
@@ -46,12 +46,17 @@ endif
 test: test-unit test-e2e test-cluster-e2e test-library-e2e
 
 # Run unit tests (hask-redis-mux tests run via nix dependency build; FillHelpersSpec from redis-client)
-test-unit:
+test-unit: test-credentials
 ifeq ($(HAS_NIX),yes)
 	nix-shell --run "cabal build all && cabal test all"
 else
 	cabal build all && cabal test all
 endif
+
+test-credentials:
+	python3 -m unittest scripts/test_azure_redis_connect.py
+	cabal build redis-client
+	./scripts/test-credential-handling.sh
 
 # Validate ephemeral TLS credential generation without starting Docker.
 test-tls-fixtures:

--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,10 @@ endif
 test-credentials:
 	python3 -m unittest scripts/test_azure_redis_connect.py
 ifeq ($(HAS_NIX),yes)
-	nix-shell --run "cabal build redis-client && cabal test CredentialSpec"
+	nix-shell --run "cabal build redis-client && cabal test CredentialSpec && ./scripts/test-credential-handling.sh"
 else
-	cabal build redis-client && cabal test CredentialSpec
+	cabal build redis-client && cabal test CredentialSpec && ./scripts/test-credential-handling.sh
 endif
-	./scripts/test-credential-handling.sh
 
 # Validate ephemeral TLS credential generation without starting Docker.
 test-tls-fixtures:

--- a/README.md
+++ b/README.md
@@ -64,14 +64,21 @@ redis-client tunn -h localhost -t -c --tunnel-mode smart  # Cluster mode
 - `REDIS_CLIENT_PASSWORD` - Redis password, access key, or Entra token used only when `REDIS_CLIENT_PASSWORD_FILE` is not set.
 - `REDIS_CLIENT_FILL_CHUNK_KB` - Size of each command batch sent to Redis in kilobytes (default: 8192 KB, range: 1024-8192 KB). Larger values reduce network round-trips but use more memory. Use smaller values (1024-2048 KB) in memory-constrained environments or larger values (4096-8192 KB) for maximum throughput.
 
-Credential command-line options are no longer accepted. This is a breaking security change that keeps live credentials out of process arguments and parallel fill child arguments. Prefer an owner-readable credential file:
+Credential command-line options are no longer accepted. This is a breaking security change that keeps live credentials out of process arguments and parallel fill child arguments. Prefer an owner-only credential file:
 
 ```sh
+install -d -m 700 "$HOME/.config/redis-client"
+umask 077
+read -rsp "Redis credential: " REDIS_CREDENTIAL && printf '\n'
+printf '%s' "$REDIS_CREDENTIAL" > "$HOME/.config/redis-client/password"
+unset REDIS_CREDENTIAL
+chmod 600 "$HOME/.config/redis-client/password"
+
 REDIS_CLIENT_PASSWORD_FILE="$HOME/.config/redis-client/password" \
   redis-client cli -h localhost
 ```
 
-Environment values are convenient for automation but may still be visible to privileged process inspection. Avoid exporting credentials into shell startup files.
+Environment values are convenient for automation but may be visible to other same-user or privileged processes, depending on operating-system and platform policy. Avoid exporting credentials into shell startup files.
 
 ## Azure Redis Integration
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ redis-client tunn -h localhost -t -c --tunnel-mode smart  # Cluster mode
 - `-h`, `--host HOST` - Host to connect to (required)
 - `-p`, `--port PORT` - Port (default: 6379 for plaintext, 6380 for TLS)
 - `-u`, `--username USERNAME` - Username (default: 'default')
-- `-a`, `--password PASSWORD` - Password
 - `-t`, `--tls` - Use TLS connection
 - `-c`, `--cluster` - Redis Cluster mode
 - `-d`, `--data GBs` - Amount of random data to fill (in GB)
@@ -61,7 +60,18 @@ redis-client tunn -h localhost -t -c --tunnel-mode smart  # Cluster mode
 
 ### Environment Variables
 
+- `REDIS_CLIENT_PASSWORD_FILE` - Path to a file containing the Redis password, access key, or Entra token. This has highest precedence. A single trailing newline is removed.
+- `REDIS_CLIENT_PASSWORD` - Redis password, access key, or Entra token used only when `REDIS_CLIENT_PASSWORD_FILE` is not set.
 - `REDIS_CLIENT_FILL_CHUNK_KB` - Size of each command batch sent to Redis in kilobytes (default: 8192 KB, range: 1024-8192 KB). Larger values reduce network round-trips but use more memory. Use smaller values (1024-2048 KB) in memory-constrained environments or larger values (4096-8192 KB) for maximum throughput.
+
+Credential command-line options are no longer accepted. This is a breaking security change that keeps live credentials out of process arguments and parallel fill child arguments. Prefer an owner-readable credential file:
+
+```sh
+REDIS_CLIENT_PASSWORD_FILE="$HOME/.config/redis-client/password" \
+  redis-client cli -h localhost
+```
+
+Environment values are convenient for automation but may still be visible to privileged process inspection. Avoid exporting credentials into shell startup files.
 
 ## Azure Redis Integration
 

--- a/app/AppConfig.hs
+++ b/app/AppConfig.hs
@@ -4,6 +4,7 @@
 module AppConfig
   ( RunState (..)
   , defaultRunState
+  , resolveRunStateCredentials
   , authenticate
   , runCommandsAgainstTLSHost
   , runCommandsAgainstPlaintextHost
@@ -11,6 +12,7 @@ module AppConfig
 
 import           Control.Exception      (bracket)
 import qualified Control.Monad.State    as State
+import           CredentialConfig       (resolveRedisPassword)
 import qualified Data.ByteString        as BS
 import qualified Data.ByteString.Char8  as BS8
 import           Database.Redis.Client  (Client (..),
@@ -42,7 +44,6 @@ data RunState = RunState
     benchDuration     :: Int,
     muxCount          :: Int
   }
-  deriving (Show)
 
 defaultRunState :: RunState
 defaultRunState = RunState
@@ -66,6 +67,11 @@ defaultRunState = RunState
   , benchDuration = 30
   , muxCount = 1
   }
+
+resolveRunStateCredentials :: RunState -> IO RunState
+resolveRunStateCredentials state = do
+  resolvedPassword <- resolveRedisPassword
+  pure state {password = resolvedPassword}
 
 authenticate :: (Client client) => String -> String -> RedisCommandClient client RespData
 authenticate _ [] = return $ RespSimpleString "OK"

--- a/app/CredentialConfig.hs
+++ b/app/CredentialConfig.hs
@@ -1,0 +1,60 @@
+module CredentialConfig
+  ( passwordEnvironmentVariable
+  , passwordFileEnvironmentVariable
+  , rejectCredentialArguments
+  , resolveRedisPassword
+  , resolveRedisPasswordFrom
+  ) where
+
+import           Control.Exception  (IOException, try)
+import           Data.List          (isPrefixOf)
+import           System.Environment (lookupEnv)
+
+passwordEnvironmentVariable :: String
+passwordEnvironmentVariable = "REDIS_CLIENT_PASSWORD"
+
+passwordFileEnvironmentVariable :: String
+passwordFileEnvironmentVariable = "REDIS_CLIENT_PASSWORD_FILE"
+
+rejectCredentialArguments :: [String] -> Either String ()
+rejectCredentialArguments args
+  | any isCredentialArgument args =
+      Left "Redis credentials cannot be passed as command-line arguments. Use REDIS_CLIENT_PASSWORD_FILE or REDIS_CLIENT_PASSWORD."
+  | otherwise = Right ()
+  where
+    isCredentialArgument arg =
+      arg == "-a"
+        || arg == "--password"
+        || "-a" `isPrefixOf` arg
+        || "--password=" `isPrefixOf` arg
+
+resolveRedisPassword :: IO String
+resolveRedisPassword = do
+  passwordFile <- lookupEnv passwordFileEnvironmentVariable
+  environmentPassword <- lookupEnv passwordEnvironmentVariable
+  resolveRedisPasswordFrom passwordFile environmentPassword readCredentialFile
+
+resolveRedisPasswordFrom :: Maybe FilePath -> Maybe String -> (FilePath -> IO String) -> IO String
+resolveRedisPasswordFrom (Just "") _ _ =
+  ioError $ userError $ passwordFileEnvironmentVariable ++ " is set but empty."
+resolveRedisPasswordFrom (Just path) _ readPassword = do
+  result <- try (readPassword path) :: IO (Either IOException String)
+  case result of
+    Left _ ->
+      ioError $ userError $ "Unable to read Redis credential file configured by " ++ passwordFileEnvironmentVariable ++ "."
+    Right contents ->
+      case stripSingleLineEnding contents of
+        ""       -> ioError $ userError "Redis credential file is empty."
+        password -> pure password
+resolveRedisPasswordFrom Nothing environmentPassword _ =
+  pure $ maybe "" id environmentPassword
+
+readCredentialFile :: FilePath -> IO String
+readCredentialFile = readFile
+
+stripSingleLineEnding :: String -> String
+stripSingleLineEnding value =
+  case reverse value of
+    '\n' : '\r' : rest -> reverse rest
+    '\n' : rest        -> reverse rest
+    _                  -> value

--- a/app/FillProcess.hs
+++ b/app/FillProcess.hs
@@ -1,0 +1,26 @@
+module FillProcess
+  ( buildChildArgs
+  ) where
+
+import           AppConfig (RunState (..))
+
+buildChildArgs :: RunState -> Int -> Int -> [String]
+buildChildArgs state idx dataGB =
+  [ "fill"
+  , "-h", host state
+  , "-d", show dataGB
+  , "--process-index", show idx
+  , "--key-size", show (keySize state)
+  , "--value-size", show (valueSize state)
+  , "--pipeline", show (pipelineBatchSize state)
+  ]
+  ++ (["-t" | useTLS state])
+  ++ (["-c" | useCluster state])
+  ++ (["-s" | serial state])
+  ++ (case port state of
+        Just p  -> ["-p", show p]
+        Nothing -> [])
+  ++ (if username state /= "default" then ["-u", username state] else [])
+  ++ (case numConnections state of
+        Just n  -> ["-n", show n]
+        Nothing -> [])

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -22,6 +22,7 @@ import           Control.Concurrent                    (forkIO, newEmptyMVar,
 
 import           AppConfig                             (RunState (..),
                                                         defaultRunState,
+                                                        resolveRunStateCredentials,
                                                         runCommandsAgainstPlaintextHost,
                                                         runCommandsAgainstTLSHost)
 import           ClusterCli                            (routeAndExecuteCommand)
@@ -29,6 +30,9 @@ import           Control.Concurrent.STM                (readTVarIO)
 import           Control.Monad                         (unless, void, when)
 import           Control.Monad.IO.Class
 import qualified Control.Monad.State                   as State
+import           CredentialConfig                      (passwordEnvironmentVariable,
+                                                        passwordFileEnvironmentVariable,
+                                                        rejectCredentialArguments)
 import qualified Data.ByteString                       as BS
 import qualified Data.ByteString.Builder               as Builder
 import qualified Data.ByteString.Char8                 as BS8
@@ -63,6 +67,7 @@ import           Database.Redis.Resp                   (Encodable (encode),
 import           Filler                                (fillCacheWithData,
                                                         fillCacheWithDataMB,
                                                         initRandomNoise)
+import           FillProcess                           (buildChildArgs)
 import           Numeric                               (showHex)
 import           System.Console.GetOpt                 (ArgDescr (..),
                                                         ArgOrder (..),
@@ -87,7 +92,6 @@ options =
   [ Option ['h'] ["host"] (ReqArg (\arg opt -> return $ opt {host = arg}) "HOST") "Host to connect to",
     Option ['p'] ["port"] (ReqArg (\arg opt -> return $ opt {port = Just . read $ arg}) "PORT") "Port to connect to. Will default to 6379 for plaintext and 6380 for TLS",
     Option ['u'] ["username"] (ReqArg (\arg opt -> return $ opt {username = arg}) "USERNAME") "Username to authenticate with (default: 'default')",
-    Option ['a'] ["password"] (ReqArg (\arg opt -> return $ opt {password = arg}) "PASSWORD") "Password to authenticate with",
     Option ['t'] ["tls"] (NoArg (\opt -> return $ opt {useTLS = True})) "Use TLS",
     Option ['d'] ["data"] (ReqArg (\arg opt -> return $ opt {dataGBs = read arg}) "GBs") "Random data amount to send in GB",
     Option ['f'] ["flush"] (NoArg (\opt -> return $ opt {flush = True})) "Flush the database",
@@ -141,28 +145,15 @@ handleArgs args = do
 main :: IO ()
 main = do
   args' <- getArgs
+  case rejectCredentialArguments args' of
+    Left message -> hPutStrLn stderr message >> exitFailure
+    Right ()     -> pure ()
   case args' of
-    [] -> do
-      putStrLn $ usageInfo "Usage: redis-client [mode] [OPTION...]" options
-      putStrLn ""
-      putStrLn "Modes:"
-      putStrLn "  cli     Interactive Redis command-line interface"
-      putStrLn "  fill    Fill Redis cache with random data for testing"
-      putStrLn "  tunn    Start TLS tunnel proxy (requires -t flag)"
-      putStrLn "  bench   Benchmark cluster throughput (requires -c flag)"
-      putStrLn ""
-      putStrLn "Cluster Mode:"
-      putStrLn "  Use -c/--cluster flag to enable Redis Cluster support"
-      putStrLn ""
-      putStrLn "Examples:"
-      putStrLn "  redis-client fill -h localhost -d 5                     # Fill 5GB standalone"
-      putStrLn "  redis-client fill -h node1 -d 5 -c                      # Fill 5GB cluster"
-      putStrLn "  redis-client cli -h localhost -c                        # CLI with cluster"
-      putStrLn "  redis-client tunn -h node1 -t -c --tunnel-mode smart    # Smart cluster proxy"
-      putStrLn "  redis-client fill ... --pipeline 4096                   # Use 4096 commands per pipeline"
-      exitFailure
+    [] -> printUsage >> exitFailure
+    ["--help"] -> printUsage >> exitSuccess
     (mode : args) -> do
-      (state, _) <- handleArgs args
+      (parsedState, _) <- handleArgs args
+      state <- resolveRunStateCredentials parsedState
       unless (mode `elem` ["cli", "fill", "tunn", "bench"]) $ do
         printf "Invalid mode '%s' specified\nValid modes are 'cli', 'fill', 'tunn', and 'bench'\n" mode
         putStrLn $ usageInfo "Usage: redis-client [mode] [OPTION...]" options
@@ -175,6 +166,32 @@ main = do
       when (mode == "cli") $ cli state
       when (mode == "fill") $ fill state
       when (mode == "bench") $ bench state
+
+printUsage :: IO ()
+printUsage = do
+  putStrLn $ usageInfo "Usage: redis-client [mode] [OPTION...]" options
+  putStrLn ""
+  putStrLn "Credentials:"
+  putStrLn $ "  " ++ passwordFileEnvironmentVariable ++ "  Path to a credential file (highest precedence)"
+  putStrLn $ "  " ++ passwordEnvironmentVariable ++ "       Credential value used when no file is configured"
+  putStrLn "  Command-line password options are rejected to keep credentials out of process listings."
+  putStrLn ""
+  putStrLn "Modes:"
+  putStrLn "  cli     Interactive Redis command-line interface"
+  putStrLn "  fill    Fill Redis cache with random data for testing"
+  putStrLn "  tunn    Start TLS tunnel proxy (requires -t flag)"
+  putStrLn "  bench   Benchmark cluster throughput (requires -c flag)"
+  putStrLn ""
+  putStrLn "Cluster Mode:"
+  putStrLn "  Use -c/--cluster flag to enable Redis Cluster support"
+  putStrLn ""
+  putStrLn "Examples:"
+  putStrLn "  REDIS_CLIENT_PASSWORD_FILE=/secure/redis.pass redis-client cli -h localhost"
+  putStrLn "  redis-client fill -h localhost -d 5                     # Fill 5GB standalone"
+  putStrLn "  redis-client fill -h node1 -d 5 -c                      # Fill 5GB cluster"
+  putStrLn "  redis-client cli -h localhost -c                        # CLI with cluster"
+  putStrLn "  redis-client tunn -h node1 -t -c --tunnel-mode smart    # Smart cluster proxy"
+  putStrLn "  redis-client fill ... --pipeline 4096                   # Use 4096 commands per pipeline"
 
 
 tunn :: RunState -> IO ()
@@ -325,29 +342,6 @@ spawnChildProcess exePath state baseGB remainder idx = do
 
   (_, _, _, ph) <- createProcess (proc exePath args)
   return ph
-
--- | Build command-line arguments for a child process
-buildChildArgs :: RunState -> Int -> Int -> [String]
-buildChildArgs state idx dataGB =
-  [ "fill"
-  , "-h", host state
-  , "-d", show dataGB
-  , "--process-index", show idx
-  , "--key-size", show (keySize state)
-  , "--value-size", show (valueSize state)
-  , "--pipeline", show (pipelineBatchSize state)
-  ]
-  ++ (["-t" | useTLS state])
-  ++ (["-c" | useCluster state])
-  ++ (["-s" | serial state])
-  ++ (case port state of
-        Just p  -> ["-p", show p]
-        Nothing -> [])
-  ++ (if null (password state) then [] else ["-a", password state])
-  ++ (if username state /= "default" then ["-u", username state] else [])
-  ++ (case numConnections state of
-        Just n  -> ["-n", show n]
-        Nothing -> [])
 
 fillStandalone :: RunState -> IO ()
 fillStandalone state = do
@@ -654,4 +648,3 @@ benchWorker muxPool clusterClient op tid kSize vSize duration opsCounter = do
           s <- submitToNodeAsync muxPool addr cmd
           fireBatch topology (counter + 1) (remaining - 1) (s : acc)
         Nothing -> fireBatch topology (counter + 1) (remaining - 1) acc
-

--- a/docs/AZURE_EXAMPLES.md
+++ b/docs/AZURE_EXAMPLES.md
@@ -145,9 +145,11 @@ Flush the cache before filling? (y/n): y
 
 Launching redis-client with command:
   redis-client fill -h my-cache.redis.cache.windows.net -p 10000 -t -c \
-    -a <token> -d 10 -f -P 8 -n 6 \
+    -d 10 -f -P 8 -n 6 \
     --key-size 512 --value-size 262144 --pipeline 8192
 ```
+
+The Azure helper supplies the token or access key through the child environment, not through command arguments.
 
 These optimized parameters were determined through comprehensive GHC runtime and concurrency testing,
 achieving 99% performance improvement (4.7 Gbps → 9.4 Gbps) on Azure Redis Premium tier clusters.
@@ -161,7 +163,7 @@ Example usage:
 Select mode (1-3): 2
 
 Launching redis-client with command:
-  redis-client cli -h my-cache.redis.cache.windows.net -t -a <token>
+  redis-client cli -h my-cache.redis.cache.windows.net -t
 
 Starting CLI mode
 > PING
@@ -182,7 +184,7 @@ Example:
 Select mode (1-3): 3
 
 Launching redis-client with command:
-  redis-client tunn -h my-cache.redis.cache.windows.net -t -a <token>
+  redis-client tunn -h my-cache.redis.cache.windows.net -t
 
 Starting tunnel mode
 Tunnel listening on localhost:6379
@@ -199,7 +201,7 @@ When a cache uses Entra authentication (access keys disabled), the script:
 2. If access policy assignments exist, determines that Entra authentication is required
 3. Uses `az account get-access-token --resource https://redis.azure.com` to obtain an OAuth token
 4. Retrieves the Object ID (OID) of the signed-in user via `az ad signed-in-user show`
-5. Passes both the Object ID (as username) and the token (as password) to redis-client
+5. Passes the Object ID as the username and supplies the token through `REDIS_CLIENT_PASSWORD`
 
 **Fallback:** If the access policy assignment check fails, the script attempts to retrieve access keys via `az redis list-keys` as a fallback method.
 
@@ -221,7 +223,7 @@ The script automatically retrieves the Object ID and passes it to redis-client u
 
 When a cache uses traditional access keys:
 1. Retrieves the primary access key using `az redis list-keys`
-2. Passes the key as the password to redis-client
+2. Supplies the key to redis-client through `REDIS_CLIENT_PASSWORD`
 
 ## Troubleshooting
 
@@ -275,11 +277,15 @@ You can script the selection process (though interactive mode is recommended):
 
 1. **Token lifetime**: Entra tokens obtained via Azure CLI typically have a lifetime of 1 hour (3600 seconds). If your session runs longer than this, the token will expire and you'll need to re-run the script to obtain a fresh token. For long-running operations like large fill jobs, monitor for authentication errors.
 
-2. **Token storage**: The script does not persist tokens. They are only used for the current session.
+2. **Token storage**: The script does not persist tokens. They are placed only in the launched process environment for the current session.
 
-3. **Access keys**: When using access key authentication, the keys are passed as command-line arguments (visible in process listings).
+3. **Saved commands**: Generated command files contain no live credential, require `REDIS_CLIENT_PASSWORD_FILE` or `REDIS_CLIENT_PASSWORD` at execution, and are created with owner-only `0700` permissions.
 
-4. **Network security**: Always use TLS (`-t` flag) when connecting to Azure Redis caches.
+4. **Process inspection**: Credentials are absent from argv. Privileged users may still inspect process environments, so prefer `REDIS_CLIENT_PASSWORD_FILE` for manual CLI usage.
+
+5. **Breaking behavior**: `redis-client` rejects `-a/--password`. Existing automation must migrate to `REDIS_CLIENT_PASSWORD_FILE` (preferred) or `REDIS_CLIENT_PASSWORD`.
+
+6. **Network security**: Always use TLS (`-t` flag) when connecting to Azure Redis caches.
 
 ## Performance Tips
 

--- a/docs/AZURE_EXAMPLES.md
+++ b/docs/AZURE_EXAMPLES.md
@@ -281,7 +281,7 @@ You can script the selection process (though interactive mode is recommended):
 
 3. **Saved commands**: Generated command files contain no live credential, require `REDIS_CLIENT_PASSWORD_FILE` or `REDIS_CLIENT_PASSWORD` at execution, and are created with owner-only `0700` permissions.
 
-4. **Process inspection**: Credentials are absent from argv. Privileged users may still inspect process environments, so prefer `REDIS_CLIENT_PASSWORD_FILE` for manual CLI usage.
+4. **Process inspection**: Credentials are absent from argv. Depending on operating-system and platform policy, other same-user or privileged processes may still inspect process environments. Prefer an owner-only `REDIS_CLIENT_PASSWORD_FILE` with mode `0600` for manual CLI usage.
 
 5. **Breaking behavior**: `redis-client` rejects `-a/--password`. Existing automation must migrate to `REDIS_CLIENT_PASSWORD_FILE` (preferred) or `REDIS_CLIENT_PASSWORD`.
 

--- a/redis-client.cabal
+++ b/redis-client.cabal
@@ -43,6 +43,18 @@ test-suite FillHelpersSpec
                     , hask-redis-mux
                     , mtl
 
+test-suite CredentialSpec
+    import:           test-defaults
+    type:             exitcode-stdio-1.0
+    main-is:          CredentialSpec.hs
+    other-modules:    AppConfig
+                    , CredentialConfig
+                    , FillProcess
+    hs-source-dirs:   app
+    build-depends:    bytestring
+                    , hask-redis-mux
+                    , mtl
+
 -- ---------------------------------------------------------------------------
 -- Flags
 -- ---------------------------------------------------------------------------
@@ -65,6 +77,7 @@ executable EndToEnd
                     , app
     other-modules:    E2EHelpers
                     , AppConfig
+                    , CredentialConfig
     build-depends:    attoparsec
                     , bytestring
                     , directory
@@ -136,7 +149,9 @@ executable redis-client
                     , ClusterFiller
                     , ClusterSetup
                     , ClusterTunnel
+                    , CredentialConfig
                     , FillHelpers
+                    , FillProcess
                     , Filler
                     , SlotMappingHelpers
     build-depends:    attoparsec

--- a/scripts/azure-redis-connect.py
+++ b/scripts/azure-redis-connect.py
@@ -60,7 +60,7 @@ class AzureRedisConnector:
         if not text:
             return text
         text = re.sub(
-            r'\beyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b',
+            r'(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?![A-Za-z0-9_-])',
             '***REDACTED***',
             text
         )

--- a/scripts/azure-redis-connect.py
+++ b/scripts/azure-redis-connect.py
@@ -13,12 +13,17 @@ Usage:
 
 import argparse
 import json
+import re
+import shlex
 import subprocess
 import sys
 import os
 import time
 import atexit
 from typing import List, Dict, Optional
+
+PASSWORD_ENVIRONMENT_VARIABLE = "REDIS_CLIENT_PASSWORD"
+PASSWORD_FILE_ENVIRONMENT_VARIABLE = "REDIS_CLIENT_PASSWORD_FILE"
 
 # Save terminal settings at startup
 _original_terminal_settings = None
@@ -54,13 +59,63 @@ class AzureRedisConnector:
         """Obfuscate access keys and tokens in text for display."""
         if not text:
             return text
-        # Look for patterns that might be access keys or tokens
-        # Azure Redis access keys are typically 43 characters base64
-        # Tokens can be much longer (JWT format)
-        import re
-        # Pattern for base64-like strings (likely access keys)
-        text = re.sub(r'\b[A-Za-z0-9+/]{40,}={0,2}\b', '***REDACTED***', text)
+        text = re.sub(
+            r'\beyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b',
+            '***REDACTED***',
+            text
+        )
+        text = re.sub(
+            r'(?<![A-Za-z0-9_+/\-])[A-Za-z0-9_+/\-]{40,}={0,2}(?![A-Za-z0-9_+/\-=])',
+            '***REDACTED***',
+            text
+        )
         return text
+
+    def build_redis_client_environment(self, credential: Optional[str]) -> Dict[str, str]:
+        """Build the child environment without placing credentials in argv."""
+        child_environment = os.environ.copy()
+        if credential:
+            child_environment[PASSWORD_ENVIRONMENT_VARIABLE] = credential
+            child_environment.pop(PASSWORD_FILE_ENVIRONMENT_VARIABLE, None)
+        return child_environment
+
+    def format_redis_client_failure(self, return_code: int) -> str:
+        """Format a child failure without including its command arguments."""
+        return f"Error running redis-client (exit code {return_code})"
+
+    def save_command_file(self, command: List[str], cache_name: str, hostname: str, port: int) -> str:
+        """Save a credential-free command that requires a secure credential channel at execution."""
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        safe_cache_name = re.sub(r'[^A-Za-z0-9._-]+', '_', cache_name)
+        filename = f"redis-command_{safe_cache_name}_{timestamp}.sh"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        fd = os.open(filename, flags, 0o700)
+        try:
+            with os.fdopen(fd, 'w') as command_file:
+                command_file.write("#!/usr/bin/env bash\n")
+                command_file.write("set -euo pipefail\n")
+                command_file.write(f"# Redis client command for {cache_name}\n")
+                command_file.write(f"# Generated: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+                command_file.write(f"# Host: {hostname}:{port}\n\n")
+                command_file.write(
+                    f'if [[ -z "${{{PASSWORD_ENVIRONMENT_VARIABLE}:-}}" '
+                    f'&& -z "${{{PASSWORD_FILE_ENVIRONMENT_VARIABLE}:-}}" ]]; then\n'
+                )
+                command_file.write(
+                    f'  echo "Set {PASSWORD_FILE_ENVIRONMENT_VARIABLE} or '
+                    f'{PASSWORD_ENVIRONMENT_VARIABLE} before running this command." >&2\n'
+                )
+                command_file.write("  exit 1\n")
+                command_file.write("fi\n\n")
+                command_file.write("exec " + shlex.join(command) + "\n")
+        except Exception:
+            try:
+                os.unlink(filename)
+            except OSError:
+                pass
+            raise
+        os.chmod(filename, 0o700)
+        return filename
     
     def run_az_command(self, command: List[str], obfuscate_output: bool = False, raise_on_error: bool = False) -> str:
         """Execute an Azure CLI command and return output.
@@ -495,7 +550,7 @@ class AzureRedisConnector:
                 ], obfuscate_output=True, raise_on_error=True)
                 keys = json.loads(keys_output)
                 return keys.get('primaryKey')
-        except Exception as e:
+        except Exception:
             # Access keys may be disabled (Enterprise caches with Entra auth)
             # This is normal and not an error - we'll use Entra auth instead
             return None
@@ -523,8 +578,9 @@ class AzureRedisConnector:
         # Check authentication method
         is_entra = self.check_entra_auth(cache)
         
-        # Build command
+        # Build command and keep the credential exclusively in the child environment.
         command = ['redis-client', mode, '-h', hostname, '-p', str(ssl_port), '-t']
+        credential = None
         
         # Add tunnel mode type if specified
         if mode == 'tunn' and tunnel_type:
@@ -545,14 +601,13 @@ class AzureRedisConnector:
         if is_entra:
             # Get Entra token and user Object ID
             token, object_id = self.get_entra_token(hostname)
+            credential = token
             if object_id:
                 # Pass the Object ID as username for Entra authentication
-                command.extend(['-u', object_id, '-a', token])
+                command.extend(['-u', object_id])
                 print(f"\n✓ Using Entra authentication with Object ID: {object_id}")
                 print(f"  (Access token hidden for security)")
             else:
-                # Fallback if we couldn't get the Object ID
-                command.extend(['-a', token])
                 print(f"\n✓ Using Entra authentication (username will default to 'default')")
                 print(f"  (Access token hidden for security)")
                 print(f"⚠ Warning: Could not retrieve Object ID; authentication may fail")
@@ -560,7 +615,7 @@ class AzureRedisConnector:
             # Get access key
             access_key = self.get_access_key(cache)
             if access_key:
-                command.extend(['-a', access_key])
+                credential = access_key
                 print(f"\n✓ Using access key authentication")
                 print(f"  (Access key hidden for security)")
             else:
@@ -628,19 +683,8 @@ class AzureRedisConnector:
                     print("Invalid input. Please enter a valid number.")
         
         print(f"\nLaunching redis-client with command:")
-        # Create a safe version of the command for display
-        safe_command = []
-        skip_next = False
-        for i, arg in enumerate(command):
-            if skip_next:
-                safe_command.append('***REDACTED***')
-                skip_next = False
-            elif arg in ['-a', '--password']:
-                safe_command.append(arg)
-                skip_next = True
-            else:
-                safe_command.append(arg)
-        print(f"  {' '.join(safe_command)}")
+        print(f"  {shlex.join(command)}")
+        child_environment = self.build_redis_client_environment(credential)
         
         # Ask if user wants to save the full command to a file
         try:
@@ -648,23 +692,7 @@ class AzureRedisConnector:
             save_cmd = input("\nSave full command to file for manual execution? (y/n): ")
             save_cmd = save_cmd.replace('\r', '').replace('\n', '').strip().lower()
             if save_cmd == 'y':
-                # Generate filename based on cache name and timestamp
-                timestamp = time.strftime("%Y%m%d_%H%M%S")
-                filename = f"redis-command_{name.replace(' ', '_')}_{timestamp}.sh"
-                
-                # Build the full command as a shell script
-                shell_cmd = ' '.join([f"'{arg}'" if ' ' in arg else arg for arg in command])
-                
-                with open(filename, 'w') as f:
-                    f.write("#!/bin/bash\n")
-                    f.write(f"# Redis client command for {name}\n")
-                    f.write(f"# Generated: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
-                    f.write(f"# Host: {hostname}:{ssl_port}\n")
-                    f.write("\n")
-                    f.write(shell_cmd + "\n")
-                
-                # Make it executable
-                os.chmod(filename, 0o755)
+                filename = self.save_command_file(command, name, hostname, ssl_port)
                 
                 print(f"\n✓ Command saved to: {filename}")
                 print(f"  Run with: ./{filename}")
@@ -679,7 +707,7 @@ class AzureRedisConnector:
         # Execute the redis-client with timing
         start_time = time.time()
         try:
-            subprocess.run(command, check=True)
+            subprocess.run(command, env=child_environment, check=True)
             
             # Display timing information for fill operations
             if mode == 'fill':
@@ -695,8 +723,7 @@ class AzureRedisConnector:
                 print("=" * 80)
                 
         except subprocess.CalledProcessError as e:
-            safe_error = self.obfuscate_sensitive_data(str(e))
-            print(f"\nError running redis-client: {safe_error}", file=sys.stderr)
+            print(f"\n{self.format_redis_client_failure(e.returncode)}", file=sys.stderr)
             restore_terminal()
             sys.exit(1)
         except KeyboardInterrupt:

--- a/scripts/test-credential-handling.sh
+++ b/scripts/test-credential-handling.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REDIS_CLIENT_BIN="$(cd "$ROOT_DIR" && cabal list-bin redis-client)"
+SYNTHETIC_SECRET='eyJhbGciOiJub25lIn0.eyJvaWQiOiJ0ZXN0LXVzZXJfMSJ9.c2lnbmF0dXJlLXNhZmU'
+
+set +e
+output="$("$REDIS_CLIENT_BIN" cli -h localhost "--password=$SYNTHETIC_SECRET" 2>&1)"
+status=$?
+set -e
+
+if [[ $status -eq 0 ]]; then
+  echo "Error: credential-bearing argv was accepted." >&2
+  exit 1
+fi
+
+if [[ "$output" == *"$SYNTHETIC_SECRET"* ]]; then
+  echo "Error: credential-bearing argv was echoed in an error." >&2
+  exit 1
+fi
+
+help_output="$("$REDIS_CLIENT_BIN" --help)"
+if [[ "$help_output" == *"--password"* || "$help_output" == *"-a PASSWORD"* ]]; then
+  echo "Error: help still advertises credential argv." >&2
+  exit 1
+fi
+
+if [[ "$help_output" != *"REDIS_CLIENT_PASSWORD_FILE"* || "$help_output" != *"REDIS_CLIENT_PASSWORD"* ]]; then
+  echo "Error: help does not document secure credential channels." >&2
+  exit 1
+fi
+
+echo "Credential argv and help checks passed."

--- a/scripts/test_azure_redis_connect.py
+++ b/scripts/test_azure_redis_connect.py
@@ -1,8 +1,10 @@
 import importlib.util
+import io
 import os
 import stat
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
@@ -12,10 +14,11 @@ SPEC = importlib.util.spec_from_file_location("azure_redis_connect", SCRIPT_PATH
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
-SYNTHETIC_JWT = (
-    "eyJhbGciOiJub25lIn0."
-    "eyJvaWQiOiJ0ZXN0LXVzZXJfMSJ9."
-    "c2lnbmF0dXJlLXNhZmU"
+SYNTHETIC_JWT_HEADER = "eyJhbGciOiJub25lIn0_"
+SYNTHETIC_JWT_CLAIMS = "eyJvaWQiOiJ0ZXN0LXVzZXJfMSJ9-_"
+SYNTHETIC_JWT_SIGNATURE = "c2lnbmF0dXJlLXNhZmU_-"
+SYNTHETIC_JWT = ".".join(
+    [SYNTHETIC_JWT_HEADER, SYNTHETIC_JWT_CLAIMS, SYNTHETIC_JWT_SIGNATURE]
 )
 SYNTHETIC_ACCESS_KEY = "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789_-+/AbCd"
 
@@ -23,11 +26,28 @@ SYNTHETIC_ACCESS_KEY = "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789_-+/AbCd"
 class AzureRedisCredentialTests(unittest.TestCase):
     def setUp(self):
         self.connector = MODULE.AzureRedisConnector("test-subscription")
+        self.cache = {
+            "name": "test-cache",
+            "cache_type": "Standard",
+            "hostName": "cache.example",
+            "sslPort": 6380,
+        }
+
+    def entra_launch_patches(self):
+        return (
+            mock.patch.object(self.connector, "check_entra_auth", return_value=True),
+            mock.patch.object(
+                self.connector,
+                "get_entra_token",
+                return_value=(SYNTHETIC_JWT, "entra-object-id"),
+            ),
+        )
 
     def test_redacts_url_safe_jwt_and_access_key(self):
         text = f"token={SYNTHETIC_JWT} key={SYNTHETIC_ACCESS_KEY}"
         redacted = self.connector.obfuscate_sensitive_data(text)
         self.assertNotIn(SYNTHETIC_JWT, redacted)
+        self.assertNotIn(SYNTHETIC_JWT_CLAIMS, redacted)
         self.assertNotIn(SYNTHETIC_ACCESS_KEY, redacted)
         self.assertEqual(redacted.count("***REDACTED***"), 2)
 
@@ -36,7 +56,10 @@ class AzureRedisCredentialTests(unittest.TestCase):
         command = ["redis-client", "cli", "-h", "cache.example"]
         child_environment = self.connector.build_redis_client_environment(SYNTHETIC_JWT)
         self.assertNotIn(SYNTHETIC_JWT, command)
-        self.assertEqual(child_environment[MODULE.PASSWORD_ENVIRONMENT_VARIABLE], SYNTHETIC_JWT)
+        self.assertEqual(
+            child_environment[MODULE.PASSWORD_ENVIRONMENT_VARIABLE],
+            SYNTHETIC_JWT,
+        )
         self.assertEqual(child_environment["PRESERVED"], "value")
 
     def test_saved_command_is_owner_only_and_contains_no_live_credential(self):
@@ -66,6 +89,83 @@ class AzureRedisCredentialTests(unittest.TestCase):
         self.assertIn(SYNTHETIC_JWT, str(error))
         safe_message = self.connector.format_redis_client_failure(error.returncode)
         self.assertNotIn(SYNTHETIC_JWT, safe_message)
+
+    @mock.patch.dict(os.environ, {"PRESERVED": "value"}, clear=True)
+    def test_launch_passes_credential_only_in_child_environment(self):
+        check_auth, get_token = self.entra_launch_patches()
+        with check_auth, get_token, \
+             mock.patch("builtins.input", return_value="n"), \
+             mock.patch.object(MODULE.subprocess, "run") as run, \
+             redirect_stdout(io.StringIO()):
+            self.connector.launch_redis_client(self.cache.copy(), "cli")
+
+        run.assert_called_once()
+        command = run.call_args.args[0]
+        child_environment = run.call_args.kwargs["env"]
+        self.assertNotIn(SYNTHETIC_JWT, command)
+        self.assertNotIn("--password", command)
+        self.assertNotIn("-a", command)
+        self.assertEqual(
+            child_environment[MODULE.PASSWORD_ENVIRONMENT_VARIABLE],
+            SYNTHETIC_JWT,
+        )
+        self.assertEqual(child_environment["PRESERVED"], "value")
+        self.assertTrue(run.call_args.kwargs["check"])
+
+    def test_launch_failure_emits_no_command_or_credential(self):
+        child_error = MODULE.subprocess.CalledProcessError(
+            9, ["redis-client", "cli", "--password", SYNTHETIC_JWT]
+        )
+        check_auth, get_token = self.entra_launch_patches()
+        stderr = io.StringIO()
+        with check_auth, get_token, \
+             mock.patch("builtins.input", return_value="n"), \
+             mock.patch.object(MODULE.subprocess, "run", side_effect=child_error), \
+             redirect_stdout(io.StringIO()), \
+             redirect_stderr(stderr), \
+             self.assertRaises(SystemExit) as exit_context:
+            self.connector.launch_redis_client(self.cache.copy(), "cli")
+
+        error_output = stderr.getvalue()
+        self.assertEqual(exit_context.exception.code, 1)
+        self.assertNotIn(SYNTHETIC_JWT, error_output)
+        self.assertNotIn(SYNTHETIC_JWT_CLAIMS, error_output)
+        self.assertNotIn("--password", error_output)
+        self.assertNotIn("cache.example", error_output)
+        self.assertEqual(
+            error_output.strip(),
+            "Error running redis-client (exit code 9)",
+        )
+
+    def test_launch_save_path_receives_and_writes_only_credential_free_command(self):
+        with tempfile.TemporaryDirectory() as temp_directory:
+            previous_directory = os.getcwd()
+            os.chdir(temp_directory)
+            try:
+                check_auth, get_token = self.entra_launch_patches()
+                with check_auth, get_token, \
+                     mock.patch("builtins.input", return_value="y"), \
+                     mock.patch.object(
+                         self.connector,
+                         "save_command_file",
+                         wraps=self.connector.save_command_file,
+                     ) as save_command, \
+                     mock.patch.object(MODULE.subprocess, "run"), \
+                     redirect_stdout(io.StringIO()):
+                    self.connector.launch_redis_client(self.cache.copy(), "cli")
+
+                saved_command = save_command.call_args.args[0]
+                saved_file = next(Path(temp_directory).glob("redis-command_*.sh"))
+                contents = saved_file.read_text()
+            finally:
+                os.chdir(previous_directory)
+
+        self.assertNotIn(SYNTHETIC_JWT, saved_command)
+        self.assertNotIn("--password", saved_command)
+        self.assertNotIn("-a", saved_command)
+        self.assertNotIn(SYNTHETIC_JWT, contents)
+        self.assertNotIn(SYNTHETIC_JWT_CLAIMS, contents)
+        self.assertIn("exec redis-client cli -h cache.example", contents)
 
 
 if __name__ == "__main__":

--- a/scripts/test_azure_redis_connect.py
+++ b/scripts/test_azure_redis_connect.py
@@ -1,0 +1,72 @@
+import importlib.util
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).with_name("azure-redis-connect.py")
+SPEC = importlib.util.spec_from_file_location("azure_redis_connect", SCRIPT_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+SYNTHETIC_JWT = (
+    "eyJhbGciOiJub25lIn0."
+    "eyJvaWQiOiJ0ZXN0LXVzZXJfMSJ9."
+    "c2lnbmF0dXJlLXNhZmU"
+)
+SYNTHETIC_ACCESS_KEY = "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789_-+/AbCd"
+
+
+class AzureRedisCredentialTests(unittest.TestCase):
+    def setUp(self):
+        self.connector = MODULE.AzureRedisConnector("test-subscription")
+
+    def test_redacts_url_safe_jwt_and_access_key(self):
+        text = f"token={SYNTHETIC_JWT} key={SYNTHETIC_ACCESS_KEY}"
+        redacted = self.connector.obfuscate_sensitive_data(text)
+        self.assertNotIn(SYNTHETIC_JWT, redacted)
+        self.assertNotIn(SYNTHETIC_ACCESS_KEY, redacted)
+        self.assertEqual(redacted.count("***REDACTED***"), 2)
+
+    @mock.patch.dict(os.environ, {"PRESERVED": "value"}, clear=True)
+    def test_child_environment_carries_credential_without_modifying_argv(self):
+        command = ["redis-client", "cli", "-h", "cache.example"]
+        child_environment = self.connector.build_redis_client_environment(SYNTHETIC_JWT)
+        self.assertNotIn(SYNTHETIC_JWT, command)
+        self.assertEqual(child_environment[MODULE.PASSWORD_ENVIRONMENT_VARIABLE], SYNTHETIC_JWT)
+        self.assertEqual(child_environment["PRESERVED"], "value")
+
+    def test_saved_command_is_owner_only_and_contains_no_live_credential(self):
+        command = ["redis-client", "cli", "-h", "cache.example"]
+        with tempfile.TemporaryDirectory() as temp_directory:
+            previous_directory = os.getcwd()
+            os.chdir(temp_directory)
+            try:
+                filename = self.connector.save_command_file(
+                    command, "cache/name", "cache.example", 6380
+                )
+                contents = Path(filename).read_text()
+                mode = stat.S_IMODE(Path(filename).stat().st_mode)
+            finally:
+                os.chdir(previous_directory)
+
+        self.assertEqual(mode, 0o700)
+        self.assertNotIn(SYNTHETIC_JWT, contents)
+        self.assertNotIn(SYNTHETIC_ACCESS_KEY, contents)
+        self.assertIn(MODULE.PASSWORD_FILE_ENVIRONMENT_VARIABLE, contents)
+        self.assertIn(MODULE.PASSWORD_ENVIRONMENT_VARIABLE, contents)
+
+    def test_subprocess_failure_message_does_not_format_command_arguments(self):
+        error = MODULE.subprocess.CalledProcessError(
+            9, ["redis-client", "cli", "--password", SYNTHETIC_JWT]
+        )
+        self.assertIn(SYNTHETIC_JWT, str(error))
+        safe_message = self.connector.format_redis_client_failure(error.returncode)
+        self.assertNotIn(SYNTHETIC_JWT, safe_message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/CredentialSpec.hs
+++ b/test/CredentialSpec.hs
@@ -1,0 +1,60 @@
+module Main where
+
+import           AppConfig        (RunState (..), defaultRunState)
+import           CredentialConfig (rejectCredentialArguments,
+                                   resolveRedisPasswordFrom)
+import           Data.List        (isInfixOf)
+import           FillProcess      (buildChildArgs)
+import           Test.Hspec
+
+syntheticJwt :: String
+syntheticJwt = "eyJhbGciOiJub25lIn0.eyJvaWQiOiJ0ZXN0LXVzZXJfMSJ9.c2lnbmF0dXJlLXNhZmU"
+
+main :: IO ()
+main = hspec $ do
+  describe "credential argument rejection" $ do
+    mapM_ rejectsWithoutEcho
+      [ ["cli", "-a", syntheticJwt]
+      , ["cli", "-a" ++ syntheticJwt]
+      , ["cli", "--password", syntheticJwt]
+      , ["cli", "--password=" ++ syntheticJwt]
+      ]
+
+    it "accepts arguments without credential options" $
+      rejectCredentialArguments ["cli", "-h", "localhost"] `shouldBe` Right ()
+
+  describe "credential resolution" $ do
+    it "prefers the credential file over the environment value" $ do
+      password <- resolveRedisPasswordFrom
+        (Just "/secure/credential")
+        (Just "environment-value")
+        (\_ -> pure "file-value\n")
+      password `shouldBe` "file-value"
+
+    it "uses the environment value when no file is configured" $ do
+      password <- resolveRedisPasswordFrom Nothing (Just syntheticJwt) (\_ -> pure "")
+      password `shouldBe` syntheticJwt
+
+    it "rejects an empty credential file" $
+      resolveRedisPasswordFrom (Just "/secure/credential") Nothing (\_ -> pure "\n")
+        `shouldThrow` anyIOException
+
+  describe "parallel fill child arguments" $ do
+    it "never copies the credential into child argv" $ do
+      let state = defaultRunState
+            { host = "localhost"
+            , password = syntheticJwt
+            , username = "entra-object-id"
+            }
+          args = buildChildArgs state 2 3
+      args `shouldSatisfy` (\values -> syntheticJwt `notElem` values)
+      args `shouldSatisfy` (\values -> "-a" `notElem` values)
+      args `shouldSatisfy` (\values -> "--password" `notElem` values)
+      unwords args `shouldSatisfy` not . isInfixOf syntheticJwt
+
+rejectsWithoutEcho :: [String] -> Spec
+rejectsWithoutEcho args =
+  it "rejects a legacy credential argv form without echoing its value" $
+    case rejectCredentialArguments args of
+      Left message -> message `shouldSatisfy` not . isInfixOf syntheticJwt
+      Right ()     -> expectationFailure "credential-bearing argv was accepted"

--- a/test/CredentialSpec.hs
+++ b/test/CredentialSpec.hs
@@ -1,10 +1,13 @@
 module Main where
 
-import           AppConfig        (RunState (..), defaultRunState)
-import           CredentialConfig (rejectCredentialArguments,
-                                   resolveRedisPasswordFrom)
-import           Data.List        (isInfixOf)
-import           FillProcess      (buildChildArgs)
+import           AppConfig         (RunState (..), defaultRunState)
+import           Control.Exception (IOException, displayException, try)
+import           CredentialConfig  (rejectCredentialArguments,
+                                    resolveRedisPasswordFrom)
+import           Data.List         (isInfixOf)
+import           FillProcess       (buildChildArgs)
+import           System.IO.Error   (doesNotExistErrorType, mkIOError,
+                                    permissionErrorType)
 import           Test.Hspec
 
 syntheticJwt :: String
@@ -38,6 +41,36 @@ main = hspec $ do
     it "rejects an empty credential file" $
       resolveRedisPasswordFrom (Just "/secure/credential") Nothing (\_ -> pure "\n")
         `shouldThrow` anyIOException
+
+    it "does not disclose a missing credential path or fallback environment credential" $ do
+      let configuredPath = "/secure/missing-credential"
+          fallbackCredential = "fallback-environment-credential"
+      result <- try $ resolveRedisPasswordFrom
+        (Just configuredPath)
+        (Just fallbackCredential)
+        (\path -> ioError (mkIOError doesNotExistErrorType fallbackCredential Nothing (Just path)))
+      case result of
+        Left exception -> do
+          let message = displayException (exception :: IOException)
+          message `shouldContain` "Unable to read Redis credential file"
+          message `shouldSatisfy` not . isInfixOf configuredPath
+          message `shouldSatisfy` not . isInfixOf fallbackCredential
+        Right _ -> expectationFailure "missing credential file was accepted"
+
+    it "does not disclose an unreadable credential path or fallback environment credential" $ do
+      let configuredPath = "/secure/unreadable-credential"
+          fallbackCredential = "fallback-environment-credential"
+      result <- try $ resolveRedisPasswordFrom
+        (Just configuredPath)
+        (Just fallbackCredential)
+        (\path -> ioError (mkIOError permissionErrorType fallbackCredential Nothing (Just path)))
+      case result of
+        Left exception -> do
+          let message = displayException (exception :: IOException)
+          message `shouldContain` "Unable to read Redis credential file"
+          message `shouldSatisfy` not . isInfixOf configuredPath
+          message `shouldSatisfy` not . isInfixOf fallbackCredential
+        Right _ -> expectationFailure "unreadable credential file was accepted"
 
   describe "parallel fill child arguments" $ do
     it "never copies the credential into child argv" $ do


### PR DESCRIPTION
## Summary
- replace `-a/--password` with `REDIS_CLIENT_PASSWORD_FILE` and `REDIS_CLIENT_PASSWORD`, with credential-file precedence
- keep parallel fill credentials in inherited process state rather than child argv
- launch Azure Redis sessions with credentials in the child environment, generate credential-free owner-only command files, and format subprocess failures without command arguments
- add focused Haskell, Python, and shell regression coverage plus migration/security documentation

## Security properties
- live Redis passwords, access keys, and Entra tokens are absent from CLI and fill-child argv
- legacy credential arguments fail with a generic error that does not echo the supplied value
- saved commands contain no live credential and are created with mode `0700`
- URL-safe JWT-shaped and access-key-shaped synthetic values are redacted in defensive Azure CLI output handling
- redis-client subprocess failures report only the exit code

## Compatibility
This intentionally breaks automation using `-a/--password`. Migrate to `REDIS_CLIENT_PASSWORD_FILE` (preferred) or `REDIS_CLIENT_PASSWORD`. If both are set, the file takes precedence. Direct environment values can be inspected by privileged users, so credential files remain the recommended manual workflow.

## Validation
- `nix-build --no-out-link`
- `make test` (unit, standalone E2E, cluster E2E, and library E2E)
- focused credential tests: Python (4), Haskell (9), and shell CLI checks
- post-change corrected Cabal profile invocation: 0.01s and 754,736 bytes allocated for `--help`

## Profiling limitation
The requested literal command includes an extra Cabal separator and passes `--` as the executable mode, so both attempts fail before a comparable profile. Before the change, `--help` was also unsupported. The supported equivalent, `cabal run --enable-profiling redis-client -- --help +RTS -p -RTS`, produced the post-change profile above. Profiling artifacts were removed.

## Review gate
Do not merge until Tester and Rai have reviewed this security change.

Closes #67
