### PR TITLE
Make connection checkout cancellation-safe

### DIFF
--- a/hask-redis-mux/bench/ConnectionPoolBench.hs
+++ b/hask-redis-mux/bench/ConnectionPoolBench.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs     #-}
+
+module Main (main) where
+
+import           Control.Concurrent                    (getNumCapabilities,
+                                                        setNumCapabilities)
+import           Control.Concurrent.Async              (mapConcurrently)
+import           Control.Monad                         (replicateM)
+import           Data.IORef                            (atomicModifyIORef',
+                                                        newIORef)
+import           Data.List                             (sort)
+import           Database.Redis.Client                 (Client (..),
+                                                        ConnectionStatus (..))
+import           Database.Redis.Cluster                (NodeAddress (..))
+import           Database.Redis.Cluster.ConnectionPool
+import           GHC.Clock                             (getMonotonicTimeNSec)
+import           System.Environment                    (getArgs)
+import           Text.Printf                           (printf)
+
+data BenchClient (a :: ConnectionStatus) where
+  BenchConnected :: BenchClient 'Connected
+
+instance Client BenchClient where
+  connect = error "unused"
+  close _ = return ()
+  send _ _ = return ()
+  receive _ = return mempty
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let requestedCapabilities =
+        case args of
+          [value] -> read value
+          _       -> 1
+  setNumCapabilities requestedCapabilities
+  capabilities <- getNumCapabilities
+  let workers = max 1 (capabilities * 8)
+      operationsPerWorker = 2000
+      totalOperations = workers * operationsPerWorker
+      config = PoolConfig 1 5 0 False
+      address = NodeAddress "benchmark" 6379
+  pool <- createPool config
+  connectionCount <- newIORef (0 :: Int)
+  let connector _ = do
+        atomicModifyIORef' connectionCount $ \count -> (count + 1, ())
+        return BenchConnected
+      oneOperation = do
+        started <- getMonotonicTimeNSec
+        withConnection pool address connector $ \_ -> return ()
+        finished <- getMonotonicTimeNSec
+        return (finished - started)
+  started <- getMonotonicTimeNSec
+  samples <- fmap concat $ mapConcurrently
+    (\_ -> replicateM operationsPerWorker oneOperation)
+    [1 .. workers]
+  finished <- getMonotonicTimeNSec
+  let sorted = sort samples
+      percentile p =
+        sorted !! min (length sorted - 1) ((length sorted * p) `div` 100)
+      seconds = fromIntegral (finished - started) / 1.0e9 :: Double
+      throughput = fromIntegral totalOperations / seconds :: Double
+  printf
+    "caps=%d workers=%d operations=%d throughput_ops_s=%.2f p95_us=%.2f p99_us=%.2f\n"
+    capabilities
+    workers
+    totalOperations
+    throughput
+    (fromIntegral (percentile 95) / 1000 :: Double)
+    (fromIntegral (percentile 99) / 1000 :: Double)
+  closePool pool

--- a/hask-redis-mux/hask-redis-mux.cabal
+++ b/hask-redis-mux/hask-redis-mux.cabal
@@ -146,6 +146,16 @@ library redis
                     , redis-command-client
                     , resp
 
+benchmark ConnectionPoolBench
+    import:           defaults
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   bench
+    main-is:          ConnectionPoolBench.hs
+    ghc-options:      -threaded -rtsopts
+    build-depends:    async >=2.2 && <2.3
+                    , client
+                    , cluster
+
 -- ---------------------------------------------------------------------------
 -- Test suites
 -- ---------------------------------------------------------------------------
@@ -198,6 +208,14 @@ test-suite MultiplexerSpec
                     , client
                     , cluster
                     , resp
+
+test-suite ConnectionPoolSpec
+    import:           test-defaults
+    type:             exitcode-stdio-1.0
+    main-is:          ConnectionPoolSpec.hs
+    build-depends:    bytestring >=0.12 && <0.13
+                    , client
+                    , cluster
 
 test-suite StandaloneSpec
     import:           test-defaults

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/ConnectionPool.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/ConnectionPool.hs
@@ -16,17 +16,23 @@
 module Database.Redis.Cluster.ConnectionPool
   ( ConnectionPool (..),
     ConnectionPoolException (..),
+    ConnectionPoolStats (..),
     PoolConfig (..),
     createPool,
     withConnection,
+    getConnectionPoolStats,
     closePool,
   )
 where
 
-import           Control.Concurrent.MVar  (MVar, modifyMVar, newEmptyMVar,
-                                           newMVar, putMVar, takeMVar)
-import           Control.Exception        (Exception, SomeException, catch,
-                                           mask, throwIO, toException, try)
+import           Control.Concurrent       (forkIOWithUnmask)
+import           Control.Concurrent.MVar  (MVar, modifyMVarMasked, newEmptyMVar,
+                                           newMVar, putMVar, readMVar, takeMVar,
+                                           withMVar)
+import           Control.Exception        (Exception, SomeException, mask,
+                                           mask_, onException, throwIO,
+                                           toException, try,
+                                           uninterruptibleMask_)
 import           Control.Monad            (forM_)
 import           Data.IORef               (IORef, newIORef, readIORef,
                                            writeIORef)
