### PR TITLE
Wake in-flight requests during multiplexer teardown

### DIFF
--- a/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
@@ -33,14 +33,15 @@ module Database.Redis.Internal.Multiplexer
   , isMultiplexerAlive
   ) where
 
-import           Control.Concurrent               (ThreadId, forkIO, killThread,
-                                                   myThreadId)
-import           Control.Concurrent.MVar          (MVar, newEmptyMVar, takeMVar,
-                                                   tryPutMVar)
+import           Control.Concurrent               (ThreadId, forkFinally,
+                                                   killThread, myThreadId)
+import           Control.Concurrent.MVar          (MVar, newEmptyMVar, newMVar,
+                                                   putMVar, takeMVar,
+                                                   tryPutMVar, withMVar)
 import           Control.Exception                (Exception, SomeException,
                                                    mask_, throwIO, toException,
                                                    try)
-import           Control.Monad                    (forM_, void)
+import           Control.Monad                    (forM_, unless, void, when)
 import qualified Data.Attoparsec.ByteString.Char8 as StrictParse
 import           Data.ByteString                  (ByteString)
 import qualified Data.ByteString                  as BS
@@ -145,21 +146,26 @@ data PendingCommand = PendingCommand
 -- Writer is sole producer, reader is sole consumer.
 -- Uses IORef + MVar signaling instead of STM TQueue.
 data PendingQueue = PendingQueue
