### PR TITLE
Make client and pool shutdown terminal

### DIFF
--- a/hask-redis-mux/README.md
+++ b/hask-redis-mux/README.md
@@ -72,6 +72,12 @@ withClusterClient clusterConfig connector $ \client ->
     get "key"
 ```
 
+The callback owns the client only for its duration. When it returns or throws,
+the library permanently closes every plaintext or TLS transport acquired by
+that client. Teardown is idempotent and each transport finalizer runs exactly
+once. A client or pool must not be reused after bracket exit or explicit close:
+later submissions return a typed closed-client/pool failure and never reconnect.
+
 ## Custom Configuration
 
 ```haskell

--- a/hask-redis-mux/hask-redis-mux.cabal
+++ b/hask-redis-mux/hask-redis-mux.cabal
@@ -199,6 +199,15 @@ test-suite MultiplexerSpec
                     , cluster
                     , resp
 
+test-suite StandaloneSpec
+    import:           test-defaults
+    type:             exitcode-stdio-1.0
+    main-is:          StandaloneSpec.hs
+    build-depends:    bytestring >=0.12 && <0.13
+                    , client
+                    , cluster
+                    , redis-command-client
+
 test-suite FromRespSpec
     import:           test-defaults
     type:             exitcode-stdio-1.0

--- a/hask-redis-mux/lib/client/Database/Redis/Client.hs
+++ b/hask-redis-mux/lib/client/Database/Redis/Client.hs
@@ -19,7 +19,7 @@ module Database.Redis.Client
   ) where
 
 import           Control.Exception               (IOException, bracket, catch,
-                                                  finally, throwIO)
+                                                  finally, onException, throwIO)
 import           Control.Monad                   (void)
 import           Control.Monad.IO.Class
 import qualified Data.ByteString                 as BS
@@ -87,11 +87,12 @@ instance Client PlainTextClient where
   connect :: (MonadIO m) => PlainTextClient 'NotConnected -> m (PlainTextClient 'Connected)
   connect (NotConnectedPlainTextClient hostname port) = liftIO $ do
     (sock, ipCorrectEndian) <- createSocket hostname (maybe 6379 fromIntegral port)
-    S.connect sock (SockAddrInet (maybe 6379 fromIntegral port) ipCorrectEndian) `catch` \(e :: IOException) -> do
-      printf "Wasn't able to connect to the server: %s...\n" (show e)
-      putStrLn "Tried to use a plain text socket on port 6379. Did you mean to use TLS on port 6380?"
-      throwIO e
-    return $ ConnectedPlainTextClient hostname ipCorrectEndian sock
+    flip onException (S.close sock) $ do
+      S.connect sock (SockAddrInet (maybe 6379 fromIntegral port) ipCorrectEndian) `catch` \(e :: IOException) -> do
+        printf "Wasn't able to connect to the server: %s...\n" (show e)
+        putStrLn "Tried to use a plain text socket on port 6379. Did you mean to use TLS on port 6380?"
+        throwIO e
+      return $ ConnectedPlainTextClient hostname ipCorrectEndian sock
 
   close :: (MonadIO m) => PlainTextClient 'Connected -> m ()
   close (ConnectedPlainTextClient _ _ sock) = liftIO $ S.close sock
@@ -161,27 +162,28 @@ connectTLS certHostname targetAddress port = liftIO $ do
         ++ ". The server identity will not be verified."
     else pure ()
   (sock, ipCorrectEndian) <- createSocket targetAddress (maybe 6380 fromIntegral port)
-  S.connect sock (SockAddrInet (maybe 6380 fromIntegral port) ipCorrectEndian)
-  store <- getSystemCertificateStore
-  let baseParams =
-        (defaultParamsClient certHostname "redis-server")
-          { clientSupported =
-              def
-                { supportedVersions = [TLS13, TLS12],
-                  supportedCiphers = ciphersuite_strong
-                },
-            clientShared =
-              def
-                { sharedCAStore = store
-                }
-          }
-      clientParams =
-        if allowInsecure
-          then baseParams {clientHooks = def {onServerCertificate = \_ _ _ _ -> pure []}}
-          else baseParams
-  context <- contextNew sock clientParams
-  handshake context
-  return $ ConnectedTLSClient certHostname ipCorrectEndian sock context
+  flip onException (S.close sock) $ do
+    S.connect sock (SockAddrInet (maybe 6380 fromIntegral port) ipCorrectEndian)
+    store <- getSystemCertificateStore
+    let baseParams =
+          (defaultParamsClient certHostname "redis-server")
+            { clientSupported =
+                def
+                  { supportedVersions = [TLS13, TLS12],
+                    supportedCiphers = ciphersuite_strong
+                  },
+              clientShared =
+                def
+                  { sharedCAStore = store
+                  }
+            }
+        clientParams =
+          if allowInsecure
+            then baseParams {clientHooks = def {onServerCertificate = \_ _ _ _ -> pure []}}
+            else baseParams
+    context <- contextNew sock clientParams
+    handshake context
+    return $ ConnectedTLSClient certHostname ipCorrectEndian sock context
 
 -- | Start a local TCP proxy on @localhost:6379@ that forwards traffic through an
 -- existing TLS connection. Useful for tunneling plain-text Redis tools over TLS.

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
@@ -42,6 +42,7 @@ module Database.Redis.Cluster.Client
     ClusterConfig (..),
     -- * Client Lifecycle
     createClusterClient,
+    createClusterClientWithFactories,
     closeClusterClient,
     withClusterClient,
     refreshTopology,
@@ -69,7 +70,9 @@ import           Control.Concurrent.STM                (TVar, atomically,
                                                         newTVarIO, readTVarIO,
                                                         writeTVar)
 import           Control.Exception                     (SomeException, bracket,
-                                                        finally, throwIO, try)
+                                                        finally, fromException,
+                                                        onException, throwIO,
+                                                        try)
 import           Control.Monad                         (when)
 import           Control.Monad.IO.Class                (MonadIO (..))
 import qualified Control.Monad.State                   as State
@@ -91,6 +94,7 @@ import           Database.Redis.Cluster                (ClusterNode (..),
                                                         findNodeAddressForSlot,
                                                         parseClusterSlots)
 import           Database.Redis.Cluster.ConnectionPool (ConnectionPool,
+                                                        ConnectionPoolException (..),
                                                         PoolConfig (..),
                                                         closePool, createPool,
                                                         withConnection)