@@ -43,6 +49,14 @@ data ConnectionPoolException = ConnectionPoolClosed
 
 instance Exception ConnectionPoolException
 
+-- | A point-in-time view of one node's logical pool accounting.
+data ConnectionPoolStats = ConnectionPoolStats
+  { statsTotalConnections     :: !Int
+  , statsAvailableConnections :: !Int
+  , statsWaitingCallers       :: !Int
+  }
+  deriving (Eq, Show)
+
 -- | Configuration for the connection pool.
 data PoolConfig = PoolConfig
   { maxConnectionsPerNode :: Int  -- ^ Maximum number of connections kept per node. Callers block when all connections are in use.
@@ -56,9 +70,19 @@ data PoolConfig = PoolConfig
 data NodePool client = NodePool
   { availableConns :: [client 'Connected]    -- ^ Idle connections ready for checkout
   , totalConns     :: !Int                   -- ^ Total connections created (available + in-use)
-  , waitQueue      :: [MVar (Either SomeException (client 'Connected))]
-    -- ^ Threads waiting for a connection. Right = success, Left = pool error (retry).
+  , waitQueue      :: !(WaitQueue (Waiter client))
   }
+
+-- | Amortized O(1) FIFO with a cached size. Cancellation is the uncommon path
+-- and filters both lists, while enqueue and direct handoff avoid Seq overhead.
+data WaitQueue a = WaitQueue ![a] ![a] !Int
+
+type Waiter client = MVar (WaiterResult client)
+
+data WaiterResult client
+  = WaiterConnection !(client 'Connected)
+  | WaiterCreate
+  | WaiterFailure !SomeException
 
 -- | Thread-safe connection pool using MVar for atomic access.
 -- Each node has a pool of connections; callers check out exclusive
@@ -83,7 +107,7 @@ createPool config = do
 data CheckoutResult client
   = UseExisting (client 'Connected)                      -- ^ Reuse an idle connection
   | CreateNew                                             -- ^ Create a new connection (slot reserved)
-  | Wait (MVar (Either SomeException (client 'Connected)))  -- ^ Block until a connection is returned
+  | Wait !(Waiter client)
   | PoolIsClosed
 
 -- | Check out a connection, run an action, and return the connection to the pool.
@@ -97,16 +121,13 @@ withConnection ::
   Connector client ->
   (client 'Connected -> IO a) ->
   IO a
-withConnection pool addr connector action = do
-  conn <- checkoutConnection pool addr connector
-  result <- try (action conn)
-  case result of
-    Right val -> do
-      returnConnection pool addr conn
-      return val
-    Left (e :: SomeException) -> do
-      discardConnection pool addr conn connector
-      throwIO e
+withConnection pool addr connector action = mask $ \restore -> do
+  conn <- checkoutConnection pool addr connector restore
+  result <- restore (action conn)
+    `onException` discardConnection pool addr conn
+  returnConnection pool addr conn
+  return result
+{-# INLINE withConnection #-}
 
 -- | Check out a connection from the pool. Creates a new one if none available
 -- and the max hasn't been reached. Blocks if pool is at capacity.
@@ -115,50 +136,61 @@ checkoutConnection ::
   ConnectionPool client ->
   NodeAddress ->
   Connector client ->
+  (forall a. IO a -> IO a) ->
   IO (client 'Connected)
-checkoutConnection pool addr connector = mask $ \restore -> do
-  result <- modifyMVar (poolConnections pool) $ \m -> do
-    closed <- readIORef (poolClosed pool)
-    if closed
-      then return (m, PoolIsClosed)
+checkoutConnection pool addr connector restore = checkout
+  where
+  checkout = do
+    result <- modifyPoolState pool $ \m -> do
+      closed <- readIORef (poolClosed pool)
+      if closed
+        then return (m, PoolIsClosed)
+        else do
+          let nodePool = Map.findWithDefault emptyNodePool addr m
+          case availableConns nodePool of
+            (conn : rest) -> do
+              let updated = nodePool { availableConns = rest }
+              return (Map.insert addr updated m, UseExisting conn)
+            [] ->
+              if totalConns nodePool < maxConnectionsPerNode (poolConfig pool)
+                then do
+                  let updated = nodePool { totalConns = totalConns nodePool + 1 }
+                  return (Map.insert addr updated m, CreateNew)
+                else do
+                  waiter <- newEmptyMVar
+                  let updated = nodePool
+                        { waitQueue = enqueueWaiter waiter (waitQueue nodePool) }
+                  return (Map.insert addr updated m, Wait waiter)
+    case result of
+      PoolIsClosed -> throwIO ConnectionPoolClosed
+      UseExisting conn -> return conn
+      CreateNew -> connectReserved
+      Wait waiter -> do
+        wakeup <- takeMVar waiter
+          `onException` cancelWaiter pool addr waiter
+        case wakeup of
+          WaiterConnection conn -> return conn
+          WaiterCreate          -> connectReserved
+          WaiterFailure e       -> throwIO e
+
+  connectReserved = do
+    open <- poolIsOpen pool
+    if not open
+      then throwIO ConnectionPoolClosed
       else do
-        let nodePool = Map.findWithDefault (NodePool [] 0 []) addr m
-        case availableConns nodePool of
-          (conn : rest) -> do
-            let updated = nodePool { availableConns = rest }
-            return (Map.insert addr updated m, UseExisting conn)
-          [] ->
-            if totalConns nodePool < maxConnectionsPerNode (poolConfig pool)
-              then do
-                let updated = nodePool { totalConns = totalConns nodePool + 1 }
-                return (Map.insert addr updated m, CreateNew)
+        connResult <- try (restore $ connector addr)
+        case connResult of
+          Right conn -> do
+            accepted <- poolIsOpen pool
+            if accepted
+              then return conn
               else do
-                waiter <- newEmptyMVar
-                let updated = nodePool { waitQueue = waitQueue nodePool ++ [waiter] }
-                return (Map.insert addr updated m, Wait waiter)
-  case result of
-    PoolIsClosed -> throwIO ConnectionPoolClosed
-    UseExisting conn -> return conn
-    CreateNew -> do
-      -- Create connection outside the MVar lock
-      connResult <- try (restore $ connector addr)
-      case connResult of
-        Right conn -> do
-          accepted <- modifyMVar (poolConnections pool) $ \m -> do
-            closed <- readIORef (poolClosed pool)
-            return (m, not closed)
-          if accepted
-            then return conn
-            else do
-              close conn `catch` \(_ :: SomeException) -> return ()
-              throwIO ConnectionPoolClosed
-        Left (e :: SomeException) -> do
-          -- Creation failed — release the reserved slot
-          modifyMVar (poolConnections pool) $ \m -> do
-            let m' = Map.adjust (\np -> np { totalConns = totalConns np - 1 }) addr m
-            return (m', ())
-          throwIO e
-    Wait waiter -> restore (takeMVar waiter) >>= either throwIO return
+                safeClose conn
+                throwIO ConnectionPoolClosed
+          Left (e :: SomeException) -> do
+            releaseReservation pool addr
+            throwIO e
+{-# INLINE checkoutConnection #-}
 
 -- | Return a connection to the pool for reuse.
 -- If threads are waiting, hand the connection directly to the next waiter.
@@ -170,94 +202,199 @@ returnConnection ::
   IO ()
 returnConnection pool addr conn =
   do
-    closeReturned <- modifyMVar (poolConnections pool) $ \m -> do
-      closed <- readIORef (poolClosed pool)
-      if closed
-        then return (m, True)
-        else do
-          let nodePool = Map.findWithDefault (NodePool [] 0 []) addr m
-          case waitQueue nodePool of
-            (waiter : rest) -> do
-              putMVar waiter (Right conn)
-              let updated = nodePool { waitQueue = rest }
+    let transition = modifyPoolState pool $ returnTransition pool addr conn
+    closeReturned <- transition `onException` do
+      closeAfterCancellation <-
+        modifyPoolStateUninterruptible pool $ returnTransition pool addr conn
+      if closeAfterCancellation then safeClose conn else return ()
+    if closeReturned then safeClose conn else return ()
+{-# INLINE returnConnection #-}
+
+returnTransition
+  :: ConnectionPool client
+  -> NodeAddress
+  -> client 'Connected
+  -> Map NodeAddress (NodePool client)
+  -> IO (Map NodeAddress (NodePool client), Bool)
+returnTransition pool addr conn m = do
+  closed <- readIORef (poolClosed pool)
+  if closed
+    then return (m, True)
+    else do
+      let nodePool = Map.findWithDefault emptyNodePool addr m
+      case dequeueWaiter (waitQueue nodePool) of
+        Just (waiter, rest) -> do
+          putMVar waiter (WaiterConnection conn)
+          let updated = nodePool { waitQueue = rest }
+          return (Map.insert addr updated m, False)
+        Nothing ->
+          if length (availableConns nodePool) < maxConnectionsPerNode (poolConfig pool)
+            then do
+              let updated = nodePool { availableConns = conn : availableConns nodePool }
               return (Map.insert addr updated m, False)
-            [] ->
-              if length (availableConns nodePool) < maxConnectionsPerNode (poolConfig pool)
-                then do
-                  let updated = nodePool { availableConns = conn : availableConns nodePool }
-                  return (Map.insert addr updated m, False)
-                else do
-                  let updated = nodePool { totalConns = totalConns nodePool - 1 }
-                  return (Map.insert addr updated m, True)
-    whenClose closeReturned
-  where
-    whenClose True  = close conn `catch` \(_ :: SomeException) -> return ()
-    whenClose False = return ()
+            else do
+              let updated = nodePool { totalConns = totalConns nodePool - 1 }
+              return (Map.insert addr updated m, True)
+{-# INLINE returnTransition #-}
 
 -- | Discard a connection (on error) and wake a waiter or release the slot.
--- If threads are waiting, attempts to create a replacement connection.
--- If replacement creation fails, the waiter receives the error.
+-- If a thread is waiting, its reservation is transferred directly so it can
+-- create the replacement without tying slow connector work to this cleanup.
 discardConnection ::
   (Client client) =>
   ConnectionPool client ->
   NodeAddress ->
   client 'Connected ->
-  Connector client ->
   IO ()
-discardConnection pool addr conn connector = do
-  close conn `catch` \(_ :: SomeException) -> return ()
-  maybeWaiter <- modifyMVar (poolConnections pool) $ \m -> do
-    closed <- readIORef (poolClosed pool)
-    if closed
-      then return (m, Nothing)
-      else do
-        let nodePool = Map.findWithDefault (NodePool [] 0 []) addr m
-        case waitQueue nodePool of
-          (waiter : rest) -> do
-            let updated = nodePool { waitQueue = rest }
-            return (Map.insert addr updated m, Just waiter)
-          [] -> do
-            let updated = nodePool { totalConns = totalConns nodePool - 1 }
-            return (Map.insert addr updated m, Nothing)
-  case maybeWaiter of
-    Nothing -> return ()
-    Just waiter -> mask $ \restore -> do
-      -- Try to create a replacement connection for the waiter
-      connResult <- try (restore $ connector addr)
-      case connResult of
-        Right newConn -> do
-          accepted <- modifyMVar (poolConnections pool) $ \m -> do
-            closed <- readIORef (poolClosed pool)
-            return (m, not closed)
-          if accepted
-            then putMVar waiter (Right newConn)
-            else do
-              close newConn `catch` \(_ :: SomeException) -> return ()
-              putMVar waiter (Left $ toException ConnectionPoolClosed)
-        Left (e :: SomeException) -> do
-          -- Failed — release the reserved slot and notify waiter of the error
-          modifyMVar (poolConnections pool) $ \m -> do
-            let m' = Map.adjust (\np -> np { totalConns = totalConns np - 1 }) addr m
-            return (m', ())
-          putMVar waiter (Left e)
+discardConnection pool addr conn = do
+  releaseReservation pool addr
+  safeClose conn
+
+-- | Read logical accounting for a single node. At quiescence,
+-- @statsTotalConnections == statsAvailableConnections@ and
+-- @statsWaitingCallers == 0@.
+getConnectionPoolStats :: ConnectionPool client -> NodeAddress -> IO ConnectionPoolStats
+getConnectionPoolStats pool addr =
+  withMVar (poolConnections pool) $ \m ->
+    case Map.lookup addr m of
+      Nothing -> return $ ConnectionPoolStats 0 0 0
+      Just nodePool -> return $ ConnectionPoolStats
+        (totalConns nodePool)
+        (length $ availableConns nodePool)
+        (waitQueueLength $ waitQueue nodePool)
 
 -- | Close all connections in the pool and wake any blocked waiters.
 -- Closure is terminal and idempotent. Later checkouts throw
 -- 'ConnectionPoolClosed' rather than creating a new connection. Exceptions
 -- during transport close are caught and ignored.
 closePool :: (Client client) => ConnectionPool client -> IO ()
-closePool pool =
-  do
-    nodePools <- modifyMVar (poolConnections pool) $ \m -> do
+closePool pool = mask_ $ do
+    nodePools <- modifyPoolStateUninterruptible pool $ \m -> do
       alreadyClosed <- readIORef (poolClosed pool)
       if alreadyClosed
         then return (m, [])
         else do
           writeIORef (poolClosed pool) True
+          let closedError = toException ConnectionPoolClosed
+          forM_ (Map.elems m) $ \nodePool ->
+            forM_ (waitQueueToList $ waitQueue nodePool) $ \waiter ->
+              putMVar waiter (WaiterFailure closedError)
           return (Map.empty, Map.elems m)
-    let closedError = toException ConnectionPoolClosed
-    forM_ nodePools $ \nodePool -> do
-      forM_ (availableConns nodePool) $ \conn ->
-        close conn `catch` \(_ :: SomeException) -> return ()
-      forM_ (waitQueue nodePool) $ \waiter ->
-        putMVar waiter (Left closedError)
+    closeDone <- mapM startClose
+      [conn | nodePool <- nodePools, conn <- availableConns nodePool]
+    mapM_ readMVar closeDone
+
+emptyNodePool :: NodePool client
+emptyNodePool = NodePool [] 0 emptyWaitQueue
+
+modifyPoolState
+  :: ConnectionPool client
+  -> (Map NodeAddress (NodePool client) -> IO (Map NodeAddress (NodePool client), a))
+  -> IO a
+modifyPoolState pool action =
+  modifyMVarMasked (poolConnections pool) action
+{-# INLINE modifyPoolState #-}
+
+modifyPoolStateUninterruptible
+  :: ConnectionPool client
+  -> (Map NodeAddress (NodePool client) -> IO (Map NodeAddress (NodePool client), a))
+  -> IO a
+modifyPoolStateUninterruptible pool action =
+  uninterruptibleMask_ $ modifyMVarMasked (poolConnections pool) action
+{-# INLINE modifyPoolStateUninterruptible #-}
+
+poolIsOpen :: ConnectionPool client -> IO Bool
+poolIsOpen pool =
+  modifyPoolStateUninterruptible pool $ \m -> do
+    open <- not <$> readIORef (poolClosed pool)
+    return (m, open)
+
+releaseReservation :: ConnectionPool client -> NodeAddress -> IO ()
+releaseReservation pool addr =
+  modifyPoolStateUninterruptible pool $ \m -> do
+    closed <- readIORef (poolClosed pool)
+    if closed
+      then return (m, ())
+      else case Map.lookup addr m of
+        Nothing -> return (m, ())
+        Just nodePool ->
+          case dequeueWaiter (waitQueue nodePool) of
+            Just (waiter, rest) -> do
+              putMVar waiter WaiterCreate
+              let updated = nodePool { waitQueue = rest }
+              return (Map.insert addr updated m, ())
+            Nothing -> do
+              let updated = nodePool
+                    { totalConns = max 0 (totalConns nodePool - 1) }
+              return (Map.insert addr updated m, ())
+
+cancelWaiter
+  :: (Client client)
+  => ConnectionPool client
+  -> NodeAddress
+  -> Waiter client
+  -> IO ()
+cancelWaiter pool addr waiter = do
+  removed <- modifyPoolStateUninterruptible pool $ \m ->
+    case Map.lookup addr m of
+      Nothing -> return (m, False)
+      Just nodePool -> do
+        let (wasRemoved, remaining) = removeWaiter waiter (waitQueue nodePool)
+            updated = nodePool { waitQueue = remaining }
+        return (Map.insert addr updated m, wasRemoved)
+  if removed
+    then return ()
+    else do
+      handedOff <- uninterruptibleMask_ $ takeMVar waiter
+      case handedOff of
+        WaiterConnection conn -> returnConnection pool addr conn
+        WaiterCreate          -> releaseReservation pool addr
+        WaiterFailure _       -> return ()
+
+safeClose :: (Client client) => client 'Connected -> IO ()
+safeClose conn = do
+  done <- startClose conn
+  readMVar done
+
+startClose :: (Client client) => client 'Connected -> IO (MVar ())
+startClose conn = do
+  done <- newEmptyMVar
+  _ <- forkIOWithUnmask $ \unmask ->
+    try (unmask $ close conn) >>= \(_ :: Either SomeException ()) ->
+      putMVar done ()
+  return done
+
+emptyWaitQueue :: WaitQueue a
+emptyWaitQueue = WaitQueue [] [] 0
+
+enqueueWaiter :: a -> WaitQueue a -> WaitQueue a
+enqueueWaiter waiter (WaitQueue front rear count) =
+  WaitQueue front (waiter : rear) (count + 1)
+{-# INLINE enqueueWaiter #-}
+
+dequeueWaiter :: WaitQueue a -> Maybe (a, WaitQueue a)
+dequeueWaiter (WaitQueue (waiter : front) rear count) =
+  Just (waiter, WaitQueue front rear (count - 1))
+dequeueWaiter (WaitQueue [] rear count) =
+  case reverse rear of
+    []                -> Nothing
+    waiter : newFront -> Just (waiter, WaitQueue newFront [] (count - 1))
+{-# INLINE dequeueWaiter #-}
+
+removeWaiter :: (Eq a) => a -> WaitQueue a -> (Bool, WaitQueue a)
+removeWaiter target (WaitQueue front rear count) =
+  let remainingFront = filter (/= target) front
+      remainingRear = filter (/= target) rear
+      removedCount =
+        (length front - length remainingFront)
+          + (length rear - length remainingRear)
+  in ( removedCount /= 0
+     , WaitQueue remainingFront remainingRear (count - removedCount)
+     )
+
+waitQueueLength :: WaitQueue a -> Int
+waitQueueLength (WaitQueue _ _ count) = count
+{-# INLINE waitQueueLength #-}
+
+waitQueueToList :: WaitQueue a -> [a]
+waitQueueToList (WaitQueue front rear _) = front <> reverse rear

--- a/hask-redis-mux/lib/redis/Database/Redis.hs
+++ b/hask-redis-mux/lib/redis/Database/Redis.hs
@@ -81,8 +81,10 @@ import           Database.Redis.Cluster.Client         (ClusterClient (..),
                                                         runClusterCommandClient)
 import           Database.Redis.Cluster.ConnectionPool (ConnectionPool (..),
                                                         ConnectionPoolException (..),
+                                                        ConnectionPoolStats (..),
                                                         PoolConfig (..),
                                                         closePool, createPool,
+                                                        getConnectionPoolStats,
                                                         withConnection)
 import           Database.Redis.Command                (ClientReplyValues (..),
                                                         ClientState (..),

--- a/hask-redis-mux/test/ConnectionPoolSpec.hs
+++ b/hask-redis-mux/test/ConnectionPoolSpec.hs
@@ -1,0 +1,272 @@
+{-# LANGUAGE DataKinds  #-}
+{-# LANGUAGE GADTs      #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Main (main) where
+
+import           Control.Concurrent                    (forkFinally, forkIO,
+                                                        killThread, threadDelay)
+import           Control.Concurrent.MVar               (MVar, newEmptyMVar,
+                                                        putMVar, takeMVar)
+import           Control.Exception                     (SomeException)
+import           Control.Monad                         (forM, replicateM_)
+import           Control.Monad.IO.Class                (liftIO)
+import           Data.IORef                            (IORef,
+                                                        atomicModifyIORef',
+                                                        newIORef, readIORef)
+import           Database.Redis.Client                 (Client (..),
+                                                        ConnectionStatus (..))
+import           Database.Redis.Cluster                (NodeAddress (..))
+import           Database.Redis.Cluster.ConnectionPool
+import           System.Timeout                        (timeout)
+import           Test.Hspec
+
+data MockClient (a :: ConnectionStatus) where
+  MockConnected :: !Int -> !(IORef Int) -> MockClient 'Connected
+
+instance Client MockClient where
+  connect = error "unused"
+  close (MockConnected _ closeCount) =
+    liftIO $ atomicModifyIORef' closeCount $ \count -> (count + 1, ())
+  send _ _ = return ()
+  receive _ = return mempty
+
+data BlockingCloseClient (a :: ConnectionStatus) where
+  BlockingCloseConnected
+    :: !(MVar ())
+    -> !(MVar ())
+    -> !(MVar ())
+    -> BlockingCloseClient 'Connected
+
+instance Client BlockingCloseClient where
+  connect = error "unused"
+  close (BlockingCloseConnected started release finished) = liftIO $ do
+    putMVar started ()
+    takeMVar release
+    putMVar finished ()
+  send _ _ = return ()
+  receive _ = return mempty
+
+node :: NodeAddress
+node = NodeAddress "127.0.0.1" 6379
+
+testPoolConfig :: PoolConfig
+testPoolConfig = PoolConfig
+  { maxConnectionsPerNode = 1
+  , connectionTimeout = 5
+  , maxRetries = 0
+  , useTLS = False
+  }
+
+createCountingConnector
+  :: IO (NodeAddress -> IO (MockClient 'Connected), IORef Int, IORef Int)
+createCountingConnector = do
+  connectionCount <- newIORef 0
+  closeCount <- newIORef 0
+  let connector _ = do
+        connectionId <- atomicModifyIORef' connectionCount $ \count ->
+          let next = count + 1
+          in (next, next)
+        return $ MockConnected connectionId closeCount
+  return (connector, connectionCount, closeCount)
+
+forkResult :: IO a -> IO (MVar (Either SomeException a), IO ())
+forkResult action = do
+  result <- newEmptyMVar
+  thread <- forkFinally action (putMVar result)
+  return (result, killThread thread)
+
+awaitWaiters :: ConnectionPool client -> Int -> IO ()
+awaitWaiters pool expected = do
+  stats <- getConnectionPoolStats pool node
+  if statsWaitingCallers stats == expected
+    then return ()
+    else threadDelay 1000 >> awaitWaiters pool expected
+
+expectWithin :: IO a -> IO a
+expectWithin action =
+  timeout 2000000 action >>= \case
+    Just result -> return result
+    Nothing     -> do
+      expectationFailure "operation did not complete within two seconds"
+      fail "timeout"
+
+isRight :: Either a b -> Bool
+isRight = either (const False) (const True)
+
+main :: IO ()
+main = hspec $ describe "ConnectionPool cancellation safety" $ do
+  it "recovers capacity when connector acquisition is cancelled" $ do
+    pool <- createPool testPoolConfig
+    connectionCount <- newIORef (0 :: Int)
+    closeCount <- newIORef (0 :: Int)
+    connectorStarted <- newEmptyMVar
+    releaseConnector <- newEmptyMVar
+    let connector _ = do
+          attempt <- atomicModifyIORef' connectionCount $ \count ->
+            let next = count + 1
+            in (next, next)
+          if attempt == 1
+            then putMVar connectorStarted () >> takeMVar releaseConnector
+            else return $ MockConnected attempt closeCount
+
+    (firstResult, cancelFirst) <- forkResult $
+      withConnection pool node connector $ \_ -> return ()
+    expectWithin (takeMVar connectorStarted)
+    cancelFirst
+    firstOutcome <- expectWithin (takeMVar firstResult)
+    firstOutcome `shouldSatisfy` either (const True) (const False)
+
+    expectWithin (withConnection pool node connector $ \_ -> return ())
+    readIORef connectionCount `shouldReturn` 2
+    getConnectionPoolStats pool node
+      `shouldReturn` ConnectionPoolStats 1 1 0
+    closePool pool
+    readIORef closeCount `shouldReturn` 1
+
+  it "removes cancelled saturated waiters before direct handoff" $ do
+    pool <- createPool testPoolConfig
+    (connector, connectionCount, closeCount) <- createCountingConnector
+    holderStarted <- newEmptyMVar
+    releaseHolder <- newEmptyMVar
+    (holderResult, _) <- forkResult $
+      withConnection pool node connector $ \_ ->
+        putMVar holderStarted () >> takeMVar releaseHolder
+    expectWithin (takeMVar holderStarted)
+
+    (cancelledResult, cancelWaiterThread) <- forkResult $
+      withConnection pool node connector $ \_ -> return ()
+    expectWithin (awaitWaiters pool 1)
+    cancelWaiterThread
+    cancelledOutcome <- expectWithin (takeMVar cancelledResult)
+    cancelledOutcome `shouldSatisfy` either (const True) (const False)
+    expectWithin (awaitWaiters pool 0)
+
+    (laterResult, _) <- forkResult $
+      withConnection pool node connector $ \_ -> return ()
+    expectWithin (awaitWaiters pool 1)
+    putMVar releaseHolder ()
+    holderOutcome <- expectWithin (takeMVar holderResult)
+    holderOutcome `shouldSatisfy` isRight
+    laterOutcome <- expectWithin (takeMVar laterResult)
+    laterOutcome `shouldSatisfy` isRight
+
+    readIORef connectionCount `shouldReturn` 1
+    getConnectionPoolStats pool node
+      `shouldReturn` ConnectionPoolStats 1 1 0
+    closePool pool
+    readIORef closeCount `shouldReturn` 1
+
+  it "cannot lose a connection when cancellation waits behind return accounting" $ do
+    pool <- createPool testPoolConfig
+    (connector, connectionCount, closeCount) <- createCountingConnector
+    actionStarted <- newEmptyMVar
+    releaseAction <- newEmptyMVar
+    (ownerResult, cancelOwner) <- forkResult $
+      withConnection pool node connector $ \_ ->
+        putMVar actionStarted () >> takeMVar releaseAction
+    expectWithin (takeMVar actionStarted)
+
+    state <- takeMVar (poolConnections pool)
+    putMVar releaseAction ()
+    threadDelay 10000
+    cancellationFinished <- newEmptyMVar
+    _ <- forkIO $ cancelOwner >> putMVar cancellationFinished ()
+    putMVar (poolConnections pool) state
+    expectWithin (takeMVar cancellationFinished)
+    _ <- expectWithin (takeMVar ownerResult)
+
+    expectWithin (withConnection pool node connector $ \_ -> return ())
+    readIORef connectionCount `shouldReturn` 1
+    getConnectionPoolStats pool node
+      `shouldReturn` ConnectionPoolStats 1 1 0
+    closePool pool
+    readIORef closeCount `shouldReturn` 1
+
+  it "recovers a direct handoff when the selected waiter is cancelled" $
+    replicateM_ 25 $ do
+      pool <- createPool testPoolConfig
+      (connector, connectionCount, closeCount) <- createCountingConnector
+      holderStarted <- newEmptyMVar
+      releaseHolder <- newEmptyMVar
+      (holderResult, _) <- forkResult $
+        withConnection pool node connector $ \_ ->
+          putMVar holderStarted () >> takeMVar releaseHolder
+      expectWithin (takeMVar holderStarted)
+
+      (waiterResult, cancelSelectedWaiter) <- forkResult $
+        withConnection pool node connector $ \_ -> return ()
+      expectWithin (awaitWaiters pool 1)
+
+      state <- takeMVar (poolConnections pool)
+      putMVar releaseHolder ()
+      threadDelay 1000
+      cancelSelectedWaiter
+      putMVar (poolConnections pool) state
+
+      holderOutcome <- expectWithin (takeMVar holderResult)
+      holderOutcome `shouldSatisfy` isRight
+      waiterOutcome <- expectWithin (takeMVar waiterResult)
+      waiterOutcome `shouldSatisfy` either (const True) (const False)
+      expectWithin (withConnection pool node connector $ \_ -> return ())
+
+      readIORef connectionCount `shouldReturn` 1
+      getConnectionPoolStats pool node
+        `shouldReturn` ConnectionPoolStats 1 1 0
+      closePool pool
+      readIORef closeCount `shouldReturn` 1
+
+  it "preserves cancellation while an independent transport close finishes" $ do
+    pool <- createPool testPoolConfig
+    actionStarted <- newEmptyMVar
+    releaseAction <- newEmptyMVar
+    closeStarted <- newEmptyMVar
+    releaseClose <- newEmptyMVar
+    closeFinished <- newEmptyMVar
+    let connector _ =
+          return $ BlockingCloseConnected closeStarted releaseClose closeFinished
+
+    (ownerResult, cancelOwner) <- forkResult $
+      withConnection pool node connector $ \_ ->
+        putMVar actionStarted () >> takeMVar releaseAction
+    expectWithin (takeMVar actionStarted)
+    closePool pool
+    putMVar releaseAction ()
+    expectWithin (takeMVar closeStarted)
+    cancelOwner
+    ownerOutcome <- expectWithin (takeMVar ownerResult)
+    ownerOutcome `shouldSatisfy` either (const True) (const False)
+    putMVar releaseClose ()
+    expectWithin (takeMVar closeFinished)
+
+  it "preserves accounting after a saturated cancellation storm" $ do
+    pool <- createPool testPoolConfig
+    (connector, connectionCount, closeCount) <- createCountingConnector
+    holderStarted <- newEmptyMVar
+    releaseHolder <- newEmptyMVar
+    (holderResult, _) <- forkResult $
+      withConnection pool node connector $ \_ ->
+        putMVar holderStarted () >> takeMVar releaseHolder
+    expectWithin (takeMVar holderStarted)
+
+    waiters <- forM [1 .. 64 :: Int] $ \_ ->
+      forkResult $ withConnection pool node connector $ \_ -> return ()
+    expectWithin (awaitWaiters pool 64)
+    mapM_ snd (take 32 waiters)
+    mapM_ (expectWithin . takeMVar . fst) (take 32 waiters)
+    expectWithin (awaitWaiters pool 32)
+
+    putMVar releaseHolder ()
+    holderOutcome <- expectWithin (takeMVar holderResult)
+    holderOutcome `shouldSatisfy` isRight
+    mapM_ (\(result, _) -> do
+      outcome <- expectWithin (takeMVar result)
+      outcome `shouldSatisfy` isRight) (drop 32 waiters)
+
+    replicateM_ 16 $
+      expectWithin (withConnection pool node connector $ \_ -> return ())
+    readIORef connectionCount `shouldReturn` 1
+    getConnectionPoolStats pool node
+      `shouldReturn` ConnectionPoolStats 1 1 0
+    closePool pool
+    readIORef closeCount `shouldReturn` 1


### PR DESCRIPTION
## Summary

Closes #51.

Makes connection checkout, use, return, waiter registration, direct handoff, and reservation transfer exception-safe under asynchronous cancellation without putting connector or transport-close work under the pool state lock.

## Concurrency design

- Wraps acquire/use/release in one masked lifecycle and restores async exceptions during connector and user work.
- Represents waiter ownership explicitly as an existing connection, a transferred creation reservation, or a terminal failure.
- Removes a cancelled waiter before handoff, or recovers and returns/releases ownership when handoff wins the race.
- Transfers failed or cancelled connector reservations to the next FIFO waiter so `totalConns` capacity cannot be stranded.
- Uses a two-list FIFO with O(1) enqueue and amortized O(1) dequeue; the uncommon cancellation removal path is O(n).
- Completes state accounting before physical close. Close operations run in independent workers outside the global state lock, preserving caller cancellation.
- Starts every idle close during terminal pool shutdown before waiting, so cancellation cannot skip later resources.

## Lifecycle invariants

`totalConns` always accounts for capacity that is available, checked out, or reserved by a connector. At quiescence, tests require:

- `totalConnections == availableConnections`
- `waitingCallers == 0`

The new public `ConnectionPoolStats` snapshot supports deterministic invariant checks without exposing internal connection values.

## Focused tests

Added deterministic coverage for:

- cancellation while holding a connector reservation
- removal of a cancelled saturated waiter
- cancellation blocked behind return accounting
- direct-handoff/cancel races across 25 repetitions
- cancellation preservation while transport close continues independently
- a 64-waiter saturation/cancellation storm with recovered capacity

The focused suite was exercised with both `-N1` and `-N4`. `ClusterCommandSpec`, `nix-build --no-out-link`, and `make test-unit` also pass. Per repository policy, full E2E is delegated to the required GitHub Actions `build` gate.

## Benchmark and profile comparison

Comparable benchmark medians using the same Cabal/compiler path:

| Runtime | Throughput before | Throughput after | p95 before | p95 after | p99 before | p99 after |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `-N1` | 456,155 ops/s | 454,430 ops/s (-0.4%) | 32.46 us | 32.02 us | 44.64 us | 45.45 us |
| `-N4` | 79,577 ops/s | 81,210 ops/s (+2.1%) | 483.94 us | 467.38 us | 683.61 us | 681.24 us |

Identical `-p` benchmark profiles show allocation decreasing from 37,637,464 to 32,061,568 bytes (-14.8%), with sampled time unchanged at 0.04 seconds. Profiling artifacts were removed from the worktree.

## Review gate

Lead and Tester must review this change. Do not merge until both lifecycle/accounting behavior and deterministic cancellation coverage are approved.