-  { pqSlots  :: !(IORef (Seq ResponseSlot))
+  { pqState  :: !(IORef PendingQueueState)
   , pqSignal :: !(MVar ())  -- signaled when new items are available
+  }
+
+data PendingQueueState = PendingQueueState
+  { pqsQueued :: !(Seq ResponseSlot)
+  , pqsActive :: !(Seq ResponseSlot)
   }
 
 newPendingQueue :: IO PendingQueue
 newPendingQueue = do
-  slots <- newIORef Seq.empty
+  state <- newIORef $ PendingQueueState Seq.empty Seq.empty
   signal <- newEmptyMVar
-  return $ PendingQueue slots signal
+  return $ PendingQueue state signal
 
 -- | Enqueue a Seq of response slots directly (avoids Seq.fromList conversion).
 pendingEnqueueSeq :: PendingQueue -> Seq ResponseSlot -> IO ()
 pendingEnqueueSeq pq newSlots = do
-  atomicModifyIORef' (pqSlots pq) $ \s ->
-    (s <> newSlots, ())
+  atomicModifyIORef' (pqState pq) $ \state ->
+    (state { pqsQueued = pqsQueued state <> newSlots }, ())
   void $ tryPutMVar (pqSignal pq) ()
 {-# INLINE pendingEnqueueSeq #-}
 
@@ -167,10 +173,16 @@ pendingEnqueueSeq pq newSlots = do
 -- Blocks if empty.
 pendingDequeue :: PendingQueue -> IO ResponseSlot
 pendingDequeue pq = do
-  mSlot <- atomicModifyIORef' (pqSlots pq) $ \s ->
-    case Seq.viewl s of
-      Seq.EmptyL  -> (s, Nothing)
-      x Seq.:< xs -> (xs, Just x)
+  mSlot <- atomicModifyIORef' (pqState pq) $ \state ->
+    case Seq.viewl (pqsQueued state) of
+      Seq.EmptyL -> (state, Nothing)
+      slot Seq.:< rest ->
+        ( state
+            { pqsQueued = rest
+            , pqsActive = pqsActive state Seq.|> slot
+            }
+        , Just slot
+        )
   case mSlot of
     Just slot -> return slot
     Nothing -> do
@@ -182,46 +194,77 @@ pendingDequeue pq = do
 -- Returns empty Seq if none available.
 pendingDequeueUpTo :: PendingQueue -> Int -> IO (Seq ResponseSlot)
 pendingDequeueUpTo pq n = do
-  atomicModifyIORef' (pqSlots pq) $ \s ->
-    let (taken, rest) = Seq.splitAt n s
-    in (rest, taken)
+  atomicModifyIORef' (pqState pq) $ \state ->
+    let (taken, rest) = Seq.splitAt n (pqsQueued state)
+    in ( state
+           { pqsQueued = rest
+           , pqsActive = pqsActive state <> taken
+           }
+       , taken
+       )
 {-# INLINE pendingDequeueUpTo #-}
 
--- | Drain all pending slots (for error propagation).
+-- | Remove the oldest reader-owned slot after it has been completed.
+pendingCompleteOne :: PendingQueue -> IO ()
+pendingCompleteOne pq =
+  atomicModifyIORef' (pqState pq) $ \state ->
+    case Seq.viewl (pqsActive state) of
+      Seq.EmptyL    -> (state, ())
+      _ Seq.:< rest -> (state { pqsActive = rest }, ())
+{-# INLINE pendingCompleteOne #-}
+
+-- | Drain all queued and reader-owned slots (for error propagation).
 pendingDrainAll :: PendingQueue -> IO [ResponseSlot]
 pendingDrainAll pq = do
-  slots <- atomicModifyIORef' (pqSlots pq) $ \s -> (Seq.empty, s)
+  slots <- atomicModifyIORef' (pqState pq) $ \state ->
+    let allSlots = pqsActive state <> pqsQueued state
+    in (PendingQueueState Seq.empty Seq.empty, allSlots)
   return $ foldr (:) [] slots
 
 -- | Lock-free MPSC (multi-producer, single-consumer) command queue.
 -- Producers use atomicModifyIORef' to cons onto the list (single CAS).
 -- The consumer reverses once per drain. MVar signals new item availability.
 data CommandQueue = CommandQueue
-  { cqItems  :: !(IORef [PendingCommand])  -- reverse order (newest first)
+  { cqState  :: !(IORef CommandQueueState)
   , cqSignal :: !(MVar ())                 -- wake writer when items available
+  }
+
+data CommandQueueState = CommandQueueState
+  { cqsOpen   :: !Bool
+  , cqsQueued :: ![PendingCommand] -- reverse order (newest first)
+  , cqsActive :: ![PendingCommand] -- writer-owned batch, submission order
   }
 
 newCommandQueue :: IO CommandQueue
 newCommandQueue = do
-  items  <- newIORef []
+  state  <- newIORef $ CommandQueueState True [] []
   signal <- newEmptyMVar
-  return $ CommandQueue items signal
+  return $ CommandQueue state signal
 
 -- | Enqueue a command (caller thread — multi-producer safe).
-commandEnqueue :: CommandQueue -> PendingCommand -> IO ()
+-- Returns 'False' once teardown has closed admission.
+commandEnqueue :: CommandQueue -> PendingCommand -> IO Bool
 commandEnqueue cq pc = do
-  atomicModifyIORef' (cqItems cq) $ \xs -> (pc : xs, ())
-  void $ tryPutMVar (cqSignal cq) ()
+  accepted <- atomicModifyIORef' (cqState cq) $ \state ->
+    if cqsOpen state
+      then (state { cqsQueued = pc : cqsQueued state }, True)
+      else (state, False)
+  when accepted $ void $ tryPutMVar (cqSignal cq) ()
+  return accepted
 {-# INLINE commandEnqueue #-}
 
 -- | Enqueue two commands atomically (caller thread — multi-producer safe).
 -- Both commands are added in a single CAS so no other command can be
 -- interleaved between them. The first command will appear before the second
 -- in the pipeline.
-commandEnqueuePair :: CommandQueue -> PendingCommand -> PendingCommand -> IO ()
+commandEnqueuePair :: CommandQueue -> PendingCommand -> PendingCommand -> IO Bool
 commandEnqueuePair cq pc1 pc2 = do
-  atomicModifyIORef' (cqItems cq) $ \xs -> (pc2 : pc1 : xs, ())
-  void $ tryPutMVar (cqSignal cq) ()
+  accepted <- atomicModifyIORef' (cqState cq) $ \state ->
+    if cqsOpen state
+      then (state { cqsQueued = pc2 : pc1 : cqsQueued state }, True)
+      else (state, False)
+  when accepted $ void $ tryPutMVar (cqSignal cq) ()
+  return accepted
 {-# INLINE commandEnqueuePair #-}
 
 -- | Drain all commands (writer thread only — single consumer).
@@ -229,30 +272,58 @@ commandEnqueuePair cq pc1 pc2 = do
 commandDrain :: CommandQueue -> IO [PendingCommand]
 commandDrain cq = do
   takeMVar (cqSignal cq)
-  batch <- atomicModifyIORef' (cqItems cq) $ \xs -> ([], xs)
-  return (reverse batch)
+  atomicModifyIORef' (cqState cq) $ \state ->
+    let batch = reverse (cqsQueued state)
+    in (state { cqsQueued = [], cqsActive = batch }, batch)
 
 -- | Non-blocking drain of any additional commands that have arrived.
 -- Returns commands in submission order. Returns [] if none available.
 commandTryDrain :: CommandQueue -> IO [PendingCommand]
-commandTryDrain cq = do
-  batch <- atomicModifyIORef' (cqItems cq) $ \xs -> ([], xs)
-  case batch of
-    [] -> return []
-    _  -> return (reverse batch)
+commandTryDrain cq =
+  atomicModifyIORef' (cqState cq) $ \state ->
+    let batch = reverse (cqsQueued state)
+    in ( state
+           { cqsQueued = []
+           , cqsActive = cqsActive state <> batch
+           }
+       , batch
+       )
 
--- | Drain remaining commands without blocking (for cleanup).
-commandFlush :: CommandQueue -> IO [PendingCommand]
-commandFlush cq = do
-  batch <- atomicModifyIORef' (cqItems cq) $ \xs -> ([], xs)
-  return (reverse batch)
+-- | Finish the masked handoff of the writer-owned batch to the pending queue.
+commandBatchTransferred :: CommandQueue -> IO ()
+commandBatchTransferred cq =
+  atomicModifyIORef' (cqState cq) $ \state ->
+    (state { cqsActive = [] }, ())
+{-# INLINE commandBatchTransferred #-}
+
+-- | Atomically stop accepting submissions. Returns whether this call closed it.
+commandClose :: CommandQueue -> IO Bool
+commandClose cq = do
+  closed <- atomicModifyIORef' (cqState cq) $ \state ->
+    if cqsOpen state
+      then (state { cqsOpen = False }, True)
+      else (state, False)
+  void $ tryPutMVar (cqSignal cq) ()
+  return closed
+
+-- | Drain queued and writer-owned commands without blocking (for cleanup).
+commandDrainAll :: CommandQueue -> IO [PendingCommand]
+commandDrainAll cq =
+  atomicModifyIORef' (cqState cq) $ \state ->
+    let allCommands = cqsActive state <> reverse (cqsQueued state)
+    in (state { cqsQueued = [], cqsActive = [] }, allCommands)
 
 -- | A multiplexer wrapping a single Redis connection.
 data Multiplexer = Multiplexer
   { muxCommandQueue :: !CommandQueue
+  , muxPendingQueue :: !PendingQueue
   , muxWriterThread :: !ThreadId
   , muxReaderThread :: !ThreadId
+  , muxWriterDone   :: !(MVar ())
+  , muxReaderDone   :: !(MVar ())
   , muxAlive        :: !(IORef Bool)
+  , muxDestroyed    :: !(IORef Bool)
+  , muxDestroyLock  :: !(MVar ())
   }
 
 -- | Create a multiplexer over an already-connected client.
@@ -267,43 +338,54 @@ createMultiplexer
 createMultiplexer conn recv = do
   cmdQueue     <- newCommandQueue
   pendingQueue <- newPendingQueue
+  transferLock <- newMVar ()
   alive        <- newIORef True
+  destroyed    <- newIORef False
+  destroyLock  <- newMVar ()
+  readerDone   <- newEmptyMVar
+  writerDone   <- newEmptyMVar
 
-  readerId <- forkIO $ readerLoop pendingQueue recv alive
-  writerId <- forkIO $ writerLoop cmdQueue pendingQueue conn alive
+  readerId <- forkFinally
+    (readerLoop transferLock cmdQueue pendingQueue recv alive)
+    (const $ putMVar readerDone ())
+  writerId <- forkFinally
+    (writerLoop transferLock cmdQueue pendingQueue conn alive)
+    (const $ putMVar writerDone ())
 
-  return $ Multiplexer cmdQueue writerId readerId alive
+  return $ Multiplexer
+    cmdQueue pendingQueue writerId readerId writerDone readerDone
+    alive destroyed destroyLock
+
+multiplexerDestroyed :: SomeException
+multiplexerDestroyed = toException $ MultiplexerDead "Multiplexer destroyed"
 
 -- | Submit a pre-encoded RESP command as a Builder and block until the response arrives.
 submitCommand :: Multiplexer -> Builder.Builder -> IO RespData
 submitCommand mux cmdBuilder = do
-  isAlive <- readIORef (muxAlive mux)
-  if not isAlive
-    then throwIO $ MultiplexerDead "Multiplexer is not alive"
-    else do
-      resultRef <- newIORef Nothing
-      signal <- newEmptyMVar
-      let slot = ResponseSlot resultRef signal
-          pending = PendingCommand cmdBuilder slot
-      commandEnqueue (muxCommandQueue mux) pending
+  resultRef <- newIORef Nothing
+  signal <- newEmptyMVar
+  let slot = ResponseSlot resultRef signal
+      pending = PendingCommand cmdBuilder slot
+  accepted <- commandEnqueue (muxCommandQueue mux) pending
+  if accepted
+    then do
       takeMVar signal
       mResult <- readIORef resultRef
       case mResult of
         Just (Right resp) -> return resp
         Just (Left e)     -> throwIO e
         Nothing           -> throwIO $ MultiplexerDead "Response slot empty after signal"
+    else throwIO multiplexerDestroyed
 
 -- | Like 'submitCommand', but acquires a 'ResponseSlot' from the pool
 -- instead of allocating a fresh IORef+MVar per call.
 submitCommandPooled :: SlotPool -> Multiplexer -> Builder.Builder -> IO RespData
 submitCommandPooled pool mux cmdBuilder = do
-  isAlive <- readIORef (muxAlive mux)
-  if not isAlive
-    then throwIO $ MultiplexerDead "Multiplexer is not alive"
-    else do
-      slot <- acquireSlot pool
-      let pending = PendingCommand cmdBuilder slot
-      commandEnqueue (muxCommandQueue mux) pending
+  slot <- acquireSlot pool
+  let pending = PendingCommand cmdBuilder slot
+  accepted <- commandEnqueue (muxCommandQueue mux) pending
+  if accepted
+    then do
       takeMVar (slotSignal slot)
       mResult <- readIORef (slotResult slot)
       releaseSlot pool slot
@@ -311,6 +393,9 @@ submitCommandPooled pool mux cmdBuilder = do
         Just (Right resp) -> return resp
         Just (Left e)     -> throwIO e
         Nothing           -> throwIO $ MultiplexerDead "Response slot empty after signal"
+    else do
+      releaseSlot pool slot
+      throwIO multiplexerDestroyed
 {-# INLINE submitCommandPooled #-}
 
 -- | Submit two commands atomically as a pair. Both are enqueued in a single
@@ -320,15 +405,13 @@ submitCommandPooled pool mux cmdBuilder = do
 -- the target command on the same connection.
 submitCommandPairPooled :: SlotPool -> Multiplexer -> Builder.Builder -> Builder.Builder -> IO RespData
 submitCommandPairPooled pool mux firstBuilder secondBuilder = do
-  isAlive <- readIORef (muxAlive mux)
-  if not isAlive
-    then throwIO $ MultiplexerDead "Multiplexer is not alive"
-    else do
-      slot1 <- acquireSlot pool
-      slot2 <- acquireSlot pool
-      let pending1 = PendingCommand firstBuilder slot1
-          pending2 = PendingCommand secondBuilder slot2
-      commandEnqueuePair (muxCommandQueue mux) pending1 pending2
+  slot1 <- acquireSlot pool
+  slot2 <- acquireSlot pool
+  let pending1 = PendingCommand firstBuilder slot1
+      pending2 = PendingCommand secondBuilder slot2
+  accepted <- commandEnqueuePair (muxCommandQueue mux) pending1 pending2
+  if accepted
+    then do
       -- Wait for and discard the first response (ASKING → +OK)
       takeMVar (slotSignal slot1)
       releaseSlot pool slot1
@@ -340,20 +423,24 @@ submitCommandPairPooled pool mux firstBuilder secondBuilder = do
         Just (Right resp) -> return resp
         Just (Left e)     -> throwIO e
         Nothing           -> throwIO $ MultiplexerDead "Response slot empty after signal"
+    else do
+      releaseSlot pool slot1
+      releaseSlot pool slot2
+      throwIO multiplexerDestroyed
 {-# INLINE submitCommandPairPooled #-}
 
 -- | Submit a command asynchronously: enqueue it and return the ResponseSlot.
 -- The caller must later call 'waitSlot' to get the result, then 'releaseSlot'.
 submitCommandAsync :: SlotPool -> Multiplexer -> Builder.Builder -> IO ResponseSlot
 submitCommandAsync pool mux cmdBuilder = do
-  isAlive <- readIORef (muxAlive mux)
-  if not isAlive
-    then throwIO $ MultiplexerDead "Multiplexer is not alive"
+  slot <- acquireSlot pool
+  let pending = PendingCommand cmdBuilder slot
+  accepted <- commandEnqueue (muxCommandQueue mux) pending
+  if accepted
+    then return slot
     else do
-      slot <- acquireSlot pool
-      let pending = PendingCommand cmdBuilder slot
-      commandEnqueue (muxCommandQueue mux) pending
-      return slot
+      releaseSlot pool slot
+      throwIO multiplexerDestroyed
 {-# INLINE submitCommandAsync #-}
 
 -- | Wait for an async submission's result and release the slot back to the pool.
@@ -370,14 +457,21 @@ waitSlot pool slot = do
 
 -- | Tear down the multiplexer: kill both threads and fail all pending commands.
 destroyMultiplexer :: Multiplexer -> IO ()
-destroyMultiplexer mux = mask_ $ do
-  atomicWriteIORef (muxAlive mux) False
-  killThread (muxWriterThread mux)
-  killThread (muxReaderThread mux)
-  remaining <- commandFlush (muxCommandQueue mux)
-  let err = MultiplexerDead "Multiplexer destroyed"
-  forM_ remaining $ \pc ->
-    failSlot (pcSlot pc) (toException err)
+destroyMultiplexer mux =
+  withMVar (muxDestroyLock mux) $ \() -> mask_ $ do
+    alreadyDestroyed <- readIORef (muxDestroyed mux)
+    unless alreadyDestroyed $ do
+      writeIORef (muxDestroyed mux) True
+      void $ commandClose (muxCommandQueue mux)
+      atomicWriteIORef (muxAlive mux) False
+      killThread (muxWriterThread mux)
+      killThread (muxReaderThread mux)
+      takeMVar (muxWriterDone mux)
+      takeMVar (muxReaderDone mux)
+      commands <- commandDrainAll (muxCommandQueue mux)
+      pending <- pendingDrainAll (muxPendingQueue mux)
+      forM_ commands $ \pc -> failSlot (pcSlot pc) multiplexerDestroyed
+      forM_ pending $ \slot -> failSlot slot multiplexerDestroyed
 
 -- | Check if the multiplexer's threads are still running.
 isMultiplexerAlive :: Multiplexer -> IO Bool
@@ -387,12 +481,13 @@ isMultiplexerAlive = readIORef . muxAlive
 -- queue (in IO, not STM), and sends batched bytes over the wire.
 writerLoop
   :: (Client client)
-  => CommandQueue
+  => MVar ()
+  -> CommandQueue
   -> PendingQueue
   -> client 'Connected
   -> IORef Bool
   -> IO ()
-writerLoop cmdQueue pendingQueue conn alive = go
+writerLoop transferLock cmdQueue pendingQueue conn alive = go
   where
     go = do
       isAlive <- readIORef alive
@@ -405,30 +500,35 @@ writerLoop cmdQueue pendingQueue conn alive = go
           extra <- commandTryDrain cmdQueue
           let allCmds = batch ++ extra
 
-          -- Single-pass: extract slots (as Seq) and build the combined Builder
-          let (!slots, !builder) = foldl'
-                (\(!sAcc, !bAcc) pc -> (sAcc Seq.|> pcSlot pc, bAcc <> pcBuilder pc))
-                (Seq.empty, mempty)
-                allCmds
+          if null allCmds
+            then return ()
+            else do
+              -- Single-pass: extract slots (as Seq) and build the combined Builder
+              let (!slots, !builder) = foldl'
+                    (\(!sAcc, !bAcc) pc -> (sAcc Seq.|> pcSlot pc, bAcc <> pcBuilder pc))
+                    (Seq.empty, mempty)
+                    allCmds
 
-          -- Push response slots to pending queue (Seq avoids fromList conversion)
-          pendingEnqueueSeq pendingQueue slots
+              transferred <- withMVar transferLock $ \() -> mask_ $ do
+                stillAlive <- readIORef alive
+                when stillAlive $ do
+                  pendingEnqueueSeq pendingQueue slots
+                  commandBatchTransferred cmdQueue
+                return stillAlive
 
-          -- Materialize with large buffer strategy and send via vectored I/O.
-          -- untrimmedStrategy avoids trimming/copying the final chunk.
-          -- 32KB initial / 64KB growth reduces chunk count vs default 4KB.
-          -- sendChunks uses writev(2) for zero-copy vectored I/O on plain sockets.
-          let !lbs = Builder.toLazyByteStringWith
-                       (Builder.untrimmedStrategy 32768 65536) LBS.empty builder
-              !chunks = LBS.toChunks lbs
-          result <- try $ sendChunks conn chunks
-          case result of
-            Right () -> go
-            Left (e :: SomeException) -> do
-              atomicWriteIORef alive False
-              remaining <- pendingDrainAll pendingQueue
-              forM_ remaining $ \slot -> failSlot slot e
-              forM_ allCmds $ \pc -> failSlot (pcSlot pc) e
+              when transferred $ do
+                -- Materialize with large buffer strategy and send via vectored I/O.
+                -- untrimmedStrategy avoids trimming/copying the final chunk.
+                -- 32KB initial / 64KB growth reduces chunk count vs default 4KB.
+                -- sendChunks uses writev(2) for zero-copy vectored I/O on plain sockets.
+                let !lbs = Builder.toLazyByteStringWith
+                             (Builder.untrimmedStrategy 32768 65536) LBS.empty builder
+                    !chunks = LBS.toChunks lbs
+                result <- try $ sendChunks conn chunks
+                case result of
+                  Right () -> go
+                  Left (e :: SomeException) ->
+                    failMultiplexerQueues transferLock cmdQueue pendingQueue alive e
 
 -- Reader thread: pops response slots from the pending queue and fills
 -- them with parsed RESP responses. When the buffer contains additional
@@ -436,11 +536,13 @@ writerLoop cmdQueue pendingQueue conn alive = go
 -- inner loop to reduce per-response dequeue overhead.
 -- Uses Attoparsec IResult directly to avoid Either allocation per response.
 readerLoop
-  :: PendingQueue
+  :: MVar ()
+  -> CommandQueue
+  -> PendingQueue
   -> IO ByteString
   -> IORef Bool
   -> IO ()
-readerLoop pendingQueue recv alive = go BS.empty
+readerLoop transferLock cmdQueue pendingQueue recv alive = go BS.empty
   where
     go !buffer = do
       isAlive <- readIORef alive
@@ -453,36 +555,23 @@ readerLoop pendingQueue recv alive = go BS.empty
     -- Drive the incremental parser, feeding data until Done or Fail.
     -- Avoids allocating Either/tuple wrappers on the hot path.
     feedParse !slot (StrictParse.Done !remainder !resp) = do
-      writeIORef (slotResult slot) (Just (Right resp))
-      void $ tryPutMVar (slotSignal slot) ()
+      completePendingSlot pendingQueue slot (Right resp)
       -- If there's remaining data, try to parse more in a tight loop
       if BS.null remainder
         then go remainder
         else drainBuffer remainder
-    feedParse !slot (StrictParse.Fail _ _ err) = do
+    feedParse !_slot (StrictParse.Fail _ _ err) = do
       let !e = toException $ MultiplexerParseError err
-      writeIORef (slotResult slot) (Just (Left e))
-      void $ tryPutMVar (slotSignal slot) ()
-      atomicWriteIORef alive False
-      remaining <- pendingDrainAll pendingQueue
-      forM_ remaining $ \s -> failSlot s e
+      failMultiplexerQueues transferLock cmdQueue pendingQueue alive e
     feedParse !slot (StrictParse.Partial cont) = do
       moreResult <- try recv
       case moreResult of
-        Left (e :: SomeException) -> do
-          writeIORef (slotResult slot) (Just (Left e))
-          void $ tryPutMVar (slotSignal slot) ()
-          atomicWriteIORef alive False
-          remaining <- pendingDrainAll pendingQueue
-          forM_ remaining $ \s -> failSlot s e
+        Left (e :: SomeException) ->
+          failMultiplexerQueues transferLock cmdQueue pendingQueue alive e
         Right moreData
           | BS.null moreData -> do
               let !e = toException MultiplexerConnectionClosed
-              writeIORef (slotResult slot) (Just (Left e))
-              void $ tryPutMVar (slotSignal slot) ()
-              atomicWriteIORef alive False
-              remaining <- pendingDrainAll pendingQueue
-              forM_ remaining $ \s -> failSlot s e
+              failMultiplexerQueues transferLock cmdQueue pendingQueue alive e
           | otherwise -> feedParse slot (cont moreData)
 
     -- Tight inner loop: buffer has data, grab available slots and parse
@@ -505,8 +594,7 @@ readerLoop pendingQueue recv alive = go BS.empty
       feedParseBatch slot remaining (StrictParse.parse parseRespData buffer)
 
     feedParseBatch !slot !remaining (StrictParse.Done !remainder !resp) = do
-      writeIORef (slotResult slot) (Just (Right resp))
-      void $ tryPutMVar (slotSignal slot) ()
+      completePendingSlot pendingQueue slot (Right resp)
       case Seq.viewl remaining of
         Seq.EmptyL ->
           if BS.null remainder
@@ -514,39 +602,65 @@ readerLoop pendingQueue recv alive = go BS.empty
             else drainBuffer remainder
         nextSlot Seq.:< restSlots ->
           feedParseBatch nextSlot restSlots (StrictParse.parse parseRespData remainder)
-    feedParseBatch !slot !remaining (StrictParse.Fail _ _ err) = do
+    feedParseBatch !_slot !_remaining (StrictParse.Fail _ _ err) = do
       let !e = toException $ MultiplexerParseError err
-      writeIORef (slotResult slot) (Just (Left e))
-      void $ tryPutMVar (slotSignal slot) ()
-      atomicWriteIORef alive False
-      forM_ remaining $ \s -> failSlot s e
-      queued <- pendingDrainAll pendingQueue
-      forM_ queued $ \s -> failSlot s e
+      failMultiplexerQueues transferLock cmdQueue pendingQueue alive e
     feedParseBatch !slot !remaining (StrictParse.Partial cont) = do
       moreResult <- try recv
       case moreResult of
-        Left (e :: SomeException) -> do
-          writeIORef (slotResult slot) (Just (Left e))
-          void $ tryPutMVar (slotSignal slot) ()
-          atomicWriteIORef alive False
-          forM_ remaining $ \s -> failSlot s e
-          queued <- pendingDrainAll pendingQueue
-          forM_ queued $ \s -> failSlot s e
+        Left (e :: SomeException) ->
+          failMultiplexerQueues transferLock cmdQueue pendingQueue alive e
         Right moreData
           | BS.null moreData -> do
               let !e = toException MultiplexerConnectionClosed
-              writeIORef (slotResult slot) (Just (Left e))
-              void $ tryPutMVar (slotSignal slot) ()
-              atomicWriteIORef alive False
-              forM_ remaining $ \s -> failSlot s e
-              queued <- pendingDrainAll pendingQueue
-              forM_ queued $ \s -> failSlot s e
+              failMultiplexerQueues transferLock cmdQueue pendingQueue alive e
           | otherwise -> feedParseBatch slot remaining (cont moreData)
+
+-- | Remove a reader-owned slot from lifecycle tracking and complete it without
+-- allowing teardown to interrupt the handoff between those two operations.
+completePendingSlot
+  :: PendingQueue
+  -> ResponseSlot
+  -> Either SomeException RespData
+  -> IO ()
+completePendingSlot pendingQueue slot result = mask_ $ do
+  pendingCompleteOne pendingQueue
+  void $ completeSlot slot result
+{-# INLINE completePendingSlot #-}
+
+-- | Close admission and fail every slot still owned by either worker queue.
+failMultiplexerQueues
+  :: MVar ()
+  -> CommandQueue
+  -> PendingQueue
+  -> IORef Bool
+  -> SomeException
+  -> IO ()
+failMultiplexerQueues transferLock cmdQueue pendingQueue alive e =
+  withMVar transferLock $ \() -> mask_ $ do
+    wasAlive <- readIORef alive
+    let failure = if wasAlive then e else multiplexerDestroyed
+    atomicWriteIORef alive False
+    void $ commandClose cmdQueue
+    commands <- commandDrainAll cmdQueue
+    pending <- pendingDrainAll pendingQueue
+    forM_ commands $ \pc -> failSlot (pcSlot pc) failure
+    forM_ pending $ \slot -> failSlot slot failure
+
+-- | Complete a response slot at most once. The result and wakeup are owned by
+-- the thread that wins the atomic transition from 'Nothing'.
+completeSlot :: ResponseSlot -> Either SomeException RespData -> IO Bool
+completeSlot slot result = do
+  completed <- atomicModifyIORef' (slotResult slot) $ \current ->
+    case current of
+      Nothing -> (Just result, True)
+      Just _  -> (current, False)
+  when completed $ void $ tryPutMVar (slotSignal slot) ()
+  return completed
+{-# INLINE completeSlot #-}
 
 -- | Fail a response slot with an exception.
 failSlot :: ResponseSlot -> SomeException -> IO ()
-failSlot slot e = do
-  writeIORef (slotResult slot) (Just (Left e))
-  void $ tryPutMVar (slotSignal slot) ()
+failSlot slot e =
+  void $ completeSlot slot (Left e)
 {-# INLINE failSlot #-}
-

--- a/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
@@ -29,6 +29,7 @@ module Database.Redis.Internal.Multiplexer
   , submitCommandPairPooled
   , submitCommandAsync
   , waitSlot
+  , sameResponseSlot
   , destroyMultiplexer
   , isMultiplexerAlive
   ) where
@@ -36,12 +37,12 @@ module Database.Redis.Internal.Multiplexer
 import           Control.Concurrent               (ThreadId, forkFinally,
                                                    killThread, myThreadId)
 import           Control.Concurrent.MVar          (MVar, newEmptyMVar, newMVar,
-                                                   putMVar, takeMVar,
+                                                   putMVar, readMVar, takeMVar,
                                                    tryPutMVar, withMVar)
 import           Control.Exception                (Exception, SomeException,
                                                    mask_, throwIO, toException,
-                                                   try)
-import           Control.Monad                    (forM_, unless, void, when)
+                                                   try, uninterruptibleMask_)
+import           Control.Monad                    (forM_, void, when)
 import qualified Data.Attoparsec.ByteString.Char8 as StrictParse
 import           Data.ByteString                  (ByteString)
 import qualified Data.ByteString                  as BS
@@ -79,6 +80,10 @@ data ResponseSlot = ResponseSlot
   { slotResult :: !(IORef (Maybe (Either SomeException RespData)))
   , slotSignal :: !(MVar ())
   }
+
+-- | Test and diagnostics identity for a pooled response slot.
+sameResponseSlot :: ResponseSlot -> ResponseSlot -> Bool
+sameResponseSlot left right = slotSignal left == slotSignal right
 
 -- | Striped pool of pre-allocated ResponseSlots.
 -- Uses multiple IORef-based stacks indexed by capability (core) to reduce
@@ -322,9 +327,15 @@ data Multiplexer = Multiplexer
   , muxWriterDone   :: !(MVar ())
   , muxReaderDone   :: !(MVar ())
   , muxAlive        :: !(IORef Bool)
-  , muxDestroyed    :: !(IORef Bool)
+  , muxLifecycle    :: !(IORef MultiplexerLifecycle)
   , muxDestroyLock  :: !(MVar ())
   }
+
+data MultiplexerLifecycle
+  = MultiplexerOpen
+  | MultiplexerDestroying
+  | MultiplexerDestroyed
+  deriving (Eq)
 
 -- | Create a multiplexer over an already-connected client.
 --
@@ -340,7 +351,7 @@ createMultiplexer conn recv = do
   pendingQueue <- newPendingQueue
   transferLock <- newMVar ()
   alive        <- newIORef True
-  destroyed    <- newIORef False
+  lifecycle    <- newIORef MultiplexerOpen
   destroyLock  <- newMVar ()
   readerDone   <- newEmptyMVar
   writerDone   <- newEmptyMVar
@@ -354,7 +365,7 @@ createMultiplexer conn recv = do
 
   return $ Multiplexer
     cmdQueue pendingQueue writerId readerId writerDone readerDone
-    alive destroyed destroyLock
+    alive lifecycle destroyLock
 
 multiplexerDestroyed :: SomeException
 multiplexerDestroyed = toException $ MultiplexerDead "Multiplexer destroyed"
@@ -459,19 +470,29 @@ waitSlot pool slot = do
 destroyMultiplexer :: Multiplexer -> IO ()
 destroyMultiplexer mux =
   withMVar (muxDestroyLock mux) $ \() -> mask_ $ do
-    alreadyDestroyed <- readIORef (muxDestroyed mux)
-    unless alreadyDestroyed $ do
-      writeIORef (muxDestroyed mux) True
-      void $ commandClose (muxCommandQueue mux)
-      atomicWriteIORef (muxAlive mux) False
+    lifecycle <- readIORef (muxLifecycle mux)
+    when (lifecycle /= MultiplexerDestroyed) $ do
+      when (lifecycle == MultiplexerOpen) $ do
+        writeIORef (muxLifecycle mux) MultiplexerDestroying
+        void $ commandClose (muxCommandQueue mux)
+        atomicWriteIORef (muxAlive mux) False
+
+      -- These operations may block and remain interruptible. If this owner is
+      -- cancelled, the Destroying state lets the next caller resume teardown.
       killThread (muxWriterThread mux)
       killThread (muxReaderThread mux)
-      takeMVar (muxWriterDone mux)
-      takeMVar (muxReaderDone mux)
-      commands <- commandDrainAll (muxCommandQueue mux)
-      pending <- pendingDrainAll (muxPendingQueue mux)
-      forM_ commands $ \pc -> failSlot (pcSlot pc) multiplexerDestroyed
-      forM_ pending $ \slot -> failSlot slot multiplexerDestroyed
+      readMVar (muxWriterDone mux)
+      readMVar (muxReaderDone mux)
+
+      -- Queue drains and slot completion are bounded, non-blocking operations.
+      -- Keeping this tail uninterruptible prevents ownership from being lost
+      -- between removing a slot from lifecycle tracking and signaling it.
+      uninterruptibleMask_ $ do
+        commands <- commandDrainAll (muxCommandQueue mux)
+        pending <- pendingDrainAll (muxPendingQueue mux)
+        forM_ commands $ \pc -> failSlot (pcSlot pc) multiplexerDestroyed
+        forM_ pending $ \slot -> failSlot slot multiplexerDestroyed
+        writeIORef (muxLifecycle mux) MultiplexerDestroyed
 
 -- | Check if the multiplexer's threads are still running.
 isMultiplexerAlive :: Multiplexer -> IO Bool

--- a/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
@@ -273,13 +273,22 @@ commandEnqueuePair cq pc1 pc2 = do
 {-# INLINE commandEnqueuePair #-}
 
 -- | Drain all commands (writer thread only — single consumer).
--- Blocks if empty. Returns commands in submission order.
+-- Blocks if empty. Stale wakeups are retried while admission remains open;
+-- an empty result is reserved for a closed queue. Returns commands in
+-- submission order.
 commandDrain :: CommandQueue -> IO [PendingCommand]
 commandDrain cq = do
   takeMVar (cqSignal cq)
-  atomicModifyIORef' (cqState cq) $ \state ->
-    let batch = reverse (cqsQueued state)
-    in (state { cqsQueued = [], cqsActive = batch }, batch)
+  result <- atomicModifyIORef' (cqState cq) $ \state ->
+    case reverse (cqsQueued state) of
+      []
+        | cqsOpen state -> (state, Nothing)
+        | otherwise     -> (state, Just [])
+      batch ->
+        (state { cqsQueued = [], cqsActive = batch }, Just batch)
+  case result of
+    Nothing    -> commandDrain cq
+    Just batch -> return batch
 
 -- | Non-blocking drain of any additional commands that have arrived.
 -- Returns commands in submission order. Returns [] if none available.

--- a/hask-redis-mux/test/MultiplexerSpec.hs
+++ b/hask-redis-mux/test/MultiplexerSpec.hs
@@ -6,9 +6,13 @@
 module Main (main) where
 
 import           Control.Concurrent                  (forkIO, threadDelay)
-import           Control.Concurrent.MVar             (newEmptyMVar, putMVar,
-                                                      takeMVar)
-import           Control.Exception                   (SomeException, try)
+import           Control.Concurrent.MVar             (MVar, newEmptyMVar,
+                                                      putMVar, takeMVar,
+                                                      tryPutMVar)
+import           Control.Exception                   (SomeException,
+                                                      fromException, try)
+import           Control.Monad                       (replicateM, replicateM_,
+                                                      void)
 import           Control.Monad.IO.Class              (liftIO)
 import           Data.ByteString                     (ByteString)
 import qualified Data.ByteString                     as BS
@@ -21,6 +25,7 @@ import           Database.Redis.Client               (Client (..),
 import           Database.Redis.Internal.Multiplexer
 import           Database.Redis.Resp                 (Encodable (..),
                                                       RespData (..))
+import           System.Timeout                      (timeout)
 import           Test.Hspec
 
 -- ---------------------------------------------------------------------------
@@ -64,6 +69,30 @@ createMockClient = do
   let client = MockConnected sendBuf recvQueue
       addRecv bs = atomicModifyIORef' recvQueue $ \xs -> (xs ++ [bs], ())
   return (client, addRecv)
+
+-- | Transport that confirms the writer reached 'send' and then withholds all
+-- responses. This lets lifecycle tests deterministically destroy a mux after
+-- its first slot has moved from the command queue to the pending queue.
+data BlockingClient (a :: ConnectionStatus) where
+  BlockingConnected :: !(MVar ()) -> !(MVar ByteString) -> BlockingClient 'Connected
+
+instance Client BlockingClient where
+  connect = error "BlockingClient: connect not supported"
+  close _ = return ()
+  send (BlockingConnected sent _) _ =
+    liftIO $ void $ tryPutMVar sent ()
+  receive (BlockingConnected _ replies) =
+    liftIO $ takeMVar replies
+
+createBlockingClient :: IO (BlockingClient 'Connected, IO (), ByteString -> IO ())
+createBlockingClient = do
+  sent <- newEmptyMVar
+  replies <- newEmptyMVar
+  let awaitSend = do
+        observed <- timeout 1000000 (takeMVar sent)
+        observed `shouldBe` Just ()
+      reply = putMVar replies
+  return (BlockingConnected sent replies, awaitSend, reply)
 
 -- | Encode a RespData to strict ByteString (for feeding to mock recv).
 encodeResp :: RespData -> ByteString
@@ -225,6 +254,114 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
       Left (e :: SomeException) -> show e `shouldContain` "MultiplexerDead"
       Right _ -> expectationFailure "Expected MultiplexerDead exception"
 
+  it "destroy wakes a sent but unanswered submitter" $ do
+    (client, awaitSend, _) <- createBlockingClient
+    mux <- createMultiplexer client (receive client)
+    resultVar <- newEmptyMVar
+
+    _ <- forkIO $ do
+      result <- try $ submitCommand mux (encodeCmd ["GET", "blocked"])
+      putMVar resultVar result
+
+    awaitSend
+    destroyMultiplexer mux
+    result <- timeout 1000000 (takeMVar resultVar)
+    result `shouldSatisfy` isTimedMultiplexerDead
+
+  it "destroy wakes pending and queued submitters" $ do
+    pool <- createSlotPool 16
+    (client, awaitSend, _) <- createBlockingClient
+    mux <- createMultiplexer client (receive client)
+    firstResult <- newEmptyMVar
+
+    _ <- forkIO $ do
+      result <- try $ submitCommandPooled pool mux (encodeCmd ["GET", "pending"])
+      putMVar firstResult result
+
+    awaitSend
+    queuedResults <- replicateM 8 newEmptyMVar
+    mapM_ (\(idx, resultVar) -> do
+      _ <- forkIO $ do
+        result <- try $ submitCommandPooled pool mux
+          (encodeCmd ["GET", LBS.toStrict $ Builder.toLazyByteString $ Builder.intDec idx])
+        putMVar resultVar result
+      return ()
+      ) (zip [1 :: Int ..] queuedResults)
+
+    threadDelay 10000
+    destroyMultiplexer mux
+    results <- timeout 1000000 $
+      mapM takeMVar (firstResult : queuedResults)
+    results `shouldSatisfy` \case
+      Just completed -> all isMultiplexerDead completed
+      Nothing        -> False
+
+  it "concurrent destroy calls are idempotent and wake the waiter once" $ do
+    pool <- createSlotPool 16
+    (client, awaitSend, _) <- createBlockingClient
+    mux <- createMultiplexer client (receive client)
+    resultVar <- newEmptyMVar
+
+    _ <- forkIO $ do
+      result <- try $ submitCommandPooled pool mux (encodeCmd ["GET", "blocked"])
+      putMVar resultVar result
+
+    awaitSend
+    destroyDone <- replicateM 8 newEmptyMVar
+    mapM_ (\done -> do
+      _ <- forkIO $ destroyMultiplexer mux >> putMVar done ()
+      return ()
+      ) destroyDone
+
+    destroysCompleted <- timeout 1000000 $ mapM_ takeMVar destroyDone
+    destroysCompleted `shouldBe` Just ()
+    result <- timeout 1000000 (takeMVar resultVar)
+    result `shouldSatisfy` isTimedMultiplexerDead
+
+    replicateM_ 3 (destroyMultiplexer mux)
+
+    -- Reusing the same pool concurrently would hang if teardown had returned
+    -- the same ResponseSlot more than once.
+    (reuseClient, addRecv) <- createMockClient
+    reuseMux <- createMultiplexer reuseClient (receive reuseClient)
+    reuseResults <- replicateM 2 newEmptyMVar
+    mapM_ (\reuseResultVar -> do
+      _ <- forkIO $ do
+        reuseResult <- try (submitCommandPooled pool reuseMux (encodeCmd ["PING"]))
+          :: IO (Either SomeException RespData)
+        putMVar reuseResultVar reuseResult
+      return ()
+      ) reuseResults
+    threadDelay 10000
+    addRecv $ encodeResp (RespSimpleString "OK") <> encodeResp (RespSimpleString "OK")
+    reused <- timeout 1000000 $ mapM takeMVar reuseResults
+    reused `shouldSatisfy` \case
+      Just completed -> all isOkResponse completed
+      Nothing        -> False
+    destroyMultiplexer reuseMux
+
+  it "worker failure racing destroy completes every waiter" $ do
+    pool <- createSlotPool 16
+    (client, awaitSend, reply) <- createBlockingClient
+    mux <- createMultiplexer client (receive client)
+    resultVars <- replicateM 4 newEmptyMVar
+
+    mapM_ (\resultVar -> do
+      _ <- forkIO $ do
+        result <- try $ submitCommandPooled pool mux (encodeCmd ["GET", "race"])
+        putMVar resultVar result
+      return ()
+      ) resultVars
+
+    awaitSend
+    _ <- forkIO $ reply "not-resp"
+    destroyMultiplexer mux
+
+    results <- timeout 1000000 $ mapM takeMVar resultVars
+    results `shouldSatisfy` \case
+      Just completed -> all isMultiplexerFailure completed
+      Nothing        -> False
+
   it "handles multiple sequential commands correctly" $ do
     (client, addRecv) <- createMockClient
     mux <- createMultiplexer client (receive client)
@@ -280,3 +417,29 @@ isMultiplexerAliveSpec = describe "isMultiplexerAlive" $ do
     threadDelay 10000
     alive <- isMultiplexerAlive mux
     alive `shouldBe` False
+
+isTimedMultiplexerDead
+  :: Maybe (Either SomeException RespData)
+  -> Bool
+isTimedMultiplexerDead (Just result) = isMultiplexerDead result
+isTimedMultiplexerDead Nothing       = False
+
+isMultiplexerDead :: Either SomeException RespData -> Bool
+isMultiplexerDead (Left e) =
+  case fromException e of
+    Just (MultiplexerDead _) -> True
+    _                        -> False
+isMultiplexerDead (Right _) = False
+
+isMultiplexerFailure :: Either SomeException RespData -> Bool
+isMultiplexerFailure (Left e) =
+  case fromException e of
+    Just (MultiplexerDead _)         -> True
+    Just (MultiplexerParseError _)   -> True
+    Just MultiplexerConnectionClosed -> True
+    Nothing                          -> False
+isMultiplexerFailure (Right _) = False
+
+isOkResponse :: Either SomeException RespData -> Bool
+isOkResponse (Right (RespSimpleString "OK")) = True
+isOkResponse _                               = False

--- a/hask-redis-mux/test/MultiplexerSpec.hs
+++ b/hask-redis-mux/test/MultiplexerSpec.hs
@@ -5,12 +5,15 @@
 
 module Main (main) where
 
-import           Control.Concurrent                  (forkIO, threadDelay)
+import           Control.Concurrent                  (forkFinally, forkIO,
+                                                      forkOn, killThread,
+                                                      threadDelay)
 import           Control.Concurrent.MVar             (MVar, newEmptyMVar,
                                                       putMVar, takeMVar,
                                                       tryPutMVar)
 import           Control.Exception                   (SomeException,
-                                                      fromException, try)
+                                                      fromException, throwIO,
+                                                      try, uninterruptibleMask_)
 import           Control.Monad                       (replicateM, replicateM_,
                                                       void)
 import           Control.Monad.IO.Class              (liftIO)
@@ -93,6 +96,65 @@ createBlockingClient = do
         observed `shouldBe` Just ()
       reply = putMVar replies
   return (BlockingConnected sent replies, awaitSend, reply)
+
+-- | Transport with a reader-owned first slot, a pending second slot whose send
+-- is uninterruptibly gated, and a blocked writer that leaves later submissions
+-- queued. It exposes deterministic lifecycle barriers for teardown tests.
+data TeardownClient (a :: ConnectionStatus) where
+  TeardownConnected
+    :: !(IORef Int)
+    -> !(MVar ())
+    -> !(MVar ())
+    -> !(MVar ())
+    -> !(MVar ())
+    -> !(MVar ByteString)
+    -> TeardownClient 'Connected
+
+instance Client TeardownClient where
+  connect = error "TeardownClient: connect not supported"
+  close _ = return ()
+  send (TeardownConnected sendCount firstSent secondStarted releaseSecond _ _) _ =
+    liftIO $ do
+      sendNumber <- atomicModifyIORef' sendCount $ \count ->
+        let next = count + 1
+        in (next, next)
+      case sendNumber of
+        1 -> void $ tryPutMVar firstSent ()
+        2 -> do
+          void $ tryPutMVar secondStarted ()
+          uninterruptibleMask_ $ takeMVar releaseSecond
+        _ -> return ()
+  receive (TeardownConnected _ _ _ _ receiveStarted replies) =
+    liftIO $ do
+      void $ tryPutMVar receiveStarted ()
+      takeMVar replies
+
+createTeardownClient
+  :: IO
+       ( TeardownClient 'Connected
+       , IO ()
+       , IO ()
+       , IO ()
+       , IO ()
+       )
+createTeardownClient = do
+  sendCount <- newIORef 0
+  firstSent <- newEmptyMVar
+  secondStarted <- newEmptyMVar
+  releaseSecond <- newEmptyMVar
+  receiveStarted <- newEmptyMVar
+  replies <- newEmptyMVar
+  let await barrier = do
+        observed <- timeout 1000000 (takeMVar barrier)
+        observed `shouldBe` Just ()
+  return
+    ( TeardownConnected
+        sendCount firstSent secondStarted releaseSecond receiveStarted replies
+    , await firstSent
+    , await secondStarted
+    , await receiveStarted
+    , putMVar releaseSecond ()
+    )
 
 -- | Encode a RespData to strict ByteString (for feeding to mock recv).
 encodeResp :: RespData -> ByteString
@@ -268,30 +330,43 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
     result <- timeout 1000000 (takeMVar resultVar)
     result `shouldSatisfy` isTimedMultiplexerDead
 
-  it "destroy wakes pending and queued submitters" $ do
+  it "a later destroy resumes cancelled teardown across active, pending, and queued slots" $ do
     pool <- createSlotPool 16
-    (client, awaitSend, _) <- createBlockingClient
+    (client, awaitFirstSend, awaitSecondSend, awaitReceive, releaseSecondSend) <-
+      createTeardownClient
     mux <- createMultiplexer client (receive client)
-    firstResult <- newEmptyMVar
+    firstSlot <- submitCommandAsync pool mux (encodeCmd ["GET", "reader-owned"])
+    firstResult <- waitForSlotInThread pool firstSlot
+    awaitFirstSend
+    awaitReceive
 
-    _ <- forkIO $ do
-      result <- try $ submitCommandPooled pool mux (encodeCmd ["GET", "pending"])
-      putMVar firstResult result
+    secondSlot <- submitCommandAsync pool mux (encodeCmd ["GET", "pending"])
+    secondResult <- waitForSlotInThread pool secondSlot
+    awaitSecondSend
 
-    awaitSend
-    queuedResults <- replicateM 8 newEmptyMVar
-    mapM_ (\(idx, resultVar) -> do
-      _ <- forkIO $ do
-        result <- try $ submitCommandPooled pool mux
-          (encodeCmd ["GET", LBS.toStrict $ Builder.toLazyByteString $ Builder.intDec idx])
-        putMVar resultVar result
-      return ()
-      ) (zip [1 :: Int ..] queuedResults)
+    queuedSlots <- mapM
+      (\idx -> submitCommandAsync pool mux
+        (encodeCmd ["GET", LBS.toStrict $ Builder.toLazyByteString $ Builder.intDec idx]))
+      [1 :: Int .. 6]
+    queuedResults <- mapM (waitForSlotInThread pool) queuedSlots
 
-    threadDelay 10000
-    destroyMultiplexer mux
+    ownerFinished <- newEmptyMVar
+    owner <- forkFinally (destroyMultiplexer mux) (putMVar ownerFinished)
+    closureStarted <- timeout 1000000 (waitUntilTeardownStarted mux)
+    closureStarted `shouldBe` Just ()
+
+    killThread owner
+    cancelledOwner <- timeout 1000000 (takeMVar ownerFinished)
+    cancelledOwner `shouldSatisfy` \case
+      Just (Left _) -> True
+      _             -> False
+
+    releaseSecondSend
+    resumedDestroy <- timeout 1000000 (destroyMultiplexer mux)
+    resumedDestroy `shouldBe` Just ()
+
     results <- timeout 1000000 $
-      mapM takeMVar (firstResult : queuedResults)
+      mapM takeMVar (firstResult : secondResult : queuedResults)
     results `shouldSatisfy` \case
       Just completed -> all isMultiplexerDead completed
       Nothing        -> False
@@ -340,27 +415,53 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
       Nothing        -> False
     destroyMultiplexer reuseMux
 
-  it "worker failure racing destroy completes every waiter" $ do
-    pool <- createSlotPool 16
-    (client, awaitSend, reply) <- createBlockingClient
-    mux <- createMultiplexer client (receive client)
-    resultVars <- replicateM 4 newEmptyMVar
+  it "returns the destroyed pooled slot exactly once for deterministic reuse" $
+    runOnCapabilityZero $ do
+      pool <- createSlotPool 1
+      (client, awaitSend, _) <- createBlockingClient
+      mux <- createMultiplexer client (receive client)
+      destroyedSlot <- submitCommandAsync pool mux (encodeCmd ["GET", "blocked"])
 
-    mapM_ (\resultVar -> do
-      _ <- forkIO $ do
-        result <- try $ submitCommandPooled pool mux (encodeCmd ["GET", "race"])
-        putMVar resultVar result
-      return ()
-      ) resultVars
+      awaitSend
+      destroyMultiplexer mux
+      destroyedResult <- try (waitSlot pool destroyedSlot)
+        :: IO (Either SomeException RespData)
+      destroyedResult `shouldSatisfy` isMultiplexerDead
 
-    awaitSend
-    _ <- forkIO $ reply "not-resp"
-    destroyMultiplexer mux
+      (reuseClient, addRecv) <- createMockClient
+      reuseMux <- createMultiplexer reuseClient (receive reuseClient)
+      reusedSlot <- submitCommandAsync pool reuseMux (encodeCmd ["PING"])
+      sameResponseSlot destroyedSlot reusedSlot `shouldBe` True
 
-    results <- timeout 1000000 $ mapM takeMVar resultVars
-    results `shouldSatisfy` \case
-      Just completed -> all isMultiplexerFailure completed
-      Nothing        -> False
+      premature <- timeout 50000 (waitSlot pool reusedSlot)
+      premature `shouldBe` Nothing
+      addRecv $ encodeResp (RespSimpleString "OK")
+      completed <- timeout 1000000 (waitSlot pool reusedSlot)
+      completed `shouldBe` Just (RespSimpleString "OK")
+      destroyMultiplexer reuseMux
+
+  it "worker failure racing destroy completes every waiter across 50 repetitions" $
+    replicateM_ 50 $ do
+      pool <- createSlotPool 16
+      (client, awaitSend, reply) <- createBlockingClient
+      mux <- createMultiplexer client (receive client)
+      resultVars <- replicateM 4 newEmptyMVar
+
+      mapM_ (\resultVar -> do
+        _ <- forkIO $ do
+          result <- try $ submitCommandPooled pool mux (encodeCmd ["GET", "race"])
+          putMVar resultVar result
+        return ()
+        ) resultVars
+
+      awaitSend
+      _ <- forkIO $ reply "not-resp"
+      destroyMultiplexer mux
+
+      results <- timeout 1000000 $ mapM takeMVar resultVars
+      results `shouldSatisfy` \case
+        Just completed -> all isMultiplexerFailure completed
+        Nothing        -> False
 
   it "handles multiple sequential commands correctly" $ do
     (client, addRecv) <- createMockClient
@@ -417,6 +518,36 @@ isMultiplexerAliveSpec = describe "isMultiplexerAlive" $ do
     threadDelay 10000
     alive <- isMultiplexerAlive mux
     alive `shouldBe` False
+
+waitForSlotInThread
+  :: SlotPool
+  -> ResponseSlot
+  -> IO (MVar (Either SomeException RespData))
+waitForSlotInThread pool slot = do
+  resultVar <- newEmptyMVar
+  _ <- forkIO $ do
+    result <- try $ waitSlot pool slot
+    putMVar resultVar result
+  return resultVar
+
+waitUntilTeardownStarted :: Multiplexer -> IO ()
+waitUntilTeardownStarted mux = do
+  alive <- isMultiplexerAlive mux
+  if alive
+    then threadDelay 1000 >> waitUntilTeardownStarted mux
+    else return ()
+
+runOnCapabilityZero :: IO () -> IO ()
+runOnCapabilityZero action = do
+  resultVar <- newEmptyMVar
+  _ <- forkOn 0 $ do
+    result <- try action
+    putMVar resultVar result
+  outcome <- timeout 3000000 (takeMVar resultVar)
+  case outcome of
+    Nothing         -> expectationFailure "pinned slot reuse test timed out"
+    Just (Left err) -> throwIO (err :: SomeException)
+    Just (Right ()) -> return ()
 
 isTimedMultiplexerDead
   :: Maybe (Either SomeException RespData)


### PR DESCRIPTION
## Summary
- close command admission atomically before multiplexer teardown
- track writer-owned and reader-owned response slots across queue transitions
- complete each response slot with a first-writer-wins atomic transition
- make concurrent destroy calls idempotent and wait for worker termination
- add deterministic blocked-transport coverage for queued and sent-but-unanswered requests

Closes #47

## Lifecycle invariants
- A command is tracked in the command queue's queued/active state or the pending queue's queued/active state until completion.
- Writer handoff from active commands to pending responses is masked and serialized against worker failure cleanup.
- Closing command admission is atomic with enqueue, so submissions cannot enter after teardown drains begin.
- Slot completion changes `Nothing` to one result atomically and signals only the winning transition.
- `forkFinally` installs worker completion reporting before worker actions can be killed.
- `destroyMultiplexer` is serialized; later destroy calls wait for the first teardown and do not drain or release slots again.

## Performance profile
Comparable `MultiplexerSpec` original 14-test workload with `+RTS -p`:

| Metric | Before | After |
|---|---:|---:|
| Sampled time | 0.02s | 0.02s |
| Total allocation | 4,452,512 B | 4,826,112 B |
| Approx. `createMultiplexer` allocation | 1.229 MB | 1.264 MB |

The total test-process increase is 8.4%; the lifecycle-heavy mux creation cost increased about 2.9% from the additional queue state, locks, and worker completion signals. The writer still performs one queue CAS per submission and batches commands as before; the new transfer lock is taken once per writer batch, not once per producer submission.

## Tests
- Focused `MultiplexerSpec`: 18 examples
- Deterministic blocked response after writer send
- Mixed pending and queued requests during destroy
- Concurrent destroy calls plus pooled-slot reuse
- Worker parse failure racing destroy
- 50 randomized full focused-suite repetitions
- `nix-build --no-out-link`
- `make test-unit`

## CI gate
Local full E2E was intentionally not run per repository policy. The required GitHub Actions `build` check is the authoritative full E2E gate.

## Required review
- [ ] Protocol review: typed failure and response-order lifecycle invariants
- [ ] Tester review: deterministic race coverage and bounded waiter completion

Do not merge until both Protocol and Tester reviews are complete.