@@ -110,6 +114,7 @@ import qualified Database.Redis.Command                as RedisCommandClient
 import           Database.Redis.Connector              (Connector)
 import           Database.Redis.FromResp               (FromResp (..))
 import           Database.Redis.Internal.MultiplexPool (MultiplexPool,
+                                                        MultiplexPoolException (..),
                                                         closeMultiplexPool,
                                                         createMultiplexPool,
                                                         submitToNode,
@@ -126,6 +131,7 @@ data ClusterError
   | MaxRetriesExceeded String -- ^ All retry attempts exhausted.
   | TopologyError String -- ^ Slot or node lookup failed (e.g., empty topology).
   | ConnectionError String -- ^ Network-level failure connecting to a node.
+  | ClusterClientClosed -- ^ The client has been terminally closed.
   deriving (Show, Eq)
 
 -- | Redirection information parsed from errors
@@ -227,36 +233,52 @@ createClusterClient ::
   Connector client ->
   IO (ClusterClient client)
 createClusterClient config connector = do
-  pool <- createPool (clusterPoolConfig config)
+  createClusterClientWithFactories createPool createMultiplexPool config connector
 
+-- | Internal construction seam for deterministic failure-injection tests.
+createClusterClientWithFactories
+  :: (Client client)
+  => (PoolConfig -> IO (ConnectionPool client))
+  -> (Connector client -> Int -> IO (MultiplexPool client))
+  -> ClusterConfig
+  -> Connector client
+  -> IO (ClusterClient client)
+createClusterClientWithFactories createConnectionPool createMuxPool config connector = do
+  pool <- createConnectionPool (clusterPoolConfig config)
+  build pool `onException` closePool pool
+  where
+    build pool = do
   -- Discover initial topology before creating TVar
-  let seedNode = clusterSeedNode config
-  response <- withConnection pool seedNode connector $ \conn -> do
-    let clientState = ClientState conn BS8.empty
-    State.evalStateT (runRedisCommandClient clusterSlots) clientState
+      let seedNode = clusterSeedNode config
+      response <- withConnection pool seedNode connector $ \conn -> do
+        let clientState = ClientState conn BS8.empty
+        State.evalStateT (runRedisCommandClient clusterSlots) clientState
 
-  currentTime <- getCurrentTime
-  case parseClusterSlots response currentTime of
-    Left err -> throwIO $ userError $ "Failed to parse cluster topology: " <> err
-    Right initialTopology -> do
-      topology <- newTVarIO initialTopology
-      refreshLock <- newMVar ()
-      muxPool <- createMultiplexPool connector 1
-      return $ ClusterClient topology pool config connector refreshLock muxPool
+      currentTime <- getCurrentTime
+      case parseClusterSlots response currentTime of
+        Left err -> throwIO $ userError $ "Failed to parse cluster topology: " <> err
+        Right initialTopology -> do
+          topology <- newTVarIO initialTopology
+          refreshLock <- newMVar ()
+          muxPool <- createMuxPool connector 1
+          return $ ClusterClient topology pool config connector refreshLock muxPool
 
 -- | Close all pooled connections across every node.
+-- Closure is terminal and idempotent: owned transports are closed exactly once,
+-- and later commands return 'ClusterClientClosed' without reconnecting.
 --
 -- Consider using 'withClusterClient' instead for automatic cleanup.
 closeClusterClient :: (Client client) => ClusterClient client -> IO ()
 closeClusterClient client = do
-  closePool (clusterConnectionPool client)
   closeMultiplexPool (clusterMultiplexPool client)
+  closePool (clusterConnectionPool client)
 
 -- | Bracket-style resource management for cluster clients.
 --
 -- Creates a client, runs the given action, and ensures the client is closed
 -- even if an exception occurs. Prefer this over manual 'createClusterClient'
--- and 'closeClusterClient'.
+-- and 'closeClusterClient'. After the callback returns, both backing pools are
+-- permanently closed.
 --
 -- @
 -- withClusterClient config connector $ \\client ->
@@ -353,7 +375,10 @@ executeOnNode client nodeAddr action connector = do
     State.evalStateT (runRedisCommandClient action) clientState
 
   case result of
-    Left (e :: SomeException) -> return $ Left $ ConnectionError $ show e
+    Left (e :: SomeException)
+      | Just ConnectionPoolClosed <- fromException e ->
+          return $ Left ClusterClientClosed
+      | otherwise -> return $ Left $ ConnectionError $ show e
     Right value               -> return $ Right value
 
 -- | Execute a command that does not target a specific key (e.g., PING, AUTH, FLUSHALL).
@@ -513,7 +538,10 @@ executeOnSlotMux client muxPool slot cmdBuilder = do
     Just addr -> do
       result <- try $ submitToNode muxPool addr cmdBuilder
       case result of
-        Left (e :: SomeException) -> return $ Left $ ConnectionError $ show e
+        Left (e :: SomeException)
+          | Just MultiplexPoolClosed <- fromException e ->
+              return $ Left ClusterClientClosed
+          | otherwise -> return $ Left $ ConnectionError $ show e
         Right respData -> case detectRedirection respData of
           Just (Left (RedirectionInfo s host port)) ->
             return $ Left $ MovedError s (NodeAddress host port)
@@ -536,7 +564,10 @@ executeOnNodeWithAsking _client muxPool addr cmdBuilder = do
   let askingBuilder = encodeCommandBuilder ["ASKING"]
   result <- try $ submitToNodeWithAsking muxPool addr askingBuilder cmdBuilder
   case result of
-    Left (e :: SomeException) -> return $ Left $ ConnectionError $ show e
+    Left (e :: SomeException)
+      | Just MultiplexPoolClosed <- fromException e ->
+          return $ Left ClusterClientClosed
+      | otherwise -> return $ Left $ ConnectionError $ show e
     Right respData -> case detectRedirection respData of
       Just (Left (RedirectionInfo s host port)) ->
         return $ Left $ MovedError s (NodeAddress host port)

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/ConnectionPool.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/ConnectionPool.hs
@@ -15,6 +15,7 @@
 -- @since 0.1.0.0
 module Database.Redis.Cluster.ConnectionPool
   ( ConnectionPool (..),
+    ConnectionPoolException (..),
     PoolConfig (..),
     createPool,
     withConnection,
@@ -24,14 +25,23 @@ where
 
 import           Control.Concurrent.MVar  (MVar, modifyMVar, newEmptyMVar,
                                            newMVar, putMVar, takeMVar)
-import           Control.Exception        (SomeException, catch, throwIO,
-                                           toException, try)
+import           Control.Exception        (Exception, SomeException, catch,
+                                           mask, throwIO, toException, try)
 import           Control.Monad            (forM_)
+import           Data.IORef               (IORef, newIORef, readIORef,
+                                           writeIORef)
 import           Data.Map.Strict          (Map)
 import qualified Data.Map.Strict          as Map
+import           Data.Typeable            (Typeable)
 import           Database.Redis.Client    (Client (..), ConnectionStatus (..))
 import           Database.Redis.Cluster   (NodeAddress (..))
 import           Database.Redis.Connector (Connector)
+
+-- | Exception thrown when a terminally closed connection pool is used.
+data ConnectionPoolException = ConnectionPoolClosed
+  deriving (Eq, Show, Typeable)
+
+instance Exception ConnectionPoolException
 
 -- | Configuration for the connection pool.
 data PoolConfig = PoolConfig
@@ -57,6 +67,7 @@ data NodePool client = NodePool
 -- is returned.
 data ConnectionPool client = ConnectionPool
   { poolConnections :: MVar (Map NodeAddress (NodePool client))
+  , poolClosed      :: IORef Bool
   , poolConfig      :: PoolConfig
   }
 
@@ -65,13 +76,15 @@ data ConnectionPool client = ConnectionPool
 createPool :: PoolConfig -> IO (ConnectionPool client)
 createPool config = do
   connections <- newMVar Map.empty
-  return $ ConnectionPool connections config
+  closed <- newIORef False
+  return $ ConnectionPool connections closed config
 
 -- | What to do after acquiring the MVar lock
 data CheckoutResult client
   = UseExisting (client 'Connected)                      -- ^ Reuse an idle connection
   | CreateNew                                             -- ^ Create a new connection (slot reserved)
   | Wait (MVar (Either SomeException (client 'Connected)))  -- ^ Block until a connection is returned
+  | PoolIsClosed
 
 -- | Check out a connection, run an action, and return the connection to the pool.
 -- If the action throws an exception, the connection is discarded (not returned)
@@ -103,38 +116,49 @@ checkoutConnection ::
   NodeAddress ->
   Connector client ->
   IO (client 'Connected)
-checkoutConnection pool addr connector = do
+checkoutConnection pool addr connector = mask $ \restore -> do
   result <- modifyMVar (poolConnections pool) $ \m -> do
-    let nodePool = Map.findWithDefault (NodePool [] 0 []) addr m
-    case availableConns nodePool of
-      (conn : rest) -> do
-        let updated = nodePool { availableConns = rest }
-        return (Map.insert addr updated m, UseExisting conn)
-      [] ->
-        if totalConns nodePool < maxConnectionsPerNode (poolConfig pool)
-          then do
-            -- Reserve a slot, create connection outside the lock
-            let updated = nodePool { totalConns = totalConns nodePool + 1 }
-            return (Map.insert addr updated m, CreateNew)
-          else do
-            -- At capacity — enqueue a waiter
-            waiter <- newEmptyMVar
-            let updated = nodePool { waitQueue = waitQueue nodePool ++ [waiter] }
-            return (Map.insert addr updated m, Wait waiter)
+    closed <- readIORef (poolClosed pool)
+    if closed
+      then return (m, PoolIsClosed)
+      else do
+        let nodePool = Map.findWithDefault (NodePool [] 0 []) addr m
+        case availableConns nodePool of
+          (conn : rest) -> do
+            let updated = nodePool { availableConns = rest }
+            return (Map.insert addr updated m, UseExisting conn)
+          [] ->
+            if totalConns nodePool < maxConnectionsPerNode (poolConfig pool)
+              then do
+                let updated = nodePool { totalConns = totalConns nodePool + 1 }
+                return (Map.insert addr updated m, CreateNew)
+              else do
+                waiter <- newEmptyMVar
+                let updated = nodePool { waitQueue = waitQueue nodePool ++ [waiter] }
+                return (Map.insert addr updated m, Wait waiter)
   case result of
+    PoolIsClosed -> throwIO ConnectionPoolClosed
     UseExisting conn -> return conn
     CreateNew -> do
       -- Create connection outside the MVar lock
-      connResult <- try (connector addr)
+      connResult <- try (restore $ connector addr)
       case connResult of
-        Right conn -> return conn
+        Right conn -> do
+          accepted <- modifyMVar (poolConnections pool) $ \m -> do
+            closed <- readIORef (poolClosed pool)
+            return (m, not closed)
+          if accepted
+            then return conn
+            else do
+              close conn `catch` \(_ :: SomeException) -> return ()
+              throwIO ConnectionPoolClosed
         Left (e :: SomeException) -> do
           -- Creation failed — release the reserved slot
           modifyMVar (poolConnections pool) $ \m -> do
             let m' = Map.adjust (\np -> np { totalConns = totalConns np - 1 }) addr m
             return (m', ())
           throwIO e
-    Wait waiter -> takeMVar waiter >>= either throwIO return
+    Wait waiter -> restore (takeMVar waiter) >>= either throwIO return
 
 -- | Return a connection to the pool for reuse.
 -- If threads are waiting, hand the connection directly to the next waiter.
@@ -145,24 +169,30 @@ returnConnection ::
   client 'Connected ->
   IO ()
 returnConnection pool addr conn =
-  modifyMVar (poolConnections pool) $ \m -> do
-    let nodePool = Map.findWithDefault (NodePool [] 0 []) addr m
-    case waitQueue nodePool of
-      (waiter : rest) -> do
-        -- Hand connection directly to a waiting thread
-        putMVar waiter (Right conn)
-        let updated = nodePool { waitQueue = rest }
-        return (Map.insert addr updated m, ())
-      [] ->
-        if length (availableConns nodePool) < maxConnectionsPerNode (poolConfig pool)
-          then do
-            let updated = nodePool { availableConns = conn : availableConns nodePool }
-            return (Map.insert addr updated m, ())
-          else do
-            -- Shouldn't happen, but close just in case
-            close conn `catch` \(_ :: SomeException) -> return ()
-            let updated = nodePool { totalConns = totalConns nodePool - 1 }
-            return (Map.insert addr updated m, ())
+  do
+    closeReturned <- modifyMVar (poolConnections pool) $ \m -> do
+      closed <- readIORef (poolClosed pool)
+      if closed
+        then return (m, True)
+        else do
+          let nodePool = Map.findWithDefault (NodePool [] 0 []) addr m
+          case waitQueue nodePool of
+            (waiter : rest) -> do
+              putMVar waiter (Right conn)
+              let updated = nodePool { waitQueue = rest }
+              return (Map.insert addr updated m, False)
+            [] ->
+              if length (availableConns nodePool) < maxConnectionsPerNode (poolConfig pool)
+                then do
+                  let updated = nodePool { availableConns = conn : availableConns nodePool }
+                  return (Map.insert addr updated m, False)
+                else do
+                  let updated = nodePool { totalConns = totalConns nodePool - 1 }
+                  return (Map.insert addr updated m, True)
+    whenClose closeReturned
+  where
+    whenClose True  = close conn `catch` \(_ :: SomeException) -> return ()
+    whenClose False = return ()
 
 -- | Discard a connection (on error) and wake a waiter or release the slot.
 -- If threads are waiting, attempts to create a replacement connection.
@@ -177,23 +207,33 @@ discardConnection ::
 discardConnection pool addr conn connector = do
   close conn `catch` \(_ :: SomeException) -> return ()
   maybeWaiter <- modifyMVar (poolConnections pool) $ \m -> do
-    let nodePool = Map.findWithDefault (NodePool [] 0 []) addr m
-    case waitQueue nodePool of
-      (waiter : rest) -> do
-        -- Keep slot reserved for the waiter (don't decrement totalConns)
-        let updated = nodePool { waitQueue = rest }
-        return (Map.insert addr updated m, Just waiter)
-      [] -> do
-        -- No waiters, just release the slot
-        let updated = nodePool { totalConns = totalConns nodePool - 1 }
-        return (Map.insert addr updated m, Nothing)
+    closed <- readIORef (poolClosed pool)
+    if closed
+      then return (m, Nothing)
+      else do
+        let nodePool = Map.findWithDefault (NodePool [] 0 []) addr m
+        case waitQueue nodePool of
+          (waiter : rest) -> do
+            let updated = nodePool { waitQueue = rest }
+            return (Map.insert addr updated m, Just waiter)
+          [] -> do
+            let updated = nodePool { totalConns = totalConns nodePool - 1 }
+            return (Map.insert addr updated m, Nothing)
   case maybeWaiter of
     Nothing -> return ()
-    Just waiter -> do
+    Just waiter -> mask $ \restore -> do
       -- Try to create a replacement connection for the waiter
-      connResult <- try (connector addr)
+      connResult <- try (restore $ connector addr)
       case connResult of
-        Right newConn -> putMVar waiter (Right newConn)
+        Right newConn -> do
+          accepted <- modifyMVar (poolConnections pool) $ \m -> do
+            closed <- readIORef (poolClosed pool)
+            return (m, not closed)
+          if accepted
+            then putMVar waiter (Right newConn)
+            else do
+              close newConn `catch` \(_ :: SomeException) -> return ()
+              putMVar waiter (Left $ toException ConnectionPoolClosed)
         Left (e :: SomeException) -> do
           -- Failed — release the reserved slot and notify waiter of the error
           modifyMVar (poolConnections pool) $ \m -> do
@@ -202,15 +242,22 @@ discardConnection pool addr conn connector = do
           putMVar waiter (Left e)
 
 -- | Close all connections in the pool and wake any blocked waiters.
--- Exceptions during close are caught and ignored.
+-- Closure is terminal and idempotent. Later checkouts throw
+-- 'ConnectionPoolClosed' rather than creating a new connection. Exceptions
+-- during transport close are caught and ignored.
 closePool :: (Client client) => ConnectionPool client -> IO ()
 closePool pool =
-  modifyMVar (poolConnections pool) $ \m -> do
-    let poolClosed = toException (userError "Connection pool closed")
-    forM_ (Map.elems m) $ \nodePool -> do
+  do
+    nodePools <- modifyMVar (poolConnections pool) $ \m -> do
+      alreadyClosed <- readIORef (poolClosed pool)
+      if alreadyClosed
+        then return (m, [])
+        else do
+          writeIORef (poolClosed pool) True
+          return (Map.empty, Map.elems m)
+    let closedError = toException ConnectionPoolClosed
+    forM_ nodePools $ \nodePool -> do
       forM_ (availableConns nodePool) $ \conn ->
         close conn `catch` \(_ :: SomeException) -> return ()
-      -- Wake all blocked waiters with an error
       forM_ (waitQueue nodePool) $ \waiter ->
-        putMVar waiter (Left poolClosed)
-    return (Map.empty, ())
+        putMVar waiter (Left closedError)

--- a/hask-redis-mux/lib/cluster/Database/Redis/Internal/MultiplexPool.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Internal/MultiplexPool.hs
@@ -4,7 +4,8 @@
 -- | Pool of 'Multiplexer's for cluster-mode usage.
 --
 -- Manages one or more multiplexed connections per node, matching the
--- StackExchange.Redis architecture. Automatically reconnects dead multiplexers.
+-- StackExchange.Redis architecture. Automatically reconnects dead multiplexers
+-- until the pool is closed.
 --
 -- @
 -- pool <- createMultiplexPool connector 1
@@ -15,6 +16,7 @@
 -- @since 0.1.0.0
 module Database.Redis.Internal.MultiplexPool
   ( MultiplexPool
+  , MultiplexPoolException (..)
   , createMultiplexPool
   , submitToNode
   , submitToNodeWithAsking
@@ -24,14 +26,15 @@ module Database.Redis.Internal.MultiplexPool
   ) where
 
 import           Control.Concurrent.MVar             (MVar, modifyMVar, newMVar)
-import           Control.Exception                   (SomeException, catch,
-                                                      throwIO)
+import           Control.Exception                   (Exception, SomeException,
+                                                      catch, mask, throwIO, try)
 import qualified Data.ByteString.Builder             as Builder
 import           Data.IORef                          (IORef, atomicModifyIORef',
                                                       atomicWriteIORef,
                                                       newIORef, readIORef)
 import           Data.Map.Strict                     (Map)
 import qualified Data.Map.Strict                     as Map
+import           Data.Typeable                       (Typeable)
 import           Data.Vector                         (Vector)
 import qualified Data.Vector                         as V
 import           Database.Redis.Client               (Client (..))
@@ -49,6 +52,12 @@ import           Database.Redis.Internal.Multiplexer (Multiplexer, ResponseSlot,
                                                       waitSlot)
 import           Database.Redis.Resp                 (RespData)
 
+-- | Exception thrown when a terminally closed multiplexer pool is used.
+data MultiplexPoolException = MultiplexPoolClosed
+  deriving (Eq, Show, Typeable)
+
+instance Exception MultiplexPoolException
+
 -- | Per-node multiplexer group with its own round-robin counter.
 -- Keeping the counter per-node eliminates cross-node CAS contention
 -- on the shared counter that existed before.
@@ -64,6 +73,7 @@ data NodeMuxes = NodeMuxes
 data MultiplexPool client = MultiplexPool
   { poolNodesRef  :: !(IORef (Map NodeAddress NodeMuxes))    -- fast reads
   , poolNodesLock :: !(MVar ())                              -- protects writes
+  , poolClosed    :: !(IORef Bool)                           -- terminal state
   , poolConnector :: !(Connector client)
   , poolSlotPool  :: !SlotPool                               -- reusable ResponseSlots
   , poolMuxCount  :: !Int                                    -- multiplexers per node
@@ -80,8 +90,9 @@ createMultiplexPool
 createMultiplexPool connector muxCnt = do
   nodesRef <- newIORef Map.empty
   nodesLock <- newMVar ()
+  closed <- newIORef False
   slotPool <- createSlotPool 256
-  return $ MultiplexPool nodesRef nodesLock connector slotPool (max 1 muxCnt)
+  return $ MultiplexPool nodesRef nodesLock closed connector slotPool (max 1 muxCnt)
 
 -- | Submit a pre-encoded RESP command (as a Builder) to the multiplexer for a given node.
 -- Creates the multiplexer on demand if the node hasn't been seen before.
@@ -156,10 +167,12 @@ getMultiplexer
   -> NodeAddress
   -> IO Multiplexer
 getMultiplexer pool addr = do
+  ensurePoolOpen pool
   m <- readIORef (poolNodesRef pool)
   case Map.lookup addr m of
     Just nm -> pickMux nm
     Nothing -> modifyMVar (poolNodesLock pool) $ \() -> do
+      ensurePoolOpen pool
       -- Double-check after acquiring lock
       m' <- readIORef (poolNodesRef pool)
       case Map.lookup addr m' of
@@ -190,11 +203,22 @@ createNodeMuxes
   -> Int
   -> IO NodeMuxes
 createNodeMuxes connector addr count = do
-  muxes <- V.generateM count $ \_ -> do
-    conn <- connector addr
-    createMultiplexer conn (receive conn)
-  counter <- newIORef 1
-  return $ NodeMuxes muxes counter
+  muxes <- mask $ \restore -> createAll restore [] count
+  counter <- newIORef 1 `catch` \(e :: SomeException) -> do
+    destroyMuxes muxes
+    throwIO e
+  return $ NodeMuxes (V.fromList $ reverse muxes) counter
+  where
+    createAll _ acc 0 = return acc
+    createAll restore acc remaining = do
+      result <- try $ restore $ do
+        conn <- connector addr
+        createMultiplexer conn (receive conn)
+      case result of
+        Right mux -> createAll restore (mux : acc) (remaining - 1)
+        Left (e :: SomeException) -> do
+          destroyMuxes acc
+          throwIO e
 
 -- | Replace a dead multiplexer for a node.
 replaceMux
@@ -203,22 +227,14 @@ replaceMux
   -> NodeAddress
   -> Multiplexer
   -> IO Multiplexer
-replaceMux pool addr oldMux = do
-  destroyMultiplexer oldMux `catch` \(_ :: SomeException) -> return ()
+replaceMux pool addr _oldMux = do
   modifyMVar (poolNodesLock pool) $ \() -> do
+    ensurePoolOpen pool
     m <- readIORef (poolNodesRef pool)
     case Map.lookup addr m of
       Just nm -> do
-        -- Find and replace the dead mux in the vector
-        newMuxes <- V.mapM (\mux -> do
-          alive <- isMultiplexerAlive mux
-          if alive
-            then return mux
-            else do
-              conn <- (poolConnector pool) addr
-              createMultiplexer conn (receive conn)
-          ) (nmMuxes nm)
-        let nm' = nm { nmMuxes = newMuxes }
+        newMuxes <- replaceDeadMuxes pool addr (V.toList $ nmMuxes nm)
+        let nm' = nm { nmMuxes = V.fromList newMuxes }
         atomicWriteIORef (poolNodesRef pool) (Map.insert addr nm' m)
         -- Return the first alive one
         mux <- pickMux nm'
@@ -228,14 +244,54 @@ replaceMux pool addr oldMux = do
         atomicWriteIORef (poolNodesRef pool) (Map.insert addr nm m)
         return ((), V.head (nmMuxes nm))
 
--- | Tear down all multiplexers across all nodes.
+-- | Tear down all multiplexers and their owned transports across all nodes.
+-- Closure is terminal and idempotent; later submissions throw
+-- 'MultiplexPoolClosed' rather than reconnecting.
 closeMultiplexPool
   :: MultiplexPool client
   -> IO ()
 closeMultiplexPool pool = do
-  modifyMVar (poolNodesLock pool) $ \() -> do
+  muxes <- modifyMVar (poolNodesLock pool) $ \() -> do
+    alreadyClosed <- readIORef (poolClosed pool)
     m <- readIORef (poolNodesRef pool)
-    mapM_ (\nm -> V.mapM_ (\mux -> destroyMultiplexer mux `catch` \(_ :: SomeException) -> return ()) (nmMuxes nm))
-          (Map.elems m)
-    atomicWriteIORef (poolNodesRef pool) Map.empty
-    return ((), ())
+    if alreadyClosed
+      then return ((), [])
+      else do
+        atomicWriteIORef (poolClosed pool) True
+        atomicWriteIORef (poolNodesRef pool) Map.empty
+        return ((), concatMap (V.toList . nmMuxes) $ Map.elems m)
+  destroyMuxes muxes
+
+ensurePoolOpen :: MultiplexPool client -> IO ()
+ensurePoolOpen pool = do
+  closed <- readIORef (poolClosed pool)
+  if closed then throwIO MultiplexPoolClosed else return ()
+
+destroyMuxes :: [Multiplexer] -> IO ()
+destroyMuxes =
+  mapM_ (\mux -> destroyMultiplexer mux `catch` \(_ :: SomeException) -> return ())
+
+replaceDeadMuxes
+  :: (Client client)
+  => MultiplexPool client
+  -> NodeAddress
+  -> [Multiplexer]
+  -> IO [Multiplexer]
+replaceDeadMuxes pool addr muxes =
+  mask $ \restore -> go restore [] [] muxes
+  where
+    go _ kept _ [] = return $ reverse kept
+    go restore kept created (mux:rest) = do
+      alive <- isMultiplexerAlive mux
+      if alive
+        then go restore (mux : kept) created rest
+        else do
+          destroyMultiplexer mux `catch` \(_ :: SomeException) -> return ()
+          result <- try $ restore $ do
+            conn <- poolConnector pool addr
+            createMultiplexer conn (receive conn)
+          case result of
+            Right newMux -> go restore (newMux : kept) (newMux : created) rest
+            Left (e :: SomeException) -> do
+              destroyMuxes created
+              throwIO e

--- a/hask-redis-mux/lib/cluster/Database/Redis/Internal/MultiplexPool.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Internal/MultiplexPool.hs
@@ -18,6 +18,7 @@ module Database.Redis.Internal.MultiplexPool
   ( MultiplexPool
   , MultiplexPoolException (..)
   , createMultiplexPool
+  , createMultiplexPoolWithHandoffHook
   , submitToNode
   , submitToNodeWithAsking
   , submitToNodeAsync
@@ -27,7 +28,8 @@ module Database.Redis.Internal.MultiplexPool
 
 import           Control.Concurrent.MVar             (MVar, modifyMVar, newMVar)
 import           Control.Exception                   (Exception, SomeException,
-                                                      catch, mask, throwIO, try)
+                                                      catch, mask_, throwIO,
+                                                      try)
 import qualified Data.ByteString.Builder             as Builder
 import           Data.IORef                          (IORef, atomicModifyIORef',
                                                       atomicWriteIORef,
@@ -37,12 +39,13 @@ import qualified Data.Map.Strict                     as Map
 import           Data.Typeable                       (Typeable)
 import           Data.Vector                         (Vector)
 import qualified Data.Vector                         as V
-import           Database.Redis.Client               (Client (..))
+import           Database.Redis.Client               (Client,
+                                                      ConnectionStatus (..))
 import           Database.Redis.Cluster              (NodeAddress (..))
 import           Database.Redis.Connector            (Connector)
 import           Database.Redis.Internal.Multiplexer (Multiplexer, ResponseSlot,
                                                       SlotPool,
-                                                      createMultiplexer,
+                                                      createMultiplexerFromConnectorWithHandoffHook,
                                                       createSlotPool,
                                                       destroyMultiplexer,
                                                       isMultiplexerAlive,
@@ -71,12 +74,13 @@ data NodeMuxes = NodeMuxes
 -- with MVar protecting creation/replacement (exclusive writes).
 -- Includes a per-pool SlotPool for ResponseSlot reuse.
 data MultiplexPool client = MultiplexPool
-  { poolNodesRef  :: !(IORef (Map NodeAddress NodeMuxes))    -- fast reads
-  , poolNodesLock :: !(MVar ())                              -- protects writes
-  , poolClosed    :: !(IORef Bool)                           -- terminal state
-  , poolConnector :: !(Connector client)
-  , poolSlotPool  :: !SlotPool                               -- reusable ResponseSlots
-  , poolMuxCount  :: !Int                                    -- multiplexers per node
+  { poolNodesRef    :: !(IORef (Map NodeAddress NodeMuxes))  -- fast reads
+  , poolNodesLock   :: !(MVar ())                            -- protects writes
+  , poolClosed      :: !(IORef Bool)                         -- terminal state
+  , poolConnector   :: !(Connector client)
+  , poolHandoffHook :: !(client 'Connected -> IO ())
+  , poolSlotPool    :: !SlotPool                             -- reusable ResponseSlots
+  , poolMuxCount    :: !Int                                  -- multiplexers per node
   }
 
 -- | Create a new empty multiplexer pool.
@@ -87,12 +91,26 @@ createMultiplexPool
   => Connector client
   -> Int
   -> IO (MultiplexPool client)
-createMultiplexPool connector muxCnt = do
+createMultiplexPool connector muxCnt =
+  createMultiplexPoolWithHandoffHook connector (const $ return ()) muxCnt
+
+-- | Create a pool with an action run after each connector returns and before
+-- multiplexer ownership is installed. The hook is intended for deterministic
+-- lifecycle testing and must not retain the connected client.
+createMultiplexPoolWithHandoffHook
+  :: (Client client)
+  => Connector client
+  -> (client 'Connected -> IO ())
+  -> Int
+  -> IO (MultiplexPool client)
+createMultiplexPoolWithHandoffHook connector handoffHook muxCnt = do
   nodesRef <- newIORef Map.empty
   nodesLock <- newMVar ()
   closed <- newIORef False
   slotPool <- createSlotPool 256
-  return $ MultiplexPool nodesRef nodesLock closed connector slotPool (max 1 muxCnt)
+  return $
+    MultiplexPool nodesRef nodesLock closed connector handoffHook slotPool
+      (max 1 muxCnt)
 
 -- | Submit a pre-encoded RESP command (as a Builder) to the multiplexer for a given node.
 -- Creates the multiplexer on demand if the node hasn't been seen before.
@@ -180,7 +198,8 @@ getMultiplexer pool addr = do
           mux <- pickMux nm
           return ((), mux)
         Nothing -> do
-          nm <- createNodeMuxes (poolConnector pool) addr (poolMuxCount pool)
+          nm <- createNodeMuxes
+            (poolConnector pool) (poolHandoffHook pool) addr (poolMuxCount pool)
           atomicWriteIORef (poolNodesRef pool) (Map.insert addr nm m')
           return ((), V.head (nmMuxes nm))
 {-# INLINE getMultiplexer #-}
@@ -199,23 +218,24 @@ pickMux nm
 createNodeMuxes
   :: (Client client)
   => Connector client
+  -> (client 'Connected -> IO ())
   -> NodeAddress
   -> Int
   -> IO NodeMuxes
-createNodeMuxes connector addr count = do
-  muxes <- mask $ \restore -> createAll restore [] count
+createNodeMuxes connector handoffHook addr count = do
+  muxes <- mask_ $ createAll [] count
   counter <- newIORef 1 `catch` \(e :: SomeException) -> do
     destroyMuxes muxes
     throwIO e
   return $ NodeMuxes (V.fromList $ reverse muxes) counter
   where
-    createAll _ acc 0 = return acc
-    createAll restore acc remaining = do
-      result <- try $ restore $ do
-        conn <- connector addr
-        createMultiplexer conn (receive conn)
+    createAll acc 0 = return acc
+    createAll acc remaining = do
+      result <- try $ do
+        createMultiplexerFromConnectorWithHandoffHook
+          connector addr handoffHook
       case result of
-        Right mux -> createAll restore (mux : acc) (remaining - 1)
+        Right mux -> createAll (mux : acc) (remaining - 1)
         Left (e :: SomeException) -> do
           destroyMuxes acc
           throwIO e
@@ -240,7 +260,8 @@ replaceMux pool addr _oldMux = do
         mux <- pickMux nm'
         return ((), mux)
       Nothing -> do
-        nm <- createNodeMuxes (poolConnector pool) addr (poolMuxCount pool)
+        nm <- createNodeMuxes
+          (poolConnector pool) (poolHandoffHook pool) addr (poolMuxCount pool)
         atomicWriteIORef (poolNodesRef pool) (Map.insert addr nm m)
         return ((), V.head (nmMuxes nm))
 
@@ -278,20 +299,20 @@ replaceDeadMuxes
   -> [Multiplexer]
   -> IO [Multiplexer]
 replaceDeadMuxes pool addr muxes =
-  mask $ \restore -> go restore [] [] muxes
+  mask_ $ go [] [] muxes
   where
-    go _ kept _ [] = return $ reverse kept
-    go restore kept created (mux:rest) = do
+    go kept _ [] = return $ reverse kept
+    go kept created (mux:rest) = do
       alive <- isMultiplexerAlive mux
       if alive
-        then go restore (mux : kept) created rest
+        then go (mux : kept) created rest
         else do
           destroyMultiplexer mux `catch` \(_ :: SomeException) -> return ()
-          result <- try $ restore $ do
-            conn <- poolConnector pool addr
-            createMultiplexer conn (receive conn)
+          result <- try $ do
+            createMultiplexerFromConnectorWithHandoffHook
+              (poolConnector pool) addr (poolHandoffHook pool)
           case result of
-            Right newMux -> go restore (newMux : kept) (newMux : created) rest
+            Right newMux -> go (newMux : kept) (newMux : created) rest
             Left (e :: SomeException) -> do
               destroyMuxes created
               throwIO e

--- a/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
@@ -24,6 +24,8 @@ module Database.Redis.Internal.Multiplexer
   , ResponseSlot
   , createSlotPool
   , createMultiplexer
+  , createMultiplexerFromConnector
+  , createMultiplexerFromConnectorWithHandoffHook
   , submitCommand
   , submitCommandPooled
   , submitCommandPairPooled
@@ -34,15 +36,14 @@ module Database.Redis.Internal.Multiplexer
   , isMultiplexerAlive
   ) where
 
-import           Control.Concurrent               (ThreadId, forkFinally,
-                                                   forkIOWithUnmask, killThread,
-                                                   myThreadId)
+import           Control.Concurrent               (ThreadId, forkIOWithUnmask,
+                                                   killThread, myThreadId)
 import           Control.Concurrent.MVar          (MVar, modifyMVar,
                                                    newEmptyMVar, newMVar,
                                                    putMVar, readMVar, takeMVar,
                                                    tryPutMVar, withMVar)
 import           Control.Exception                (Exception, SomeException,
-                                                   catch, mask, mask_,
+                                                   catch, finally, mask_,
                                                    onException, throwIO,
                                                    toException, try,
                                                    uninterruptibleMask_)
@@ -64,6 +65,8 @@ import           Data.Typeable                    (Typeable)
 import qualified Data.Vector                      as V
 import           Database.Redis.Client            (Client (..),
                                                    ConnectionStatus (..))
+import           Database.Redis.Cluster           (NodeAddress)
+import           Database.Redis.Connector         (Connector)
 import           Database.Redis.Resp              (RespData, parseRespData)
 import qualified GHC.Conc                         as GHC (threadCapability)
 
@@ -387,13 +390,13 @@ createMultiplexer
   => client 'Connected
   -> IO ByteString       -- ^ Action to receive bytes from the connection
   -> IO Multiplexer
-createMultiplexer conn recv = mask $ \restore -> do
+createMultiplexer conn recv = mask_ $ do
   transport <- newTransportFinalizer (close conn)
     `onException` (close conn `catch` \(_ :: SomeException) -> return ())
-  build restore transport
+  build transport
     `onException` (closeTransport transport `catch` \(_ :: SomeException) -> return ())
   where
-    build restore transport = do
+    build transport = do
       cmdQueue     <- newCommandQueue
       pendingQueue <- newPendingQueue
       transferLock <- newMVar ()
@@ -403,12 +406,12 @@ createMultiplexer conn recv = mask $ \restore -> do
       readerDone   <- newEmptyMVar
       writerDone   <- newEmptyMVar
 
-      readerId <- forkFinally
-        (restore $ readerLoop transferLock cmdQueue pendingQueue recv alive)
-        (const $ putMVar readerDone ())
-      writerId <- forkFinally
-        (restore $ writerLoop transferLock cmdQueue pendingQueue conn alive)
-        (const $ putMVar writerDone ())
+      readerId <- forkIOWithUnmask $ \unmask ->
+        unmask (readerLoop transferLock cmdQueue pendingQueue recv alive)
+          `finally` putMVar readerDone ()
+      writerId <- (forkIOWithUnmask $ \unmask ->
+        unmask (writerLoop transferLock cmdQueue pendingQueue conn alive)
+          `finally` putMVar writerDone ())
         `onException` do
           killThread readerId
           readMVar readerDone
@@ -416,6 +419,34 @@ createMultiplexer conn recv = mask $ \restore -> do
       return $ Multiplexer
         cmdQueue pendingQueue writerId readerId writerDone readerDone
         alive lifecycle destroyLock transport
+
+-- | Acquire a connected transport and transfer it to a multiplexer without an
+-- asynchronous-exception gap between connector return and finalizer ownership.
+createMultiplexerFromConnector
+  :: (Client client)
+  => Connector client
+  -> NodeAddress
+  -> IO Multiplexer
+createMultiplexerFromConnector connector addr =
+  createMultiplexerFromConnectorWithHandoffHook
+    connector addr (const $ return ())
+
+-- | Variant with a masked handoff hook for deterministic lifecycle tests.
+-- The hook runs after the connector returns but before finalizer installation.
+createMultiplexerFromConnectorWithHandoffHook
+  :: (Client client)
+  => Connector client
+  -> NodeAddress
+  -> (client 'Connected -> IO ())
+  -> IO Multiplexer
+createMultiplexerFromConnectorWithHandoffHook connector addr handoffHook =
+  mask_ $ do
+    -- Masking remains interruptible, so blocking DNS/connect/TLS work can
+    -- still be cancelled while the post-return ownership gap stays closed.
+    conn <- connector addr
+    handoffHook conn
+      `onException` (close conn `catch` \(_ :: SomeException) -> return ())
+    createMultiplexer conn (receive conn)
 
 multiplexerDestroyed :: SomeException
 multiplexerDestroyed = toException $ MultiplexerDead "Multiplexer destroyed"

--- a/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
@@ -35,13 +35,17 @@ module Database.Redis.Internal.Multiplexer
   ) where
 
 import           Control.Concurrent               (ThreadId, forkFinally,
-                                                   killThread, myThreadId)
-import           Control.Concurrent.MVar          (MVar, newEmptyMVar, newMVar,
+                                                   forkIOWithUnmask, killThread,
+                                                   myThreadId)
+import           Control.Concurrent.MVar          (MVar, modifyMVar,
+                                                   newEmptyMVar, newMVar,
                                                    putMVar, readMVar, takeMVar,
                                                    tryPutMVar, withMVar)
 import           Control.Exception                (Exception, SomeException,
-                                                   mask_, throwIO, toException,
-                                                   try, uninterruptibleMask_)
+                                                   catch, mask, mask_,
+                                                   onException, throwIO,
+                                                   toException, try,
+                                                   uninterruptibleMask_)
 import           Control.Monad                    (forM_, void, when)
 import qualified Data.Attoparsec.ByteString.Char8 as StrictParse
 import           Data.ByteString                  (ByteString)
@@ -338,6 +342,7 @@ data Multiplexer = Multiplexer
   , muxAlive        :: !(IORef Bool)
   , muxLifecycle    :: !(IORef MultiplexerLifecycle)
   , muxDestroyLock  :: !(MVar ())
+  , muxTransport    :: !TransportFinalizer
   }
 
 data MultiplexerLifecycle
@@ -346,35 +351,71 @@ data MultiplexerLifecycle
   | MultiplexerDestroyed
   deriving (Eq)
 
+-- | An exactly-once transport finalizer. Closing runs in its own thread so an
+-- interrupted destroy caller cannot cancel the close action or invoke it twice.
+data TransportFinalizer = TransportFinalizer
+  { transportCloseAction :: !(IO ())
+  , transportCloseState  :: !(MVar (Maybe (MVar (Either SomeException ()))))
+  }
+
+newTransportFinalizer :: IO () -> IO TransportFinalizer
+newTransportFinalizer action =
+  TransportFinalizer action <$> newMVar Nothing
+
+startTransportClose :: TransportFinalizer -> IO (MVar (Either SomeException ()))
+startTransportClose finalizer =
+  modifyMVar (transportCloseState finalizer) $ \case
+    Just done -> return (Just done, done)
+    Nothing -> do
+      done <- newEmptyMVar
+      _ <- forkIOWithUnmask $ \unmask ->
+        try (unmask $ transportCloseAction finalizer) >>= putMVar done
+      return (Just done, done)
+
+closeTransport :: TransportFinalizer -> IO ()
+closeTransport finalizer = do
+  done <- startTransportClose finalizer
+  readMVar done >>= either throwIO return
+
 -- | Create a multiplexer over an already-connected client.
 --
--- Spawns a writer and reader green thread. The caller must eventually call
--- 'destroyMultiplexer' to clean up.
+-- Ownership of the connected transport transfers to the multiplexer. It is
+-- closed exactly once by 'destroyMultiplexer', including partial construction
+-- failure.
 createMultiplexer
   :: (Client client)
   => client 'Connected
   -> IO ByteString       -- ^ Action to receive bytes from the connection
   -> IO Multiplexer
-createMultiplexer conn recv = do
-  cmdQueue     <- newCommandQueue
-  pendingQueue <- newPendingQueue
-  transferLock <- newMVar ()
-  alive        <- newIORef True
-  lifecycle    <- newIORef MultiplexerOpen
-  destroyLock  <- newMVar ()
-  readerDone   <- newEmptyMVar
-  writerDone   <- newEmptyMVar
+createMultiplexer conn recv = mask $ \restore -> do
+  transport <- newTransportFinalizer (close conn)
+    `onException` (close conn `catch` \(_ :: SomeException) -> return ())
+  build restore transport
+    `onException` (closeTransport transport `catch` \(_ :: SomeException) -> return ())
+  where
+    build restore transport = do
+      cmdQueue     <- newCommandQueue
+      pendingQueue <- newPendingQueue
+      transferLock <- newMVar ()
+      alive        <- newIORef True
+      lifecycle    <- newIORef MultiplexerOpen
+      destroyLock  <- newMVar ()
+      readerDone   <- newEmptyMVar
+      writerDone   <- newEmptyMVar
 
-  readerId <- forkFinally
-    (readerLoop transferLock cmdQueue pendingQueue recv alive)
-    (const $ putMVar readerDone ())
-  writerId <- forkFinally
-    (writerLoop transferLock cmdQueue pendingQueue conn alive)
-    (const $ putMVar writerDone ())
+      readerId <- forkFinally
+        (restore $ readerLoop transferLock cmdQueue pendingQueue recv alive)
+        (const $ putMVar readerDone ())
+      writerId <- forkFinally
+        (restore $ writerLoop transferLock cmdQueue pendingQueue conn alive)
+        (const $ putMVar writerDone ())
+        `onException` do
+          killThread readerId
+          readMVar readerDone
 
-  return $ Multiplexer
-    cmdQueue pendingQueue writerId readerId writerDone readerDone
-    alive lifecycle destroyLock
+      return $ Multiplexer
+        cmdQueue pendingQueue writerId readerId writerDone readerDone
+        alive lifecycle destroyLock transport
 
 multiplexerDestroyed :: SomeException
 multiplexerDestroyed = toException $ MultiplexerDead "Multiplexer destroyed"
@@ -486,12 +527,15 @@ destroyMultiplexer mux =
         void $ commandClose (muxCommandQueue mux)
         atomicWriteIORef (muxAlive mux) False
 
+      transportDone <- startTransportClose (muxTransport mux)
+
       -- These operations may block and remain interruptible. If this owner is
       -- cancelled, the Destroying state lets the next caller resume teardown.
       killThread (muxWriterThread mux)
       killThread (muxReaderThread mux)
       readMVar (muxWriterDone mux)
       readMVar (muxReaderDone mux)
+      transportResult <- readMVar transportDone
 
       -- Queue drains and slot completion are bounded, non-blocking operations.
       -- Keeping this tail uninterruptible prevents ownership from being lost
@@ -502,6 +546,8 @@ destroyMultiplexer mux =
         forM_ commands $ \pc -> failSlot (pcSlot pc) multiplexerDestroyed
         forM_ pending $ \slot -> failSlot slot multiplexerDestroyed
         writeIORef (muxLifecycle mux) MultiplexerDestroyed
+
+      either throwIO return transportResult
 
 -- | Check if the multiplexer's threads are still running.
 isMultiplexerAlive :: Multiplexer -> IO Bool

--- a/hask-redis-mux/lib/cluster/Database/Redis/Standalone.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Standalone.hs
@@ -49,8 +49,7 @@ import           Control.Exception                   (SomeException, bracket,
 import           Control.Monad.IO.Class              (MonadIO (..))
 import           Control.Monad.Reader                (ReaderT, ask, runReaderT)
 import           Data.ByteString                     (ByteString)
-import           Database.Redis.Client               (Client (..),
-                                                      PlainTextClient)
+import           Database.Redis.Client               (Client, PlainTextClient)
 import           Database.Redis.Cluster              (NodeAddress (..))
 import           Database.Redis.Command              (ClientReplyValues (..),
                                                       RedisCommands (..),
@@ -65,7 +64,7 @@ import           Database.Redis.Connector            (Connector,
                                                       clusterPlaintextConnector)
 import           Database.Redis.FromResp             (FromResp (..))
 import           Database.Redis.Internal.Multiplexer (Multiplexer, SlotPool,
-                                                      createMultiplexer,
+                                                      createMultiplexerFromConnector,
                                                       createSlotPool,
                                                       destroyMultiplexer,
                                                       submitCommandPooled)
@@ -109,8 +108,7 @@ createStandaloneClient
   -> NodeAddress
   -> IO StandaloneClient
 createStandaloneClient connector addr = do
-  conn <- connector addr
-  mux <- createMultiplexer conn (receive conn)
+  mux <- createMultiplexerFromConnector connector addr
   pool <- createSlotPool 256
     `onException` closeStandaloneMux mux
   return $ StandaloneClient mux pool
@@ -121,8 +119,8 @@ createStandaloneClientFromConfig
   => StandaloneConfig client
   -> IO StandaloneClient
 createStandaloneClientFromConfig config = do
-  conn <- standaloneConnector config (standaloneNodeAddress config)
-  mux <- createMultiplexer conn (receive conn)
+  mux <- createMultiplexerFromConnector
+    (standaloneConnector config) (standaloneNodeAddress config)
   pool <- createSlotPool 256
     `onException` closeStandaloneMux mux
   return $ StandaloneClient mux pool

--- a/hask-redis-mux/lib/cluster/Database/Redis/Standalone.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Standalone.hs
@@ -45,7 +45,7 @@ module Database.Redis.Standalone
   ) where
 
 import           Control.Exception                   (SomeException, bracket,
-                                                      catch)
+                                                      catch, onException)
 import           Control.Monad.IO.Class              (MonadIO (..))
 import           Control.Monad.Reader                (ReaderT, ask, runReaderT)
 import           Data.ByteString                     (ByteString)
@@ -112,6 +112,7 @@ createStandaloneClient connector addr = do
   conn <- connector addr
   mux <- createMultiplexer conn (receive conn)
   pool <- createSlotPool 256
+    `onException` closeStandaloneMux mux
   return $ StandaloneClient mux pool
 
 -- | Create a standalone client from a 'StandaloneConfig'.
@@ -123,21 +124,28 @@ createStandaloneClientFromConfig config = do
   conn <- standaloneConnector config (standaloneNodeAddress config)
   mux <- createMultiplexer conn (receive conn)
   pool <- createSlotPool 256
+    `onException` closeStandaloneMux mux
   return $ StandaloneClient mux pool
 
 -- | Close the standalone client, destroying the underlying multiplexer.
+-- The owned plaintext or TLS transport is closed exactly once. Closure is
+-- terminal and idempotent; later commands fail instead of reconnecting.
 --
 -- Consider using 'withStandaloneClient' instead for automatic cleanup.
 closeStandaloneClient :: StandaloneClient -> IO ()
 closeStandaloneClient client =
-  destroyMultiplexer (standaloneMux client)
-    `catch` \(_ :: SomeException) -> return ()
+  closeStandaloneMux (standaloneMux client)
+
+closeStandaloneMux :: Multiplexer -> IO ()
+closeStandaloneMux mux =
+  destroyMultiplexer mux `catch` \(_ :: SomeException) -> return ()
 
 -- | Bracket-style resource management for standalone clients.
 --
 -- Creates a client, runs the given action, and ensures the client is closed
 -- even if an exception occurs. Prefer this over manual 'createStandaloneClientFromConfig'
--- and 'closeStandaloneClient'.
+-- and 'closeStandaloneClient'. After the callback returns, the client and its
+-- transport are permanently closed.
 --
 -- @
 -- withStandaloneClient config $ \\client ->

--- a/hask-redis-mux/lib/redis/Database/Redis.hs
+++ b/hask-redis-mux/lib/redis/Database/Redis.hs
@@ -80,6 +80,7 @@ import           Database.Redis.Cluster.Client         (ClusterClient (..),
                                                         refreshTopology,
                                                         runClusterCommandClient)
 import           Database.Redis.Cluster.ConnectionPool (ConnectionPool (..),
+                                                        ConnectionPoolException (..),
                                                         PoolConfig (..),
                                                         closePool, createPool,
                                                         withConnection)
@@ -109,6 +110,7 @@ import           Database.Redis.Internal.Multiplexer   (Multiplexer,
                                                         isMultiplexerAlive,
                                                         submitCommand)
 import           Database.Redis.Internal.MultiplexPool (MultiplexPool,
+                                                        MultiplexPoolException (..),
                                                         closeMultiplexPool,
                                                         createMultiplexPool,
                                                         submitToNode)

--- a/hask-redis-mux/test/ClusterCommandSpec.hs
+++ b/hask-redis-mux/test/ClusterCommandSpec.hs
@@ -8,6 +8,8 @@ import           Control.Concurrent                    (forkIO, threadDelay)
 import           Control.Concurrent.MVar               (newEmptyMVar, newMVar,
                                                         putMVar, takeMVar)
 import           Control.Concurrent.STM                (newTVarIO)
+import           Control.Exception                     (SomeException, throwIO,
+                                                        try)
 import           Control.Monad.IO.Class                (liftIO)
 import           Data.ByteString                       (ByteString)
 import qualified Data.ByteString                       as BS
@@ -191,6 +193,9 @@ spec = do
       let err = ConnectionError "Connection timeout"
       show err `shouldContain` "ConnectionError"
 
+    it "creates ClusterClientClosed correctly" $ do
+      ClusterClientClosed `shouldBe` ClusterClientClosed
+
   describe "ClusterConfig" $ do
     it "creates valid cluster config" $ do
       let poolConfig = PoolConfig
@@ -231,6 +236,7 @@ spec = do
       redir1 `shouldNotBe` redir3
 
   askRedirectSpec
+  clusterLifecycleSpec
 
 -- ---------------------------------------------------------------------------
 -- Mock client (same pattern as MultiplexPoolSpec)
@@ -239,15 +245,17 @@ spec = do
 data MockClient (a :: ConnectionStatus) where
   MockConnected :: !(IORef ByteString)   -- sendBuf
                -> !(IORef [ByteString]) -- recvQueue
+               -> !(IORef Int)          -- closeCount
                -> MockClient 'Connected
 
 instance Client MockClient where
   connect = error "MockClient: connect not supported"
-  close _ = return ()
-  send (MockConnected sendBuf _) lbs = liftIO $ do
+  close (MockConnected _ _ closeCount) =
+    liftIO $ atomicModifyIORef' closeCount $ \count -> (count + 1, ())
+  send (MockConnected sendBuf _ _) lbs = liftIO $ do
     let !bs = LBS.toStrict lbs
     atomicModifyIORef' sendBuf $ \old -> (old <> bs, ())
-  receive (MockConnected sRef recvQueue) = liftIO $ recvLoop sRef recvQueue
+  receive (MockConnected sRef recvQueue _) = liftIO $ recvLoop sRef recvQueue
 
 recvLoop :: IORef ByteString -> IORef [ByteString] -> IO ByteString
 recvLoop sRef recvQueue = do
@@ -265,7 +273,8 @@ createMockClient :: IO (MockClient 'Connected, ByteString -> IO ())
 createMockClient = do
   sendBuf <- newIORef BS.empty
   recvQueue <- newIORef []
-  let client = MockConnected sendBuf recvQueue
+  closeCount <- newIORef 0
+  let client = MockConnected sendBuf recvQueue closeCount
       addRecv bs = atomicModifyIORef' recvQueue $ \xs -> (xs ++ [bs], ())
   return (client, addRecv)
 
@@ -281,6 +290,19 @@ createMockConnector = do
         atomicModifyIORef' connCount $ \n -> (n + 1, ())
         return client
   return (connector, mapRef, connCount)
+
+createLifecycleConnector
+  :: RespData
+  -> IO (NodeAddress -> IO (MockClient 'Connected), IORef Int, IORef Int)
+createLifecycleConnector response = do
+  connectionCount <- newIORef 0
+  closeCount <- newIORef 0
+  let connector _ = do
+        sendBuf <- newIORef BS.empty
+        recvQueue <- newIORef [encodeResp response]
+        atomicModifyIORef' connectionCount $ \count -> (count + 1, ())
+        return $ MockConnected sendBuf recvQueue closeCount
+  return (connector, connectionCount, closeCount)
 
 getAddRecvs :: AddRecvMap -> NodeAddress -> IO [ByteString -> IO ()]
 getAddRecvs mapRef addr = do
@@ -305,6 +327,37 @@ mkTopology addr = do
       nodeMap = Map.singleton nodeIdBS node
   return $ ClusterTopology slotVec addrVec nodeMap now
 
+validClusterSlots :: RespData
+validClusterSlots =
+  RespArray
+    [ RespArray
+        [ RespInteger 0
+        , RespInteger 16383
+        , RespArray
+            [ RespBulkString "127.0.0.1"
+            , RespInteger 6379
+            , RespBulkString "test-node-id-1"
+            ]
+        ]
+    ]
+
+testPoolConfig :: PoolConfig
+testPoolConfig = PoolConfig
+  { maxConnectionsPerNode = 1
+  , connectionTimeout     = 5000
+  , maxRetries            = 3
+  , useTLS                = False
+  }
+
+testClusterConfig :: ClusterConfig
+testClusterConfig = ClusterConfig
+  { clusterSeedNode                = node1
+  , clusterPoolConfig              = testPoolConfig
+  , clusterMaxRetries              = 5
+  , clusterRetryDelay              = 1000
+  , clusterTopologyRefreshInterval = 600
+  }
+
 -- | Build a ClusterClient backed by a mock connector and a given topology.
 mkClusterClient
   :: (NodeAddress -> IO (MockClient 'Connected))
@@ -312,24 +365,58 @@ mkClusterClient
   -> IO (ClusterClient MockClient)
 mkClusterClient connector topo = do
   topoVar   <- newTVarIO topo
-  pool      <- createPool poolCfg
+  pool      <- createPool testPoolConfig
   muxPool   <- createMultiplexPool connector 1
   refreshLk <- newMVar ()
-  return $ ClusterClient topoVar pool clusterCfg connector refreshLk muxPool
-  where
-    poolCfg = PoolConfig
-      { maxConnectionsPerNode = 1
-      , connectionTimeout     = 5000
-      , maxRetries            = 3
-      , useTLS                = False
-      }
-    clusterCfg = ClusterConfig
-      { clusterSeedNode                = NodeAddress "127.0.0.1" 6379
-      , clusterPoolConfig              = poolCfg
-      , clusterMaxRetries              = 5
-      , clusterRetryDelay              = 1000
-      , clusterTopologyRefreshInterval = 600
-      }
+  return $ ClusterClient topoVar pool testClusterConfig connector refreshLk muxPool
+
+clusterLifecycleSpec :: Spec
+clusterLifecycleSpec = describe "Cluster client lifecycle" $ do
+  it "closes the discovery connection when topology parsing fails" $ do
+    (connector, connectionCount, closeCount) <-
+      createLifecycleConnector (RespSimpleString "not cluster slots")
+
+    result <- try (createClusterClient testClusterConfig connector)
+      :: IO (Either SomeException (ClusterClient MockClient))
+    case result of
+      Left _  -> return ()
+      Right _ -> expectationFailure "Expected topology parsing failure"
+    readIORef connectionCount `shouldReturn` 1
+    readIORef closeCount `shouldReturn` 1
+
+  it "closes the discovery pool when later initialization fails" $ do
+    (connector, connectionCount, closeCount) <-
+      createLifecycleConnector validClusterSlots
+    let failMuxCreation _ _ =
+          throwIO $ userError "injected multiplexer pool initialization failure"
+
+    result <- try $
+      createClusterClientWithFactories
+        createPool failMuxCreation testClusterConfig connector
+      :: IO (Either SomeException (ClusterClient MockClient))
+    case result of
+      Left _  -> return ()
+      Right _ -> expectationFailure "Expected multiplexer pool initialization failure"
+    readIORef connectionCount `shouldReturn` 1
+    readIORef closeCount `shouldReturn` 1
+
+  it "closes once and keeps both cluster pools terminal" $ do
+    (connector, connectionCount, closeCount) <-
+      createLifecycleConnector validClusterSlots
+    client <- createClusterClient testClusterConfig connector
+
+    closeClusterClient client
+    closeClusterClient client
+    readIORef connectionCount `shouldReturn` 1
+    readIORef closeCount `shouldReturn` 1
+
+    keyless <- executeKeylessClusterCommand client
+      (ping :: RedisCommandClient MockClient RespData)
+    keyless `shouldBe` Left ClusterClientClosed
+    keyed <- executeKeyedClusterCommand client "key" ["GET", "key"]
+    keyed `shouldBe` Left ClusterClientClosed
+    readIORef connectionCount `shouldReturn` 1
+    readIORef closeCount `shouldReturn` 1
 
 -- ---------------------------------------------------------------------------
 -- ASK redirect integration tests

--- a/hask-redis-mux/test/MultiplexPoolSpec.hs
+++ b/hask-redis-mux/test/MultiplexPoolSpec.hs
@@ -5,10 +5,11 @@
 
 module Main (main) where
 
-import           Control.Concurrent                    (forkIO, threadDelay)
-import           Control.Concurrent.MVar               (newEmptyMVar, putMVar,
-                                                        takeMVar)
-import           Control.Exception                     (SomeException,
+import           Control.Concurrent                    (forkFinally, forkIO,
+                                                        killThread, threadDelay)
+import           Control.Concurrent.MVar               (MVar, newEmptyMVar,
+                                                        putMVar, takeMVar)
+import           Control.Exception                     (SomeException, bracket_,
                                                         fromException, throwIO,
                                                         try)
 import           Control.Monad.IO.Class                (liftIO)
@@ -25,6 +26,7 @@ import           Database.Redis.Cluster                (NodeAddress (..))
 import           Database.Redis.Internal.MultiplexPool
 import           Database.Redis.Resp                   (Encodable (..),
                                                         RespData (..))
+import           System.Timeout                        (timeout)
 import           Test.Hspec
 
 -- ---------------------------------------------------------------------------
@@ -137,6 +139,67 @@ createCountingConnector failAt firstSendFails = do
             atomicModifyIORef' mapRef $ \xs -> (xs ++ [(addr, addRecv)], ())
             return client
   return (connector, mapRef, attempts, closeCount)
+
+data HandoffClient (a :: ConnectionStatus) where
+  HandoffConnected
+    :: !Int
+    -> !(IORef Int)
+    -> !(IORef Int)
+    -> !Bool
+    -> !(MVar ByteString)
+    -> HandoffClient 'Connected
+
+instance Client HandoffClient where
+  connect = error "HandoffClient: connect not supported"
+  close (HandoffConnected _ closeCount _ _ _) =
+    liftIO $ atomicModifyIORef' closeCount $ \count -> (count + 1, ())
+  send (HandoffConnected _ _ _ failSend _) _ =
+    if failSend
+      then liftIO $ throwIO $ userError "injected send failure"
+      else return ()
+  receive (HandoffConnected _ _ activeReaders _ replies) =
+    liftIO $ bracket_
+      (atomicModifyIORef' activeReaders $ \count -> (count + 1, ()))
+      (atomicModifyIORef' activeReaders $ \count -> (count - 1, ()))
+      (takeMVar replies)
+
+createHandoffConnector
+  :: Bool
+  -> IO
+       ( NodeAddress -> IO (HandoffClient 'Connected)
+       , IORef Int
+       , IORef Int
+       , IORef Int
+       )
+createHandoffConnector firstSendFails = do
+  attempts <- newIORef 0
+  closeCount <- newIORef 0
+  activeReaders <- newIORef 0
+  let connector _ = do
+        attempt <- atomicModifyIORef' attempts $ \count ->
+          let next = count + 1
+          in (next, next)
+        replies <- newEmptyMVar
+        return $ HandoffConnected
+          attempt closeCount activeReaders (firstSendFails && attempt == 1) replies
+  return (connector, attempts, closeCount, activeReaders)
+
+handoffGate
+  :: Int
+  -> MVar ()
+  -> MVar ()
+  -> HandoffClient 'Connected
+  -> IO ()
+handoffGate target started release (HandoffConnected attempt _ _ _ _)
+  | attempt == target = putMVar started () >> takeMVar release
+  | otherwise = return ()
+
+waitForZero :: IORef Int -> IO ()
+waitForZero ref = do
+  count <- readIORef ref
+  if count == 0
+    then return ()
+    else threadDelay 1000 >> waitForZero ref
 
 -- | Get addRecv functions for a given node address.
 getAddRecvs :: AddRecvMap -> NodeAddress -> IO [ByteString -> IO ()]
@@ -436,7 +499,7 @@ poolClosureSpec = describe "Pool closure" $ do
     closeMultiplexPool pool
 
 constructionFailureSpec :: Spec
-constructionFailureSpec = describe "Partial multiplexer construction" $
+constructionFailureSpec = describe "Partial multiplexer construction" $ do
   mapM_ (\failureIndex ->
     it ("closes all transports created before connector failure " <> show failureIndex) $ do
       (connector, _, attempts, closeCount) <-
@@ -451,6 +514,31 @@ constructionFailureSpec = describe "Partial multiplexer construction" $
       closeMultiplexPool pool
       readIORef closeCount `shouldReturn` (failureIndex - 1)
     ) [1..3]
+
+  it "closes the returned transport and earlier muxes when initial handoff is cancelled" $ do
+    (connector, attempts, closeCount, activeReaders) <-
+      createHandoffConnector False
+    handoffStarted <- newEmptyMVar
+    releaseHandoff <- newEmptyMVar
+    pool <- createMultiplexPoolWithHandoffHook
+      connector (handoffGate 2 handoffStarted releaseHandoff) 3
+
+    finished <- newEmptyMVar
+    owner <- forkFinally
+      (submitToNode pool node1 $ encodeCmd ["PING"])
+      (putMVar finished)
+    timeout 1000000 (takeMVar handoffStarted) `shouldReturn` Just ()
+    killThread owner
+    outcome <- timeout 1000000 (takeMVar finished)
+    outcome `shouldSatisfy` \case
+      Just (Left _) -> True
+      _             -> False
+
+    timeout 1000000 (waitForZero activeReaders) `shouldReturn` Just ()
+    readIORef attempts `shouldReturn` 2
+    readIORef closeCount `shouldReturn` 2
+    closeMultiplexPool pool
+    readIORef closeCount `shouldReturn` 2
 
 replacementFailureSpec :: Spec
 replacementFailureSpec = describe "Multiplexer replacement failure" $ do
@@ -467,6 +555,31 @@ replacementFailureSpec = describe "Multiplexer replacement failure" $ do
 
     closeMultiplexPool pool
     readIORef closeCount `shouldReturn` 1
+
+  it "closes the returned replacement transport when handoff is cancelled" $ do
+    (connector, attempts, closeCount, activeReaders) <-
+      createHandoffConnector True
+    handoffStarted <- newEmptyMVar
+    releaseHandoff <- newEmptyMVar
+    pool <- createMultiplexPoolWithHandoffHook
+      connector (handoffGate 2 handoffStarted releaseHandoff) 1
+
+    finished <- newEmptyMVar
+    owner <- forkFinally
+      (submitToNode pool node1 $ encodeCmd ["PING"])
+      (putMVar finished)
+    timeout 1000000 (takeMVar handoffStarted) `shouldReturn` Just ()
+    killThread owner
+    outcome <- timeout 1000000 (takeMVar finished)
+    outcome `shouldSatisfy` \case
+      Just (Left _) -> True
+      _             -> False
+
+    timeout 1000000 (waitForZero activeReaders) `shouldReturn` Just ()
+    readIORef attempts `shouldReturn` 2
+    readIORef closeCount `shouldReturn` 2
+    closeMultiplexPool pool
+    readIORef closeCount `shouldReturn` 2
 
 askingSpec :: Spec
 askingSpec = describe "ASKING support (submitToNodeWithAsking)" $ do

--- a/hask-redis-mux/test/MultiplexPoolSpec.hs
+++ b/hask-redis-mux/test/MultiplexPoolSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE GADTs             #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main (main) where
@@ -7,6 +8,9 @@ module Main (main) where
 import           Control.Concurrent                    (forkIO, threadDelay)
 import           Control.Concurrent.MVar               (newEmptyMVar, putMVar,
                                                         takeMVar)
+import           Control.Exception                     (SomeException,
+                                                        fromException, throwIO,
+                                                        try)
 import           Control.Monad.IO.Class                (liftIO)
 import           Data.ByteString                       (ByteString)
 import qualified Data.ByteString                       as BS
@@ -31,15 +35,21 @@ import           Test.Hspec
 data MockClient (a :: ConnectionStatus) where
   MockConnected :: !(IORef ByteString)   -- sendBuf
                 -> !(IORef [ByteString]) -- recvQueue
+                -> !(IORef Int)          -- closeCount
+                -> !Bool                 -- failSend
                 -> MockClient 'Connected
 
 instance Client MockClient where
   connect = error "MockClient: connect not supported"
-  close _ = return ()
-  send (MockConnected sendBuf _) lbs = liftIO $ do
-    let !bs = LBS.toStrict lbs
-    atomicModifyIORef' sendBuf $ \old -> (old <> bs, ())
-  receive (MockConnected sRef recvQueue) = liftIO $ recvLoop sRef recvQueue
+  close (MockConnected _ _ closeCount _) =
+    liftIO $ atomicModifyIORef' closeCount $ \count -> (count + 1, ())
+  send (MockConnected sendBuf _ _ failSend) lbs = liftIO $
+    if failSend
+      then throwIO $ userError "injected send failure"
+      else do
+        let !bs = LBS.toStrict lbs
+        atomicModifyIORef' sendBuf $ \old -> (old <> bs, ())
+  receive (MockConnected sRef recvQueue _ _) = liftIO $ recvLoop sRef recvQueue
 
 recvLoop :: IORef ByteString -> IORef [ByteString] -> IO ByteString
 recvLoop sRef recvQueue = do
@@ -57,7 +67,19 @@ createMockClient :: IO (MockClient 'Connected, ByteString -> IO ())
 createMockClient = do
   sendBuf <- newIORef BS.empty
   recvQueue <- newIORef []
-  let client = MockConnected sendBuf recvQueue
+  closeCount <- newIORef 0
+  let client = MockConnected sendBuf recvQueue closeCount False
+      addRecv bs = atomicModifyIORef' recvQueue $ \xs -> (xs ++ [bs], ())
+  return (client, addRecv)
+
+createTrackedClient
+  :: IORef Int
+  -> Bool
+  -> IO (MockClient 'Connected, ByteString -> IO ())
+createTrackedClient closeCount failSend = do
+  sendBuf <- newIORef BS.empty
+  recvQueue <- newIORef []
+  let client = MockConnected sendBuf recvQueue closeCount failSend
       addRecv bs = atomicModifyIORef' recvQueue $ \xs -> (xs ++ [bs], ())
   return (client, addRecv)
 
@@ -89,6 +111,33 @@ createMockConnector = do
         return client
   return (connector, mapRef)
 
+createCountingConnector
+  :: Maybe Int
+  -> Bool
+  -> IO
+       ( NodeAddress -> IO (MockClient 'Connected)
+       , AddRecvMap
+       , IORef Int
+       , IORef Int
+       )
+createCountingConnector failAt firstSendFails = do
+  mapRef <- newIORef []
+  attempts <- newIORef 0
+  closeCount <- newIORef 0
+  let connector addr = do
+        attempt <- atomicModifyIORef' attempts $ \count ->
+          let next = count + 1
+          in (next, next)
+        case failAt of
+          Just failureIndex | attempt == failureIndex ->
+            throwIO $ userError "injected connector failure"
+          _ -> do
+            (client, addRecv) <-
+              createTrackedClient closeCount (firstSendFails && attempt == 1)
+            atomicModifyIORef' mapRef $ \xs -> (xs ++ [(addr, addRecv)], ())
+            return client
+  return (connector, mapRef, attempts, closeCount)
+
 -- | Get addRecv functions for a given node address.
 getAddRecvs :: AddRecvMap -> NodeAddress -> IO [ByteString -> IO ()]
 getAddRecvs mapRef addr = do
@@ -118,6 +167,8 @@ spec = do
   lazyCreationSpec
   multiNodeRoutingSpec
   poolClosureSpec
+  constructionFailureSpec
+  replacementFailureSpec
   askingSpec
 
 roundRobinSpec :: Spec
@@ -339,8 +390,9 @@ multiNodeRoutingSpec = describe "Multi-node routing" $ do
 
 poolClosureSpec :: Spec
 poolClosureSpec = describe "Pool closure" $ do
-  it "closeMultiplexPool destroys all multiplexers" $ do
-    (connector, addRecvMap) <- createMockConnector
+  it "closes transports once and rejects later submissions without reconnecting" $ do
+    (connector, addRecvMap, attempts, closeCount) <-
+      createCountingConnector Nothing False
     pool <- createMultiplexPool connector 1
 
     -- Create muxes for two nodes
@@ -362,26 +414,18 @@ poolClosureSpec = describe "Pool closure" $ do
     (firstOf fns2) (encodeResp (RespSimpleString "OK"))
     _ <- takeMVar r2MVar
 
-    -- Close the pool
     closeMultiplexPool pool
-    threadDelay 20000
-
-    -- After close, submitting should create new multiplexers (pool is empty)
-    -- The old ones should be destroyed — verify by submitting again and seeing new connections
-    r3MVar <- newEmptyMVar
-    _ <- forkIO $ do
-      r <- submitToNode pool node1 (encodeCmd ["PING"])
-      putMVar r3MVar r
-    threadDelay 50000
-    fns3 <- getAddRecvs addRecvMap node1
-    -- Should now have 2 connections for node1 (1 old + 1 new)
-    length fns3 `shouldBe` 2
-    -- Feed to the newest one (last in list)
-    (last fns3) (encodeResp (RespSimpleString "REOPENED"))
-    r3 <- takeMVar r3MVar
-    r3 `shouldBe` RespSimpleString "REOPENED"
-
     closeMultiplexPool pool
+    readIORef attempts `shouldReturn` 2
+    readIORef closeCount `shouldReturn` 2
+
+    result <- try (submitToNode pool node1 $ encodeCmd ["PING"])
+      :: IO (Either SomeException RespData)
+    result `shouldSatisfy` \case
+      Left err -> fromException err == Just MultiplexPoolClosed
+      Right _  -> False
+    readIORef attempts `shouldReturn` 2
+    readIORef closeCount `shouldReturn` 2
 
   it "closeMultiplexPool on empty pool does not crash" $ do
     (connector, _) <- createMockConnector
@@ -390,6 +434,39 @@ poolClosureSpec = describe "Pool closure" $ do
     closeMultiplexPool pool
     -- Close again — should be idempotent
     closeMultiplexPool pool
+
+constructionFailureSpec :: Spec
+constructionFailureSpec = describe "Partial multiplexer construction" $
+  mapM_ (\failureIndex ->
+    it ("closes all transports created before connector failure " <> show failureIndex) $ do
+      (connector, _, attempts, closeCount) <-
+        createCountingConnector (Just failureIndex) False
+      pool <- createMultiplexPool connector 3
+
+      result <- try (submitToNode pool node1 $ encodeCmd ["PING"])
+        :: IO (Either SomeException RespData)
+      result `shouldSatisfy` either (const True) (const False)
+      readIORef attempts `shouldReturn` failureIndex
+      readIORef closeCount `shouldReturn` (failureIndex - 1)
+      closeMultiplexPool pool
+      readIORef closeCount `shouldReturn` (failureIndex - 1)
+    ) [1..3]
+
+replacementFailureSpec :: Spec
+replacementFailureSpec = describe "Multiplexer replacement failure" $ do
+  it "closes the dead transport and leaves no replacement behind" $ do
+    (connector, _, attempts, closeCount) <-
+      createCountingConnector (Just 2) True
+    pool <- createMultiplexPool connector 1
+
+    result <- try (submitToNode pool node1 $ encodeCmd ["PING"])
+      :: IO (Either SomeException RespData)
+    result `shouldSatisfy` either (const True) (const False)
+    readIORef attempts `shouldReturn` 2
+    readIORef closeCount `shouldReturn` 1
+
+    closeMultiplexPool pool
+    readIORef closeCount `shouldReturn` 1
 
 askingSpec :: Spec
 askingSpec = describe "ASKING support (submitToNodeWithAsking)" $ do

--- a/hask-redis-mux/test/MultiplexerSpec.hs
+++ b/hask-redis-mux/test/MultiplexerSpec.hs
@@ -156,6 +156,23 @@ createTeardownClient = do
     , putMVar releaseSecond ()
     )
 
+data ClosingClient (a :: ConnectionStatus) where
+  ClosingConnected
+    :: !(IORef Int)
+    -> !(MVar ())
+    -> !(MVar ())
+    -> !(MVar ByteString)
+    -> ClosingClient 'Connected
+
+instance Client ClosingClient where
+  connect = error "ClosingClient: connect not supported"
+  close (ClosingConnected closeCount closeStarted releaseClose _) = liftIO $ do
+    atomicModifyIORef' closeCount $ \count -> (count + 1, ())
+    void $ tryPutMVar closeStarted ()
+    takeMVar releaseClose
+  send _ _ = return ()
+  receive (ClosingConnected _ _ _ replies) = liftIO $ takeMVar replies
+
 -- | Encode a RespData to strict ByteString (for feeding to mock recv).
 encodeResp :: RespData -> ByteString
 encodeResp = LBS.toStrict . Builder.toLazyByteString . encode
@@ -304,6 +321,30 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
     case result of
       Left (e :: SomeException) -> show e `shouldContain` "MultiplexerDead"
       Right _ -> expectationFailure "Expected MultiplexerDead exception"
+
+  it "closes the owned transport exactly once when the destroy owner is cancelled" $ do
+    closeCount <- newIORef 0
+    closeStarted <- newEmptyMVar
+    releaseClose <- newEmptyMVar
+    replies <- newEmptyMVar
+    let client = ClosingConnected closeCount closeStarted releaseClose replies
+    mux <- createMultiplexer client (receive client)
+
+    ownerDone <- newEmptyMVar
+    owner <- forkFinally (destroyMultiplexer mux) (putMVar ownerDone)
+    started <- timeout 1000000 (takeMVar closeStarted)
+    started `shouldBe` Just ()
+    killThread owner
+    cancelled <- timeout 1000000 (takeMVar ownerDone)
+    cancelled `shouldSatisfy` \case
+      Just (Left _) -> True
+      _             -> False
+
+    putMVar releaseClose ()
+    resumed <- timeout 1000000 (destroyMultiplexer mux)
+    resumed `shouldBe` Just ()
+    replicateM_ 3 (destroyMultiplexer mux)
+    readIORef closeCount `shouldReturn` 1
 
   it "submit-after-destroy with pooled also throws MultiplexerDead" $ do
     pool <- createSlotPool 16

--- a/hask-redis-mux/test/MultiplexerSpec.hs
+++ b/hask-redis-mux/test/MultiplexerSpec.hs
@@ -25,6 +25,7 @@ import           Data.IORef                          (IORef, atomicModifyIORef',
                                                       newIORef, readIORef)
 import           Database.Redis.Client               (Client (..),
                                                       ConnectionStatus (..))
+import           Database.Redis.Cluster              (NodeAddress (..))
 import           Database.Redis.Internal.Multiplexer
 import           Database.Redis.Resp                 (Encodable (..),
                                                       RespData (..))
@@ -155,6 +156,23 @@ createTeardownClient = do
     , await receiveStarted
     , putMVar releaseSecond ()
     )
+
+data AcquisitionClient (a :: ConnectionStatus) where
+  AcquisitionConnected
+    :: !(IORef Int)
+    -> !(IORef Int)
+    -> !(MVar ByteString)
+    -> AcquisitionClient 'Connected
+
+instance Client AcquisitionClient where
+  connect = error "AcquisitionClient: connect not supported"
+  close (AcquisitionConnected closeCount _ _) =
+    liftIO $ atomicModifyIORef' closeCount $ \count -> (count + 1, ())
+  send (AcquisitionConnected _ workerStarts _) _ =
+    liftIO $ atomicModifyIORef' workerStarts $ \count -> (count + 1, ())
+  receive (AcquisitionConnected _ workerStarts replies) = liftIO $ do
+    atomicModifyIORef' workerStarts $ \count -> (count + 1, ())
+    takeMVar replies
 
 data ClosingClient (a :: ConnectionStatus) where
   ClosingConnected
@@ -321,6 +339,32 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
     case result of
       Left (e :: SomeException) -> show e `shouldContain` "MultiplexerDead"
       Right _ -> expectationFailure "Expected MultiplexerDead exception"
+
+  mapM_ (\transportName ->
+    it ("closes a returned " <> transportName <> " transport cancelled before finalizer installation") $ do
+      closeCount <- newIORef 0
+      workerStarts <- newIORef 0
+      replies <- newEmptyMVar
+      handoffStarted <- newEmptyMVar
+      releaseHandoff <- newEmptyMVar
+      let client = AcquisitionConnected closeCount workerStarts replies
+          connector _ = return client
+          handoffHook _ = putMVar handoffStarted () >> takeMVar releaseHandoff
+
+      finished <- newEmptyMVar
+      owner <- forkFinally
+        (createMultiplexerFromConnectorWithHandoffHook
+          connector (NodeAddress "127.0.0.1" 6379) handoffHook)
+        (putMVar finished)
+      timeout 1000000 (takeMVar handoffStarted) `shouldReturn` Just ()
+      killThread owner
+      outcome <- timeout 1000000 (takeMVar finished)
+      case outcome of
+        Just (Left _) -> return ()
+        _             -> expectationFailure "handoff cancellation did not terminate creation"
+      readIORef closeCount `shouldReturn` 1
+      readIORef workerStarts `shouldReturn` 0
+    ) ["plaintext", "TLS"]
 
   it "closes the owned transport exactly once when the destroy owner is cancelled" $ do
     closeCount <- newIORef 0

--- a/hask-redis-mux/test/StandaloneSpec.hs
+++ b/hask-redis-mux/test/StandaloneSpec.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs     #-}
+
+module Main (main) where
+
+import           Control.Concurrent.MVar   (MVar, newEmptyMVar, takeMVar)
+import           Control.Exception         (SomeException, try)
+import           Control.Monad.IO.Class    (liftIO)
+import           Data.ByteString           (ByteString)
+import           Data.IORef                (IORef, atomicModifyIORef', newIORef,
+                                            readIORef)
+import           Database.Redis.Client     (Client (..), ConnectionStatus (..))
+import           Database.Redis.Cluster    (NodeAddress (..))
+import           Database.Redis.Command    (RedisCommands (..))
+import           Database.Redis.Standalone
+import           Test.Hspec
+
+data MockClient (a :: ConnectionStatus) where
+  MockConnected :: !(IORef Int) -> !(MVar ByteString) -> MockClient 'Connected
+
+instance Client MockClient where
+  connect = error "MockClient: connect not supported"
+  close (MockConnected closeCount _) =
+    liftIO $ atomicModifyIORef' closeCount $ \count -> (count + 1, ())
+  send _ _ = return ()
+  receive (MockConnected _ replies) = liftIO $ takeMVar replies
+
+main :: IO ()
+main = hspec $ describe "Standalone client lifecycle" $ do
+  it "owns its transport, closes once, and remains terminal" $ do
+    connectionCount <- newIORef (0 :: Int)
+    closeCount <- newIORef (0 :: Int)
+    replies <- newEmptyMVar
+    let connector _ = do
+          atomicModifyIORef' connectionCount $ \count -> (count + 1, ())
+          return $ MockConnected closeCount replies
+
+    client <- createStandaloneClient connector (NodeAddress "127.0.0.1" 6379)
+    closeStandaloneClient client
+    closeStandaloneClient client
+
+    result <- try $ runStandaloneClient client (ping :: StandaloneCommandClient ByteString)
+      :: IO (Either SomeException ByteString)
+    result `shouldSatisfy` either (const True) (const False)
+    readIORef connectionCount `shouldReturn` 1
+    readIORef closeCount `shouldReturn` 1

--- a/test/LibraryE2E/ConnectionPoolTests.hs
+++ b/test/LibraryE2E/ConnectionPoolTests.hs
@@ -1,17 +1,20 @@
 {-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module LibraryE2E.ConnectionPoolTests (spec) where
 
 import           Control.Concurrent.Async              (mapConcurrently)
-import           Control.Exception                     (SomeException, throwIO,
+import           Control.Exception                     (SomeException,
+                                                        fromException, throwIO,
                                                         try)
 import           Control.Monad                         (forM_)
 import           Database.Redis.Cluster.Client         (ClusterClient (..),
                                                         ClusterConfig (..),
                                                         closeClusterClient,
                                                         executeKeyedClusterCommand)
-import           Database.Redis.Cluster.ConnectionPool (PoolConfig (..),
+import           Database.Redis.Cluster.ConnectionPool (ConnectionPoolException (..),
+                                                        PoolConfig (..),
                                                         closePool,
                                                         withConnection)
 import           Database.Redis.Command                (showBS)
@@ -101,7 +104,7 @@ spec = describe "ConnectionPool Thread Safety" $ do
       closeClusterClient client
 
   describe "closePool" $ do
-    it "closes connections and pool remains usable for new connections" $ do
+    it "is terminal and rejects later checkouts" $ do
       client <- createTestClient
 
       -- Warm pool
@@ -110,9 +113,15 @@ spec = describe "ConnectionPool Thread Safety" $ do
       -- Close the pool
       closePool (clusterConnectionPool client)
 
-      -- After close, new operations should still work (pool creates new connections)
-      result <- executeKeyedClusterCommand client "close-test2" ["SET", "close-test2", "v2"]
-      result `shouldSatisfy` isRight
+      result <- try $
+        withConnection
+          (clusterConnectionPool client)
+          seedNode
+          testConnector
+          (\_ -> return ())
+      result `shouldSatisfy` \case
+        Left err -> fromException err == Just ConnectionPoolClosed
+        Right () -> False
 
       closeClusterClient client
 


### PR DESCRIPTION
Closes #48

## Design
- Transfers each connected plaintext/TLS transport into its `Multiplexer`, whose dedicated exactly-once finalizer survives destroy-owner cancellation and participates in the merged `Open`/`Destroying`/`Destroyed` lifecycle.
- Makes ordinary and multiplex connection pools idempotently terminal. Post-close checkout/submission returns `ConnectionPoolClosed`, `MultiplexPoolClosed`, or `ClusterClientClosed` and never reconnects.
- Makes multi-multiplexer creation/replacement and standalone/cluster construction exception-safe, including connector-index failures, replacement failure, topology parse failure, and later cluster initialization failure.
- Closes sockets on plaintext connect and TLS connect/context/handshake failure before ownership transfer.
- Documents bracket exit and explicit close as permanent teardown with exactly-once transport finalization.

## Deterministic coverage
- Cancelled destroy owner with gated transport close; resumed/repeated destroy observes exactly one close.
- Successful/repeated pool and standalone close counters plus submit-after-close connection counters.
- Connector failure at every creation index and dead-mux replacement failure cleanup.
- Cluster topology parse/later initialization cleanup and terminal keyed/keyless commands.
- Updated E2E connection-pool contract from reusable-after-close to terminal.

## Validation
- Focused `MultiplexerSpec`, `MultiplexPoolSpec`, `StandaloneSpec`, and `ClusterCommandSpec`: 83 examples, 0 failures.
- `cabal build all --enable-tests`: passed.
- `cabal build redis-client:exe:LibraryE2E -fe2e`: passed (compile only per repository policy).
- `nix-build --no-out-link`: passed.
- Code-review pass: no high-confidence lifecycle findings.

## Profile
Comparable `MultiplexerSpec +RTS -p` against the merged #47 baseline:
- allocation: 9,296,928 -> 9,436,784 bytes (+139,856, +1.5%), including the new exactly-once close test;
- `createMultiplexer` allocation share: 49.9% -> 49.3%;
- elapsed time: 0.01s -> 0.02s (10ms sampling noise at this test size).

No serious regression observed. Generated profiling and Cabal artifacts were removed.

## Review gate
Ready for Performance and Tester review. Required GitHub Actions `build` remains the full E2E merge gate. Auto-merge is not enabled.