### PR TITLE
Enforce connection setup deadlines and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
     *   Credentialed plaintext connections are rejected unless `--allow-insecure-plaintext-auth` is supplied.
     *   The plaintext-auth override emits a warning naming the target and stating that credentials are unencrypted.
     *   `REDIS_CLIENT_TLS_INSECURE` disables certificate verification only when set to exactly `1`; false values preserve verification and invalid values fail.
+*   **Bounded connection setup**
+    *   `PoolConfig.connectionTimeout` now bounds DNS, TCP connect, and TLS context/handshake setup for every cluster connection attempt.
+    *   Setup timeouts preserve the transport phase and endpoint in `ConnectionSetupTimeout` and participate in bounded cluster retries.
+    *   Plaintext and TLS setup failures close partially allocated sockets; the separate 300-second post-connect receive timeout is unchanged.
 
 ## 0.6.0.0 -- 2026-02-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@
     *   The plaintext-auth override emits a warning naming the target and stating that credentials are unencrypted.
     *   `REDIS_CLIENT_TLS_INSECURE` disables certificate verification only when set to exactly `1`; false values preserve verification and invalid values fail.
 *   **Bounded connection setup**
-    *   `PoolConfig.connectionTimeout` now bounds DNS, TCP connect, and TLS context/handshake setup for every cluster connection attempt.
+    *   `PoolConfig.connectionTimeout` now uses a supervised wall-clock deadline for DNS, TCP connect, and TLS context/handshake setup.
+    *   The executable applies the same deadline through AUTH and across cluster, standalone, benchmark, fill, flush, and pinned-tunnel paths.
+    *   Timeout cleanup aborts failed TLS setup instead of waiting for graceful `bye`, with exactly-once registered transport cleanup.
     *   Setup timeouts preserve the transport phase and endpoint in `ConnectionSetupTimeout` and participate in bounded cluster retries.
+    *   Added timeout-aware direct helpers; legacy raw connector helpers remain intentionally unbounded for API compatibility.
     *   Plaintext and TLS setup failures close partially allocated sockets; the separate 300-second post-connect receive timeout is unchanged.
 
 ## 0.6.0.0 -- 2026-02-13

--- a/app/AppConfig.hs
+++ b/app/AppConfig.hs
@@ -13,19 +13,25 @@ module AppConfig
   , runCommandsAgainstPlaintextHost
   ) where
 
-import           Control.Exception      (bracket)
-import qualified Control.Monad.State    as State
-import           CredentialConfig       (resolveRedisPassword)
-import qualified Data.ByteString        as BS
-import qualified Data.ByteString.Char8  as BS8
-import           Database.Redis.Client  (Client (..),
-                                         PlainTextClient (NotConnectedPlainTextClient),
-                                         TLSClient (..))
-import           Database.Redis.Command (ClientState (..),
-                                         RedisCommandClient (..),
-                                         RedisCommands (..))
-import           Database.Redis.Resp    (RespData (..))
-import           System.IO              (hPutStrLn, stderr)
+import           Control.Exception        (bracket, onException)
+import qualified Control.Monad.State      as State
+import           CredentialConfig         (resolveRedisPassword)
+import qualified Data.ByteString          as BS
+import qualified Data.ByteString.Char8    as BS8
+import           Data.Maybe               (fromMaybe)
+import           Database.Redis.Client    (Client (..), ConnectionPhase (..),
+                                           ConnectionStatus (..),
+                                           PlainTextClient, TLSClient,
+                                           connectPlaintextWithCleanup,
+                                           connectTLSWithCleanup)
+import           Database.Redis.Cluster   (NodeAddress (..))
+import           Database.Redis.Command   (ClientState (..),
+                                           RedisCommandClient (..),
+                                           RedisCommands (..))
+import           Database.Redis.Connector (ConnectionSupervisor (..),
+                                           withConnectionTimeoutSupervised)
+import           Database.Redis.Resp      (RespData (..))
+import           System.IO                (hPutStrLn, stderr)
 
 data RunState = RunState
   { host                       :: String,
@@ -112,13 +118,61 @@ authenticate uname pwd = do
 
 runCommandsAgainstTLSHost :: RunState -> RedisCommandClient TLSClient a -> IO a
 runCommandsAgainstTLSHost st action = do
-  bracket (connect (NotConnectedTLSClient (host st) (port st))) close $ \client -> do
-    State.evalStateT (runRedisCommandClient (authenticate (username st) (password st) >> action)) (ClientState client BS.empty)
+  bracket (connectTLSHost st) close $ \client -> do
+    State.evalStateT
+      (runRedisCommandClient action)
+      (ClientState client BS.empty)
 
 runCommandsAgainstPlaintextHost :: RunState -> RedisCommandClient PlainTextClient a -> IO a
 runCommandsAgainstPlaintextHost st action = do
   enforcePlaintextAuthenticationPolicy st
-  bracket
-    (connect $ NotConnectedPlainTextClient (host st) (port st))
-    close
-    $ \client -> State.evalStateT (runRedisCommandClient (authenticate (username st) (password st) >> action)) (ClientState client BS.empty)
+  bracket (connectPlaintextHost st) close
+    $ \client -> State.evalStateT
+        (runRedisCommandClient action)
+        (ClientState client BS.empty)
+
+connectTLSHost :: RunState -> IO (TLSClient 'Connected)
+connectTLSHost st =
+  withConnectionTimeoutSupervised 300 DNSResolution
+    (\supervisor _ -> do
+      client <- connectTLSWithCleanup
+        (setConnectionPhase supervisor)
+        (registerSetupCleanup supervisor)
+        (host st)
+        (host st)
+        (port st)
+      authenticateConnected st supervisor client)
+    endpoint
+  where
+    endpoint = NodeAddress (host st) $ fromMaybe 6380 (port st)
+
+connectPlaintextHost :: RunState -> IO (PlainTextClient 'Connected)
+connectPlaintextHost st =
+  withConnectionTimeoutSupervised 300 DNSResolution
+    (\supervisor _ -> do
+      client <- connectPlaintextWithCleanup
+        (setConnectionPhase supervisor)
+        (registerSetupCleanup supervisor)
+        (host st)
+        (port st)
+      authenticateConnected st supervisor client)
+    endpoint
+  where
+    endpoint = NodeAddress (host st) $ fromMaybe 6379 (port st)
+
+authenticateConnected
+  :: (Client client)
+  => RunState
+  -> ConnectionSupervisor client
+  -> client 'Connected
+  -> IO (client 'Connected)
+authenticateConnected st supervisor client = do
+  cleanup <- registerConnectedTransport supervisor client
+  setConnectionPhase supervisor Authentication
+  (do
+      _ <- State.evalStateT
+        (runRedisCommandClient $
+          authenticate (username st) (password st))
+        (ClientState client BS.empty)
+      return client)
+    `onException` cleanup

--- a/app/ClusterFiller.hs
+++ b/app/ClusterFiller.hs
@@ -9,7 +9,8 @@ import           Control.Concurrent                 (MVar, forkIO, newEmptyMVar,
                                                      putMVar, takeMVar,
                                                      threadDelay)
 import           Control.Concurrent.STM             (readTVarIO)
-import           Control.Exception                  (SomeException, catch)
+import           Control.Exception                  (SomeException, bracket,
+                                                     catch)
 import           Control.Monad                      (when)
 import qualified Control.Monad.State                as State
 import qualified Data.ByteString                    as BS
@@ -59,7 +60,7 @@ fillClusterWithData ::
   Int ->              -- Value size in bytes
   Int ->              -- Pipeline batch size
   IO ()
-fillClusterWithData clusterClient connector totalGB threadsPerNode baseSeed keySize valueSize pipelineBatchSize = do
+fillClusterWithData clusterClient _connector totalGB threadsPerNode baseSeed keySize valueSize pipelineBatchSize = do
   -- Get cluster topology to find master nodes
   topology <- readTVarIO (clusterTopology clusterClient)
   let masterNodes = [node | node <- Map.elems (topologyNodes topology), nodeRole node == Master]
@@ -87,7 +88,10 @@ fillClusterWithData clusterClient connector totalGB threadsPerNode baseSeed keyS
                        (zip [0..] masterNodes)
 
   -- Execute jobs in parallel
-  mvars <- mapM (executeJob clusterClient connector slotRanges baseSeed keySize valueSize pipelineBatchSize) jobs
+  mvars <- mapM
+    (executeJob clusterClient (clusterConnector clusterClient)
+      slotRanges baseSeed keySize valueSize pipelineBatchSize)
+    jobs
   mapM_ takeMVar mvars
 
   putStrLn "Cluster fill complete!"
@@ -149,26 +153,25 @@ executeJob clusterClient connector slotRanges baseSeed keySize valueSize pipelin
 
           -- Create a unique connection for this thread using connector directly
           -- This avoids connection pool contention where threads share connections
-          conn <- connector addr
+          bracket (connector addr) close $ \conn -> do
+            -- Find which slots this node owns
+            topology <- readTVarIO (clusterTopology clusterClient)
+            let masters = [node | node <- Map.elems (topologyNodes topology), nodeRole node == Master]
+                maybeNode = findNodeByAddress masters addr
 
-          -- Find which slots this node owns
-          topology <- readTVarIO (clusterTopology clusterClient)
-          let masters = [node | node <- Map.elems (topologyNodes topology), nodeRole node == Master]
-              maybeNode = findNodeByAddress masters addr
+            case maybeNode of
+              Nothing -> do
+                printf "Warning: Could not find node for address %s:%d\n"
+                       (nodeHost addr) (nodePort addr)
+              Just node -> do
+                let nId = nodeId node
+                    slots = Map.findWithDefault [] nId slotRanges
 
-          case maybeNode of
-            Nothing -> do
-              printf "Warning: Could not find node for address %s:%d\n"
-                     (nodeHost addr) (nodePort addr)
-            Just node -> do
-              let nId = nodeId node
-                  slots = Map.findWithDefault [] nId slotRanges
+                when (null slots) $ do
+                  printf "Warning: Node %s has no assigned slots\n" (BS8.unpack nId)
 
-              when (null slots) $ do
-                printf "Warning: Node %s has no assigned slots\n" (BS8.unpack nId)
-
-              -- Fill data for this node using its slots
-              fillNodeWithData conn slots mbToFill baseSeed threadIdx keySize valueSize pipelineBatchSize
+                -- Fill data for this node using its slots
+                fillNodeWithData conn slots mbToFill baseSeed threadIdx keySize valueSize pipelineBatchSize
           ) (\e -> do
             -- If any exception occurs, log it and continue
             printf "Error in thread %d for node %s:%d: %s\n"

--- a/app/ClusterSetup.hs
+++ b/app/ClusterSetup.hs
@@ -3,8 +3,11 @@
 
 module ClusterSetup
   ( authenticateClient
+  , createAuthenticatedConnectorWithTimeout
   , createPlaintextConnector
+  , createPlaintextConnectorWithTimeout
   , createTLSConnector
+  , createTLSConnectorWithTimeout
   , createClusterClientFromState
   , flushAllClusterNodes
   ) where
@@ -18,23 +21,28 @@ import qualified Control.Monad.State                   as State
 import qualified Data.ByteString                       as BS
 import qualified Data.Map.Strict                       as Map
 import           Data.Maybe                            (fromMaybe)
-import           Database.Redis.Client                 (Client (close, connect),
+import           Database.Redis.Client                 (Client (abort),
+                                                        ConnectionPhase (..),
                                                         ConnectionStatus (..),
                                                         PlainTextClient (..),
-                                                        TLSClient (..))
+                                                        TLSClient (..),
+                                                        connectPlaintextWithCleanup,
+                                                        connectTLSWithCleanup)
 import           Database.Redis.Cluster                (ClusterNode (..),
                                                         ClusterTopology (..),
                                                         NodeAddress (..),
                                                         NodeRole (..))
 import           Database.Redis.Cluster.Client         (ClusterClient (..),
                                                         ClusterConfig (..),
-                                                        createClusterClient)
+                                                        createClusterClientWithBoundedConnector)
 import           Database.Redis.Cluster.ConnectionPool (PoolConfig (PoolConfig))
 import qualified Database.Redis.Cluster.ConnectionPool as CP
 import           Database.Redis.Command                (ClientState (ClientState),
                                                         RedisCommands (flushAll))
 import qualified Database.Redis.Command                as RedisCommand
-import           Database.Redis.Connector              (Connector)
+import           Database.Redis.Connector              (ConnectionSupervisor (..),
+                                                        Connector,
+                                                        withConnectionTimeoutSupervised)
 import           Database.Redis.Resp                   (RespData)
 import           Text.Printf                           (printf)
 
@@ -42,27 +50,75 @@ import           Text.Printf                           (printf)
 authenticateClient :: (Client client) => RunState -> client 'Connected -> IO (client 'Connected)
 authenticateClient state client
   | null (password state) = return client
-  | otherwise = (do
+  | otherwise =
+      runAuthentication state client
+      `onException` abort client
+
+runAuthentication
+  :: (Client client)
+  => RunState
+  -> client 'Connected
+  -> IO (client 'Connected)
+runAuthentication state client
+  | null (password state) = return client
+  | otherwise = do
       _ <- State.evalStateT
              (RedisCommand.runRedisCommandClient (authenticate (username state) (password state)))
              (ClientState client BS.empty)
-      return client)
-      `onException` close client
+      return client
 
 -- | Create cluster connector for plaintext connections
 createPlaintextConnector :: RunState -> Connector PlainTextClient
-createPlaintextConnector state addr = do
-  enforcePlaintextAuthenticationPolicy state
-  client <- connect $ NotConnectedPlainTextClient (nodeHost addr) (Just $ nodePort addr)
-  authenticateClient state client
+createPlaintextConnector = createPlaintextConnectorWithTimeout 300
+
+createPlaintextConnectorWithTimeout
+  :: Int
+  -> RunState
+  -> Connector PlainTextClient
+createPlaintextConnectorWithTimeout seconds state =
+  createAuthenticatedConnectorWithTimeout seconds state $ \supervisor addr -> do
+      enforcePlaintextAuthenticationPolicy state
+      connectPlaintextWithCleanup
+        (setConnectionPhase supervisor)
+        (registerSetupCleanup supervisor)
+        (nodeHost addr)
+        (Just $ nodePort addr)
 
 -- | Create cluster connector for TLS connections
 -- Uses the original seed hostname for TLS certificate validation to avoid
 -- hostname mismatch errors when CLUSTER SLOTS returns IP addresses
 createTLSConnector :: RunState -> Connector TLSClient
-createTLSConnector state addr = do
-  client <- connect $ NotConnectedTLSClientWithHostname (host state) (nodeHost addr) (Just $ nodePort addr)
-  authenticateClient state client
+createTLSConnector = createTLSConnectorWithTimeout 300
+
+createTLSConnectorWithTimeout
+  :: Int
+  -> RunState
+  -> Connector TLSClient
+createTLSConnectorWithTimeout seconds state =
+  createAuthenticatedConnectorWithTimeout seconds state $ \supervisor addr ->
+    connectTLSWithCleanup
+      (setConnectionPhase supervisor)
+      (registerSetupCleanup supervisor)
+      (host state)
+      (nodeHost addr)
+      (Just $ nodePort addr)
+
+-- | Production connector seam shared by plaintext, TLS, and deterministic
+-- authentication tests. Transport ownership is registered before AUTH.
+createAuthenticatedConnectorWithTimeout
+  :: (Client client)
+  => Int
+  -> RunState
+  -> (ConnectionSupervisor client
+      -> NodeAddress
+      -> IO (client 'Connected))
+  -> Connector client
+createAuthenticatedConnectorWithTimeout seconds state connectTransport =
+  withConnectionTimeoutSupervised seconds DNSResolution $ \supervisor addr -> do
+    client <- connectTransport supervisor addr
+    cleanup <- registerConnectedTransport supervisor client
+    setConnectionPhase supervisor Authentication
+    runAuthentication state client `onException` cleanup
 
 -- | Create a cluster client from RunState
 createClusterClientFromState :: (Client client) =>
@@ -85,14 +141,14 @@ createClusterClientFromState state connector = do
         , clusterRetryDelay = 100000  -- 100ms
         , clusterTopologyRefreshInterval = 600  -- 10 minutes
         }
-  createClusterClient clusterCfg connector
+  createClusterClientWithBoundedConnector clusterCfg connector
 
 -- | Flush all master nodes in a cluster
 flushAllClusterNodes :: (Client client) =>
   ClusterClient client ->
   Connector client ->
   IO ()
-flushAllClusterNodes clusterClient connector = do
+flushAllClusterNodes clusterClient _connector = do
   topology <- readTVarIO (clusterTopology clusterClient)
   let masterNodes = [node | node <- Map.elems (topologyNodes topology), nodeRole node == Master]
 
@@ -101,7 +157,10 @@ flushAllClusterNodes clusterClient connector = do
   mapM_ (\node -> do
       let addr = nodeAddress node
       printf "  Flushing node %s:%d\n" (nodeHost addr) (nodePort addr)
-      CP.withConnection (clusterConnectionPool clusterClient) addr connector $ \conn -> do
+      CP.withConnectionBounded
+        (clusterConnectionPool clusterClient)
+        addr
+        (clusterConnector clusterClient) $ \conn -> do
         let clientState = ClientState conn BS.empty
         (_ :: RespData) <- State.evalStateT (RedisCommand.runRedisCommandClient flushAll) clientState
         return ()

--- a/app/ClusterSetup.hs
+++ b/app/ClusterSetup.hs
@@ -13,11 +13,12 @@ import           AppConfig                             (RunState (..),
                                                         authenticate,
                                                         enforcePlaintextAuthenticationPolicy)
 import           Control.Concurrent.STM                (readTVarIO)
+import           Control.Exception                     (onException)
 import qualified Control.Monad.State                   as State
 import qualified Data.ByteString                       as BS
 import qualified Data.Map.Strict                       as Map
 import           Data.Maybe                            (fromMaybe)
-import           Database.Redis.Client                 (Client (connect),
+import           Database.Redis.Client                 (Client (close, connect),
                                                         ConnectionStatus (..),
                                                         PlainTextClient (..),
                                                         TLSClient (..))
@@ -41,11 +42,12 @@ import           Text.Printf                           (printf)
 authenticateClient :: (Client client) => RunState -> client 'Connected -> IO (client 'Connected)
 authenticateClient state client
   | null (password state) = return client
-  | otherwise = do
+  | otherwise = (do
       _ <- State.evalStateT
              (RedisCommand.runRedisCommandClient (authenticate (username state) (password state)))
              (ClientState client BS.empty)
-      return client
+      return client)
+      `onException` close client
 
 -- | Create cluster connector for plaintext connections
 createPlaintextConnector :: RunState -> Connector PlainTextClient

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -556,7 +556,8 @@ bench state = do
 benchWithConnector :: (Client client) => RunState -> Connector client -> String -> Int -> Int -> Int -> Int -> IO ()
 benchWithConnector state connector op duration nConns kSize vSize = do
   clusterClient <- createClusterClientFromState state connector
-  muxPool <- createMultiplexPool connector (muxCount state)
+  muxPool <- createMultiplexPool
+    (clusterConnector clusterClient) (muxCount state)
 
   -- Pre-populate keys for GET and mixed workloads
   when (op `elem` ["get", "mixed"]) $ do

--- a/hask-redis-mux/README.md
+++ b/hask-redis-mux/README.md
@@ -112,15 +112,43 @@ verification; other values are rejected instead of silently weakening TLS.
 `PoolConfig.connectionTimeout` is a per-attempt wall-clock deadline in seconds.
 For plaintext connections it covers DNS resolution, socket creation/options,
 and TCP connect. For TLS connections it covers those phases plus certificate
-store loading, TLS context creation, and the TLS handshake. A timed-out setup
-throws `ConnectionSetupTimeout`, which records the endpoint and whether the
-attempt was plaintext or TLS without including credentials.
+store loading, TLS context creation, and the TLS handshake. The redis-client
+executable also includes AUTH in the same deadline. A timed-out setup throws
+`ConnectionSetupTimeout`, which records the endpoint and active phase without
+including credentials.
 
 Cluster multiplexers and ordinary pooled connections use the same deadline.
+The cluster client retains that bounded connector for benchmark, fill, flush,
+and pinned-tunnel connections rather than falling back to the raw connector.
 Timeout retries are bounded by `clusterMaxRetries`; the total worst-case
 connection time is the per-attempt deadline multiplied by the retry count, plus
 configured retry backoff. Timeout retries do not start an additional topology
 refresh connection.
+
+The low-level `connectPlaintext`, `connectTLS`, `clusterPlaintextConnector`, and
+`clusterTLSConnector` helpers are intentionally unbounded because they do not
+take timeout configuration. Direct callers should use the timeout-aware
+variants:
+
+```haskell
+conn <- connectTLSWithTimeout 5 "redis.example.net" 6380
+
+let standaloneConfig = defaultStandaloneConfig
+      { standaloneConnector = clusterPlaintextConnectorWithTimeout 5 }
+withStandaloneClient standaloneConfig $ \client ->
+  runStandaloneClient client ping
+```
+
+`withConnectionTimeoutSupervised` is available for custom connectors. Register
+the connected transport before a potentially blocking AUTH phase so expiry can
+abort the socket without waiting for graceful TLS shutdown.
+
+The caller-side deadline is independent of asynchronous exception delivery.
+The supervisor returns at the configured wall-clock boundary, requests worker
+cancellation, and aborts any registered transport. A platform resolver or TLS
+FFI call that is genuinely non-interruptible may transiently keep its worker
+alive until that call returns; no connection returned after expiry is exposed,
+and any owned socket is closed as soon as it is available.
 
 The existing 300-second `receive` timeout applies only after a connection has
 been established. It is independent of `connectionTimeout` and is not part of

--- a/hask-redis-mux/README.md
+++ b/hask-redis-mux/README.md
@@ -107,6 +107,25 @@ only, set `REDIS_CLIENT_TLS_INSECURE=1` to disable verification. The client emit
 a warning whenever the bypass is active. Unset, empty, `0`, and `false` preserve
 verification; other values are rejected instead of silently weakening TLS.
 
+## Connection Setup Timeouts
+
+`PoolConfig.connectionTimeout` is a per-attempt wall-clock deadline in seconds.
+For plaintext connections it covers DNS resolution, socket creation/options,
+and TCP connect. For TLS connections it covers those phases plus certificate
+store loading, TLS context creation, and the TLS handshake. A timed-out setup
+throws `ConnectionSetupTimeout`, which records the endpoint and whether the
+attempt was plaintext or TLS without including credentials.
+
+Cluster multiplexers and ordinary pooled connections use the same deadline.
+Timeout retries are bounded by `clusterMaxRetries`; the total worst-case
+connection time is the per-attempt deadline multiplied by the retry count, plus
+configured retry backoff. Timeout retries do not start an additional topology
+refresh connection.
+
+The existing 300-second `receive` timeout applies only after a connection has
+been established. It is independent of `connectionTimeout` and is not part of
+the setup or retry budget.
+
 ## Documentation
 
 - [Haddock API docs](https://hackage.haskell.org/package/hask-redis-mux)

--- a/hask-redis-mux/hask-redis-mux.cabal
+++ b/hask-redis-mux/hask-redis-mux.cabal
@@ -81,8 +81,8 @@ library client
     import:           defaults
     hs-source-dirs:   lib/client
     exposed-modules:  Database.Redis.Client
-    other-modules:    Database.Redis.Client.ConnectionSetup
-                    , Database.Redis.Client.TLSConfig
+                    , Database.Redis.Client.ConnectionSetup
+    other-modules:    Database.Redis.Client.TLSConfig
     build-depends:    bytestring >=0.12 && <0.13
                     , crypton-x509-system >=1.6 && <1.7
                     , data-default-class >=0.1 && <0.3
@@ -183,9 +183,11 @@ test-suite ConnectionSetupSpec
     import:           test-defaults
     type:             exitcode-stdio-1.0
     main-is:          ConnectionSetupSpec.hs
-    other-modules:    Database.Redis.Client.ConnectionSetup
-    hs-source-dirs:   test
-                    , lib/client
+    build-depends:    bytestring >=0.12 && <0.13
+                    , client
+                    , cluster
+                    , stm
+                    , time
 
 test-suite ClusterSpec
     import:           test-defaults

--- a/hask-redis-mux/hask-redis-mux.cabal
+++ b/hask-redis-mux/hask-redis-mux.cabal
@@ -81,7 +81,8 @@ library client
     import:           defaults
     hs-source-dirs:   lib/client
     exposed-modules:  Database.Redis.Client
-    other-modules:    Database.Redis.Client.TLSConfig
+    other-modules:    Database.Redis.Client.ConnectionSetup
+                    , Database.Redis.Client.TLSConfig
     build-depends:    bytestring >=0.12 && <0.13
                     , crypton-x509-system >=1.6 && <1.7
                     , data-default-class >=0.1 && <0.3
@@ -175,6 +176,14 @@ test-suite TLSConfigSpec
     type:             exitcode-stdio-1.0
     main-is:          TLSConfigSpec.hs
     other-modules:    Database.Redis.Client.TLSConfig
+    hs-source-dirs:   test
+                    , lib/client
+
+test-suite ConnectionSetupSpec
+    import:           test-defaults
+    type:             exitcode-stdio-1.0
+    main-is:          ConnectionSetupSpec.hs
+    other-modules:    Database.Redis.Client.ConnectionSetup
     hs-source-dirs:   test
                     , lib/client
 

--- a/hask-redis-mux/hask-redis-mux.cabal
+++ b/hask-redis-mux/hask-redis-mux.cabal
@@ -189,6 +189,12 @@ test-suite ConnectionSetupSpec
                     , stm
                     , time
 
+test-suite PublicApiSpec
+    import:           test-defaults
+    type:             exitcode-stdio-1.0
+    main-is:          PublicApiSpec.hs
+    build-depends:    redis
+
 test-suite ClusterSpec
     import:           test-defaults
     type:             exitcode-stdio-1.0

--- a/hask-redis-mux/lib/client/Database/Redis/Client.hs
+++ b/hask-redis-mux/lib/client/Database/Redis/Client.hs
@@ -12,6 +12,13 @@
 -- @since 0.1.0.0
 module Database.Redis.Client
   ( Client (..)
+  , CleanupRegistrar
+  , ConnectionPhase (..)
+  , PhaseSetter
+  , connectPlaintextWithCleanup
+  , connectPlaintextWithPhases
+  , connectTLSWithCleanup
+  , connectTLSWithPhases
   , serve
   , PlainTextClient (NotConnectedPlainTextClient)
   , TLSClient (NotConnectedTLSClient, NotConnectedTLSClientWithHostname, TLSTunnel)
@@ -26,10 +33,18 @@ import qualified Data.ByteString                       as BS
 import qualified Data.ByteString.Char8                 as BS8
 import qualified Data.ByteString.Lazy                  as LBS
 import           Data.Default.Class                    (def)
+import           Data.IORef                            (atomicModifyIORef',
+                                                        newIORef)
 import           Data.IP                               (IPv4, toHostAddress)
 import           Data.Kind                             (Type)
 import           Data.Word                             (Word32)
-import           Database.Redis.Client.ConnectionSetup (withSetupResource)
+import           Database.Redis.Client.ConnectionSetup (CleanupRegistrar,
+                                                        ConnectionPhase (..),
+                                                        PhaseSetter,
+                                                        PlaintextSetupOperations (..),
+                                                        TLSSetupOperations (..),
+                                                        runPlaintextSetup,
+                                                        runTLSSetup)
 import           Database.Redis.Client.TLSConfig       (parseTLSVerificationBypass,
                                                         tlsInsecureEnvironmentVariable)
 import           Network.DNS                           (defaultResolvConf,
@@ -80,6 +95,9 @@ data ConnectionStatus = Connected | NotConnected | Server
 class Client (client :: ConnectionStatus -> Type) where
   connect :: (MonadIO m) => client 'NotConnected -> m (client 'Connected)
   close :: (MonadIO m) => client 'Connected -> m ()
+  -- | Abort a failed or timed-out setup without graceful protocol shutdown.
+  abort :: (MonadIO m) => client 'Connected -> m ()
+  abort = close
   send :: (MonadIO m) => client 'Connected -> LBS.ByteString -> m ()
   -- | Send multiple strict ByteString chunks via vectored I/O (writev).
   -- Default implementation falls back to 'send' with lazy concatenation.
@@ -92,31 +110,26 @@ class Client (client :: ConnectionStatus -> Type) where
 -- a hostname and optional port (defaults to 6379).
 data PlainTextClient (a :: ConnectionStatus) where
   NotConnectedPlainTextClient :: String -> Maybe Int -> PlainTextClient 'NotConnected
-  ConnectedPlainTextClient :: String -> Word32 -> Socket -> PlainTextClient 'Connected
+  ConnectedPlainTextClient :: String -> Word32 -> Socket -> IO () -> PlainTextClient 'Connected
 
 instance Client PlainTextClient where
   connect :: (MonadIO m) => PlainTextClient 'NotConnected -> m (PlainTextClient 'Connected)
-  connect (NotConnectedPlainTextClient hostname port) = liftIO $
-    withSetupResource
-      (createSocket hostname $ maybe 6379 fromIntegral port)
-      (S.close . fst) $ \(sock, ipCorrectEndian) -> do
-        S.connect sock (SockAddrInet (maybe 6379 fromIntegral port) ipCorrectEndian) `catch` \(e :: IOException) -> do
-          printf "Wasn't able to connect to the server: %s...\n" (show e)
-          putStrLn "Tried to use a plain text socket on port 6379. Did you mean to use TLS on port 6380?"
-          throwIO e
-        return $ ConnectedPlainTextClient hostname ipCorrectEndian sock
+  connect (NotConnectedPlainTextClient hostname port) =
+    liftIO $ connectPlaintextWithPhases (const $ return ()) hostname port
 
   close :: (MonadIO m) => PlainTextClient 'Connected -> m ()
-  close (ConnectedPlainTextClient _ _ sock) = liftIO $ S.close sock
+  close (ConnectedPlainTextClient _ _ _ cleanup) = liftIO cleanup
+
+  abort (ConnectedPlainTextClient _ _ _ cleanup) = liftIO cleanup
 
   send :: (MonadIO m) => PlainTextClient 'Connected -> LBS.ByteString -> m ()
-  send (ConnectedPlainTextClient _ _ sock) dat = liftIO $ sendAll sock dat
+  send (ConnectedPlainTextClient _ _ sock _) dat = liftIO $ sendAll sock dat
 
   sendChunks :: (MonadIO m) => PlainTextClient 'Connected -> [BS.ByteString] -> m ()
-  sendChunks (ConnectedPlainTextClient _ _ sock) chunks = liftIO $ sendMany sock chunks
+  sendChunks (ConnectedPlainTextClient _ _ sock _) chunks = liftIO $ sendMany sock chunks
 
   receive :: (MonadIO m, MonadFail m) => PlainTextClient 'Connected -> m BS.ByteString
-  receive (ConnectedPlainTextClient _ _ sock) = do
+  receive (ConnectedPlainTextClient _ _ sock _) = do
     -- Post-connect receive deadline; independent of PoolConfig.connectionTimeout.
     val <- liftIO $ timeout receiveTimeoutMicroseconds $ recv sock 16384
     case val of
@@ -133,25 +146,29 @@ data TLSClient (a :: ConnectionStatus) where
   -- This is useful for cluster mode where CLUSTER SLOTS returns IP addresses
   -- but we need to use the original hostname for TLS certificate validation
   NotConnectedTLSClientWithHostname :: String -> String -> Maybe Int -> TLSClient 'NotConnected
-  ConnectedTLSClient :: String -> Word32 -> Socket -> Context -> TLSClient 'Connected
+  ConnectedTLSClient :: String -> Word32 -> Socket -> Context -> IO () -> TLSClient 'Connected
   TLSTunnel :: TLSClient 'Connected -> TLSClient 'Server
 
 instance Client TLSClient where
   connect :: (MonadIO m) => TLSClient 'NotConnected -> m (TLSClient 'Connected)
   connect (NotConnectedTLSClient hostname port) =
-    connectTLS hostname hostname port
+    liftIO $ connectTLSWithPhases (const $ return ()) hostname hostname port
 
   connect (NotConnectedTLSClientWithHostname certHostname targetAddress port) =
-    connectTLS certHostname targetAddress port
+    liftIO $ connectTLSWithPhases
+      (const $ return ()) certHostname targetAddress port
 
   close :: (MonadIO m) => TLSClient 'Connected -> m ()
-  close (ConnectedTLSClient _ _ sock ctx) = liftIO $ bye ctx `finally` S.close sock
+  close (ConnectedTLSClient _ _ _ ctx cleanup) =
+    liftIO $ bye ctx `finally` cleanup
+
+  abort (ConnectedTLSClient _ _ _ _ cleanup) = liftIO cleanup
 
   send :: (MonadIO m) => TLSClient 'Connected -> LBS.ByteString -> m ()
-  send (ConnectedTLSClient _ _ _ ctx) dat = liftIO $ sendData ctx dat
+  send (ConnectedTLSClient _ _ _ ctx _) dat = liftIO $ sendData ctx dat
 
   receive :: (MonadIO m, MonadFail m) => TLSClient 'Connected -> m BS.ByteString
-  receive (ConnectedTLSClient _ _ _ ctx) = do
+  receive (ConnectedTLSClient _ _ _ ctx _) = do
     -- Post-connect receive deadline; independent of PoolConfig.connectionTimeout.
     val <- liftIO $ timeout receiveTimeoutMicroseconds $ recvData ctx
     case val of
@@ -160,8 +177,57 @@ instance Client TLSClient where
 
 -- | Connect to a TLS server, using certHostname for certificate validation
 -- and targetAddress for the actual network connection.
-connectTLS :: (MonadIO m) => String -> String -> Maybe Int -> m (TLSClient 'Connected)
-connectTLS certHostname targetAddress port = liftIO $ do
+connectPlaintextWithPhases
+  :: PhaseSetter
+  -> String
+  -> Maybe Int
+  -> IO (PlainTextClient 'Connected)
+connectPlaintextWithPhases setPhase hostname port =
+  connectPlaintextWithCleanup setPhase localCleanupRegistrar hostname port
+
+connectPlaintextWithCleanup
+  :: PhaseSetter
+  -> CleanupRegistrar
+  -> String
+  -> Maybe Int
+  -> IO (PlainTextClient 'Connected)
+connectPlaintextWithCleanup setPhase registerCleanup hostname port =
+  runPlaintextSetup setPhase registerCleanup PlaintextSetupOperations
+    { plaintextResolve = resolve hostname
+    , plaintextOpenSocket = socket AF_INET Stream defaultProtocol
+    , plaintextConfigureSocket = configureSocket
+    , plaintextConnectSocket = \sock ipCorrectEndian ->
+        S.connect sock
+          (SockAddrInet (maybe 6379 fromIntegral port) ipCorrectEndian)
+          `catch` \(e :: IOException) -> do
+            printf "Wasn't able to connect to the server: %s...\n" (show e)
+            putStrLn "Tried to use a plain text socket on port 6379. Did you mean to use TLS on port 6380?"
+            throwIO e
+    , plaintextCloseSocket = S.close
+    , plaintextConnected = \sock ipCorrectEndian cleanup ->
+        ConnectedPlainTextClient hostname ipCorrectEndian sock cleanup
+    }
+
+connectTLSWithPhases
+  :: PhaseSetter
+  -> String
+  -> String
+  -> Maybe Int
+  -> IO (TLSClient 'Connected)
+connectTLSWithPhases setPhase certHostname targetAddress port =
+  connectTLSWithCleanup
+    setPhase localCleanupRegistrar certHostname targetAddress port
+
+connectTLSWithCleanup
+  :: PhaseSetter
+  -> CleanupRegistrar
+  -> String
+  -> String
+  -> Maybe Int
+  -> IO (TLSClient 'Connected)
+connectTLSWithCleanup setPhase registerCleanup
+    certHostname targetAddress port = do
+  setPhase TLSContextCreation
   insecureValue <- lookupEnv tlsInsecureEnvironmentVariable
   allowInsecure <-
     case parseTLSVerificationBypass insecureValue of
@@ -173,30 +239,51 @@ connectTLS certHostname targetAddress port = liftIO $ do
         ++ show certHostname
         ++ ". The server identity will not be verified."
     else pure ()
-  withSetupResource
-    (createSocket targetAddress $ maybe 6380 fromIntegral port)
-    (S.close . fst) $ \(sock, ipCorrectEndian) -> do
-      S.connect sock (SockAddrInet (maybe 6380 fromIntegral port) ipCorrectEndian)
-      store <- getSystemCertificateStore
+  runTLSSetup setPhase registerCleanup TLSSetupOperations
+    { tlsResolve = resolve targetAddress
+    , tlsOpenSocket = socket AF_INET Stream defaultProtocol
+    , tlsConfigureSocket = configureSocket
+    , tlsConnectSocket = \sock ipCorrectEndian ->
+        S.connect sock
+          (SockAddrInet (maybe 6380 fromIntegral port) ipCorrectEndian)
+    , tlsCloseSocket = S.close
+    , tlsLoadStore = getSystemCertificateStore
+    , tlsCreateContext = \sock store ->
+        contextNew sock $ tlsClientParams allowInsecure store
+    , tlsCloseContext = const $ return ()
+    , tlsRunHandshake = handshake
+    , tlsConnected = \sock ipCorrectEndian context cleanup ->
+        ConnectedTLSClient
+          certHostname ipCorrectEndian sock context cleanup
+    }
+  where
+    tlsClientParams allowInsecure store =
       let baseParams =
             (defaultParamsClient certHostname "redis-server")
               { clientSupported =
                   def
-                    { supportedVersions = [TLS13, TLS12],
-                      supportedCiphers = ciphersuite_strong
-                    },
-                clientShared =
+                    { supportedVersions = [TLS13, TLS12]
+                    , supportedCiphers = ciphersuite_strong
+                    }
+              , clientShared =
                   def
                     { sharedCAStore = store
                     }
               }
-          clientParams =
-            if allowInsecure
-              then baseParams {clientHooks = def {onServerCertificate = \_ _ _ _ -> pure []}}
-              else baseParams
-      context <- contextNew sock clientParams
-      handshake context
-      return $ ConnectedTLSClient certHostname ipCorrectEndian sock context
+      in if allowInsecure
+           then baseParams
+             { clientHooks =
+                 def {onServerCertificate = \_ _ _ _ -> pure []}
+             }
+           else baseParams
+
+localCleanupRegistrar :: CleanupRegistrar
+localCleanupRegistrar cleanup = do
+  finalized <- newIORef False
+  return $ do
+    shouldRun <- atomicModifyIORef' finalized $ \done ->
+      (True, not done)
+    if shouldRun then cleanup else return ()
 
 -- | Start a local TCP proxy on @localhost:6379@ that forwards traffic through an
 -- existing TLS connection. Useful for tunneling plain-text Redis tools over TLS.
@@ -225,15 +312,10 @@ serve (TLSTunnel redisClient) = liftIO $ do
       loop client redis
 
 -- | Create a TCP socket with standard options (NoDelay, KeepAlive) and resolve the hostname.
-createSocket :: String -> S.PortNumber -> IO (Socket, HostAddress)
-createSocket hostname _port = do
-  ipAddr <- resolve hostname
-  withSetupResource
-    (socket AF_INET Stream defaultProtocol)
-    S.close $ \sock -> do
-      setSocketOption sock NoDelay 1
-      setSocketOption sock KeepAlive 1
-      return (sock, ipAddr)
+configureSocket :: Socket -> IO ()
+configureSocket sock = do
+  setSocketOption sock NoDelay 1
+  setSocketOption sock KeepAlive 1
 
 -- | Resolve a hostname or IP address string to a 'HostAddress'.
 -- Handles @\"localhost\"@, dotted-quad IPv4 literals, and DNS A-record lookups.

--- a/hask-redis-mux/lib/client/Database/Redis/Client.hs
+++ b/hask-redis-mux/lib/client/Database/Redis/Client.hs
@@ -18,46 +18,57 @@ module Database.Redis.Client
   , ConnectionStatus (..)
   ) where
 
-import           Control.Exception               (IOException, bracket, catch,
-                                                  finally, onException, throwIO)
-import           Control.Monad                   (void)
+import           Control.Exception                     (IOException, bracket,
+                                                        catch, finally, throwIO)
+import           Control.Monad                         (void)
 import           Control.Monad.IO.Class
-import qualified Data.ByteString                 as BS
-import qualified Data.ByteString.Char8           as BS8
-import qualified Data.ByteString.Lazy            as LBS
-import           Data.Default.Class              (def)
-import           Data.IP                         (IPv4, toHostAddress)
-import           Data.Kind                       (Type)
-import           Data.Word                       (Word32)
-import           Database.Redis.Client.TLSConfig (parseTLSVerificationBypass,
-                                                  tlsInsecureEnvironmentVariable)
-import           Network.DNS                     (defaultResolvConf, lookupA,
-                                                  makeResolvSeed, withResolver)
-import           Network.Socket                  (Family (AF_INET), HostAddress,
-                                                  SockAddr (SockAddrInet),
-                                                  Socket, SocketOption (..),
-                                                  SocketType (Stream),
-                                                  defaultProtocol,
-                                                  setSocketOption, socket,
-                                                  tupleToHostAddress)
-import qualified Network.Socket                  as S
-import           Network.Socket.ByteString       (recv, sendMany)
-import           Network.Socket.ByteString.Lazy  (sendAll)
-import           Network.TLS                     (ClientHooks (..),
-                                                  ClientParams (..), Context,
-                                                  Shared (..), Supported (..),
-                                                  Version (..), bye, contextNew,
-                                                  defaultParamsClient,
-                                                  handshake, recvData, sendData)
-import           Network.TLS.Extra               (ciphersuite_strong)
-import           Prelude                         hiding (getContents)
-import           System.Environment              (lookupEnv)
-import           System.IO                       (BufferMode (LineBuffering),
-                                                  hFlush, hPutStrLn,
-                                                  hSetBuffering, stderr, stdout)
-import           System.Timeout                  (timeout)
-import           System.X509.Unix                (getSystemCertificateStore)
-import           Text.Printf                     (printf)
+import qualified Data.ByteString                       as BS
+import qualified Data.ByteString.Char8                 as BS8
+import qualified Data.ByteString.Lazy                  as LBS
+import           Data.Default.Class                    (def)
+import           Data.IP                               (IPv4, toHostAddress)
+import           Data.Kind                             (Type)
+import           Data.Word                             (Word32)
+import           Database.Redis.Client.ConnectionSetup (withSetupResource)
+import           Database.Redis.Client.TLSConfig       (parseTLSVerificationBypass,
+                                                        tlsInsecureEnvironmentVariable)
+import           Network.DNS                           (defaultResolvConf,
+                                                        lookupA, makeResolvSeed,
+                                                        withResolver)
+import           Network.Socket                        (Family (AF_INET),
+                                                        HostAddress,
+                                                        SockAddr (SockAddrInet),
+                                                        Socket,
+                                                        SocketOption (..),
+                                                        SocketType (Stream),
+                                                        defaultProtocol,
+                                                        setSocketOption, socket,
+                                                        tupleToHostAddress)
+import qualified Network.Socket                        as S
+import           Network.Socket.ByteString             (recv, sendMany)
+import           Network.Socket.ByteString.Lazy        (sendAll)
+import           Network.TLS                           (ClientHooks (..),
+                                                        ClientParams (..),
+                                                        Context, Shared (..),
+                                                        Supported (..),
+                                                        Version (..), bye,
+                                                        contextNew,
+                                                        defaultParamsClient,
+                                                        handshake, recvData,
+                                                        sendData)
+import           Network.TLS.Extra                     (ciphersuite_strong)
+import           Prelude                               hiding (getContents)
+import           System.Environment                    (lookupEnv)
+import           System.IO                             (BufferMode (LineBuffering),
+                                                        hFlush, hPutStrLn,
+                                                        hSetBuffering, stderr,
+                                                        stdout)
+import           System.Timeout                        (timeout)
+import           System.X509.Unix                      (getSystemCertificateStore)
+import           Text.Printf                           (printf)
+
+receiveTimeoutMicroseconds :: Int
+receiveTimeoutMicroseconds = 300 * 1000000
 
 -- | Connection lifecycle phase, used as a DataKinds-promoted type parameter
 -- to statically track whether a client is connected.
@@ -85,14 +96,15 @@ data PlainTextClient (a :: ConnectionStatus) where
 
 instance Client PlainTextClient where
   connect :: (MonadIO m) => PlainTextClient 'NotConnected -> m (PlainTextClient 'Connected)
-  connect (NotConnectedPlainTextClient hostname port) = liftIO $ do
-    (sock, ipCorrectEndian) <- createSocket hostname (maybe 6379 fromIntegral port)
-    flip onException (S.close sock) $ do
-      S.connect sock (SockAddrInet (maybe 6379 fromIntegral port) ipCorrectEndian) `catch` \(e :: IOException) -> do
-        printf "Wasn't able to connect to the server: %s...\n" (show e)
-        putStrLn "Tried to use a plain text socket on port 6379. Did you mean to use TLS on port 6380?"
-        throwIO e
-      return $ ConnectedPlainTextClient hostname ipCorrectEndian sock
+  connect (NotConnectedPlainTextClient hostname port) = liftIO $
+    withSetupResource
+      (createSocket hostname $ maybe 6379 fromIntegral port)
+      (S.close . fst) $ \(sock, ipCorrectEndian) -> do
+        S.connect sock (SockAddrInet (maybe 6379 fromIntegral port) ipCorrectEndian) `catch` \(e :: IOException) -> do
+          printf "Wasn't able to connect to the server: %s...\n" (show e)
+          putStrLn "Tried to use a plain text socket on port 6379. Did you mean to use TLS on port 6380?"
+          throwIO e
+        return $ ConnectedPlainTextClient hostname ipCorrectEndian sock
 
   close :: (MonadIO m) => PlainTextClient 'Connected -> m ()
   close (ConnectedPlainTextClient _ _ sock) = liftIO $ S.close sock
@@ -105,8 +117,8 @@ instance Client PlainTextClient where
 
   receive :: (MonadIO m, MonadFail m) => PlainTextClient 'Connected -> m BS.ByteString
   receive (ConnectedPlainTextClient _ _ sock) = do
-    -- Timeout increased to 300s (5 minutes) to handle massive backlogs during fill operations
-    val <- liftIO $ timeout (300 * 1000000) $ recv sock 16384
+    -- Post-connect receive deadline; independent of PoolConfig.connectionTimeout.
+    val <- liftIO $ timeout receiveTimeoutMicroseconds $ recv sock 16384
     case val of
       Nothing -> fail "recv socket timeout (plaintext)"
       Just v  -> return v
@@ -140,8 +152,8 @@ instance Client TLSClient where
 
   receive :: (MonadIO m, MonadFail m) => TLSClient 'Connected -> m BS.ByteString
   receive (ConnectedTLSClient _ _ _ ctx) = do
-    -- Timeout increased to 300s (5 minutes) to handle massive backlogs
-    val <- liftIO $ timeout (300 * 1000000) $ recvData ctx
+    -- Post-connect receive deadline; independent of PoolConfig.connectionTimeout.
+    val <- liftIO $ timeout receiveTimeoutMicroseconds $ recvData ctx
     case val of
       Nothing -> fail "recv socket timeout (TLS)"
       Just v  -> return v
@@ -161,29 +173,30 @@ connectTLS certHostname targetAddress port = liftIO $ do
         ++ show certHostname
         ++ ". The server identity will not be verified."
     else pure ()
-  (sock, ipCorrectEndian) <- createSocket targetAddress (maybe 6380 fromIntegral port)
-  flip onException (S.close sock) $ do
-    S.connect sock (SockAddrInet (maybe 6380 fromIntegral port) ipCorrectEndian)
-    store <- getSystemCertificateStore
-    let baseParams =
-          (defaultParamsClient certHostname "redis-server")
-            { clientSupported =
-                def
-                  { supportedVersions = [TLS13, TLS12],
-                    supportedCiphers = ciphersuite_strong
-                  },
-              clientShared =
-                def
-                  { sharedCAStore = store
-                  }
-            }
-        clientParams =
-          if allowInsecure
-            then baseParams {clientHooks = def {onServerCertificate = \_ _ _ _ -> pure []}}
-            else baseParams
-    context <- contextNew sock clientParams
-    handshake context
-    return $ ConnectedTLSClient certHostname ipCorrectEndian sock context
+  withSetupResource
+    (createSocket targetAddress $ maybe 6380 fromIntegral port)
+    (S.close . fst) $ \(sock, ipCorrectEndian) -> do
+      S.connect sock (SockAddrInet (maybe 6380 fromIntegral port) ipCorrectEndian)
+      store <- getSystemCertificateStore
+      let baseParams =
+            (defaultParamsClient certHostname "redis-server")
+              { clientSupported =
+                  def
+                    { supportedVersions = [TLS13, TLS12],
+                      supportedCiphers = ciphersuite_strong
+                    },
+                clientShared =
+                  def
+                    { sharedCAStore = store
+                    }
+              }
+          clientParams =
+            if allowInsecure
+              then baseParams {clientHooks = def {onServerCertificate = \_ _ _ _ -> pure []}}
+              else baseParams
+      context <- contextNew sock clientParams
+      handshake context
+      return $ ConnectedTLSClient certHostname ipCorrectEndian sock context
 
 -- | Start a local TCP proxy on @localhost:6379@ that forwards traffic through an
 -- existing TLS connection. Useful for tunneling plain-text Redis tools over TLS.
@@ -215,10 +228,12 @@ serve (TLSTunnel redisClient) = liftIO $ do
 createSocket :: String -> S.PortNumber -> IO (Socket, HostAddress)
 createSocket hostname _port = do
   ipAddr <- resolve hostname
-  sock <- socket AF_INET Stream defaultProtocol
-  setSocketOption sock NoDelay 1
-  setSocketOption sock KeepAlive 1
-  return (sock, ipAddr)
+  withSetupResource
+    (socket AF_INET Stream defaultProtocol)
+    S.close $ \sock -> do
+      setSocketOption sock NoDelay 1
+      setSocketOption sock KeepAlive 1
+      return (sock, ipAddr)
 
 -- | Resolve a hostname or IP address string to a 'HostAddress'.
 -- Handles @\"localhost\"@, dotted-quad IPv4 literals, and DNS A-record lookups.

--- a/hask-redis-mux/lib/client/Database/Redis/Client/ConnectionSetup.hs
+++ b/hask-redis-mux/lib/client/Database/Redis/Client/ConnectionSetup.hs
@@ -1,0 +1,12 @@
+module Database.Redis.Client.ConnectionSetup
+  ( withSetupResource
+  ) where
+
+import           Control.Exception (mask, onException)
+
+-- | Acquire a setup resource under interruptible masking and release it if any
+-- later setup phase fails or is cancelled before ownership transfer.
+withSetupResource :: IO resource -> (resource -> IO ()) -> (resource -> IO result) -> IO result
+withSetupResource acquire release use = mask $ \restore -> do
+  resource <- acquire
+  restore (use resource) `onException` release resource

--- a/hask-redis-mux/lib/client/Database/Redis/Client/ConnectionSetup.hs
+++ b/hask-redis-mux/lib/client/Database/Redis/Client/ConnectionSetup.hs
@@ -1,12 +1,99 @@
 module Database.Redis.Client.ConnectionSetup
-  ( withSetupResource
+  ( ConnectionPhase (..)
+  , PhaseSetter
+  , CleanupRegistrar
+  , PlaintextSetupOperations (..)
+  , TLSSetupOperations (..)
+  , runPlaintextSetup
+  , runTLSSetup
   ) where
 
-import           Control.Exception (mask, onException)
+import           Control.Exception (finally, mask, onException)
 
--- | Acquire a setup resource under interruptible masking and release it if any
--- later setup phase fails or is cancelled before ownership transfer.
-withSetupResource :: IO resource -> (resource -> IO ()) -> (resource -> IO result) -> IO result
-withSetupResource acquire release use = mask $ \restore -> do
-  resource <- acquire
-  restore (use resource) `onException` release resource
+-- | The production connection phase active when a setup deadline expires.
+data ConnectionPhase
+  = DNSResolution
+  | SocketCreation
+  | SocketConfiguration
+  | TCPConnection
+  | TLSContextCreation
+  | TLSHandshake
+  | Authentication
+  | PlaintextConnectionSetup
+  | TLSConnectionSetup
+  deriving (Eq, Show)
+
+type PhaseSetter = ConnectionPhase -> IO ()
+type CleanupRegistrar = IO () -> IO (IO ())
+
+data PlaintextSetupOperations socket address connected = PlaintextSetupOperations
+  { plaintextResolve         :: IO address
+  , plaintextOpenSocket      :: IO socket
+  , plaintextConfigureSocket :: socket -> IO ()
+  , plaintextConnectSocket   :: socket -> address -> IO ()
+  , plaintextCloseSocket     :: socket -> IO ()
+  , plaintextConnected       :: socket -> address -> IO () -> connected
+  }
+
+data TLSSetupOperations socket address store context connected = TLSSetupOperations
+  { tlsResolve         :: IO address
+  , tlsOpenSocket      :: IO socket
+  , tlsConfigureSocket :: socket -> IO ()
+  , tlsConnectSocket   :: socket -> address -> IO ()
+  , tlsCloseSocket     :: socket -> IO ()
+  , tlsLoadStore       :: IO store
+  , tlsCreateContext   :: socket -> store -> IO context
+  , tlsCloseContext    :: context -> IO ()
+  , tlsRunHandshake    :: context -> IO ()
+  , tlsConnected       :: socket -> address -> context -> IO () -> connected
+  }
+
+runPlaintextSetup
+  :: PhaseSetter
+  -> CleanupRegistrar
+  -> PlaintextSetupOperations socket address connected
+  -> IO connected
+runPlaintextSetup setPhase registerCleanup operations =
+  mask $ \restore -> do
+    setPhase DNSResolution
+    address <- restore $ plaintextResolve operations
+    setPhase SocketCreation
+    sock <- restore $ plaintextOpenSocket operations
+    cleanup <- registerCleanup $ plaintextCloseSocket operations sock
+    restore (do
+      setPhase SocketConfiguration
+      plaintextConfigureSocket operations sock
+      setPhase TCPConnection
+      plaintextConnectSocket operations sock address
+      return $ plaintextConnected operations sock address cleanup)
+      `onException` cleanup
+
+runTLSSetup
+  :: PhaseSetter
+  -> CleanupRegistrar
+  -> TLSSetupOperations socket address store context connected
+  -> IO connected
+runTLSSetup setPhase registerCleanup operations =
+  mask $ \restore -> do
+    setPhase DNSResolution
+    address <- restore $ tlsResolve operations
+    setPhase SocketCreation
+    sock <- restore $ tlsOpenSocket operations
+    socketCleanup <- registerCleanup $ tlsCloseSocket operations sock
+    restore (do
+      setPhase SocketConfiguration
+      tlsConfigureSocket operations sock
+      setPhase TCPConnection
+      tlsConnectSocket operations sock address
+      setPhase TLSContextCreation
+      store <- tlsLoadStore operations
+      context <- tlsCreateContext operations sock store
+      contextCleanup <- registerCleanup $
+        tlsCloseContext operations context `finally` socketCleanup
+      (do
+          setPhase TLSHandshake
+          tlsRunHandshake operations context
+          return $
+            tlsConnected operations sock address context contextCleanup)
+        `onException` contextCleanup)
+      `onException` socketCleanup

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
@@ -69,7 +69,8 @@ import           Control.Concurrent.MVar               (MVar, newMVar, putMVar,
 import           Control.Concurrent.STM                (TVar, atomically,
                                                         newTVarIO, readTVarIO,
                                                         writeTVar)
-import           Control.Exception                     (SomeException, bracket,
+import           Control.Exception                     (SomeAsyncException,
+                                                        SomeException, bracket,
                                                         finally, fromException,
                                                         onException, throwIO,
                                                         try)
@@ -111,7 +112,10 @@ import           Database.Redis.Command                (ClientState (..),
                                                         runRedisCommandClient,
                                                         showBS)
 import qualified Database.Redis.Command                as RedisCommandClient
-import           Database.Redis.Connector              (Connector)
+import           Database.Redis.Connector              (ConnectionPhase (..),
+                                                        ConnectionSetupException,
+                                                        Connector,
+                                                        withConnectionTimeout)
 import           Database.Redis.FromResp               (FromResp (..))
 import           Database.Redis.Internal.MultiplexPool (MultiplexPool,
                                                         MultiplexPoolException (..),
@@ -131,6 +135,7 @@ data ClusterError
   | MaxRetriesExceeded String -- ^ All retry attempts exhausted.
   | TopologyError String -- ^ Slot or node lookup failed (e.g., empty topology).
   | ConnectionError String -- ^ Network-level failure connecting to a node.
+  | ConnectionTimeoutError ConnectionSetupException -- ^ A bounded connection setup attempt timed out.
   | ClusterClientClosed -- ^ The client has been terminally closed.
   deriving (Show, Eq)
 
@@ -260,7 +265,15 @@ createClusterClientWithFactories createConnectionPool createMuxPool config conne
         Right initialTopology -> do
           topology <- newTVarIO initialTopology
           refreshLock <- newMVar ()
-          muxPool <- createMuxPool connector 1
+          let poolCfg = clusterPoolConfig config
+              phase =
+                if useTLS poolCfg
+                  then TLSConnectionSetup
+                  else PlaintextConnectionSetup
+              boundedConnector =
+                withConnectionTimeout
+                  (connectionTimeout poolCfg) phase connector
+          muxPool <- createMuxPool boundedConnector 1
           return $ ClusterClient topology pool config connector refreshLock muxPool
 
 -- | Close all pooled connections across every node.
@@ -370,16 +383,14 @@ executeOnNode ::
   Connector client ->
   IO (Either ClusterError a)
 executeOnNode client nodeAddr action connector = do
-  result <- try $ withConnection (clusterConnectionPool client) nodeAddr connector $ \conn -> do
+  result <- tryClusterAction $
+    withConnection (clusterConnectionPool client) nodeAddr connector $ \conn -> do
     let clientState = ClientState conn BS8.empty
     State.evalStateT (runRedisCommandClient action) clientState
 
   case result of
-    Left (e :: SomeException)
-      | Just ConnectionPoolClosed <- fromException e ->
-          return $ Left ClusterClientClosed
-      | otherwise -> return $ Left $ ConnectionError $ show e
-    Right value               -> return $ Right value
+    Left err    -> return $ Left err
+    Right value -> return $ Right value
 
 -- | Execute a command that does not target a specific key (e.g., PING, AUTH, FLUSHALL).
 -- Routed to an arbitrary master node.
@@ -427,15 +438,44 @@ withRetryAndRefresh client maxRetries initialDelay action = go 0 initialDelay No
               threadDelay delay
               go (attempt + 1) (delay * 2) Nothing
             Left (MovedError _ _) -> do
-              refreshTopology client
-              go (attempt + 1) delay Nothing
+              refreshResult <- tryClusterAction $ refreshTopology client
+              case refreshResult of
+                Left ClusterClientClosed -> return $ Left ClusterClientClosed
+                _ -> do
+                  threadDelay delay
+                  go (attempt + 1) (delay * 2) Nothing
             Left (AskError _ addr) -> do
               go (attempt + 1) delay (Just addr)
             Left (ConnectionError _) -> do
-              refreshTopology client
-              go (attempt + 1) delay Nothing
+              refreshResult <- tryClusterAction $ refreshTopology client
+              case refreshResult of
+                Left ClusterClientClosed -> return $ Left ClusterClientClosed
+                _ -> do
+                  threadDelay delay
+                  go (attempt + 1) (delay * 2) Nothing
+            Left (ConnectionTimeoutError _) -> do
+              threadDelay delay
+              go (attempt + 1) (delay * 2) Nothing
             Left err -> return $ Left err
             Right value -> return $ Right value
+
+tryClusterAction :: IO a -> IO (Either ClusterError a)
+tryClusterAction action = do
+  result <- try action
+  case result of
+    Right value -> return $ Right value
+    Left (e :: SomeException) ->
+      case fromException e of
+        Just async -> throwIO (async :: SomeAsyncException)
+        Nothing
+          | Just ConnectionPoolClosed <- fromException e ->
+              return $ Left ClusterClientClosed
+          | Just MultiplexPoolClosed <- fromException e ->
+              return $ Left ClusterClientClosed
+          | Just timeoutError <- fromException e ->
+              return $ Left $ ConnectionTimeoutError timeoutError
+          | otherwise ->
+              return $ Left $ ConnectionError $ show e
 
 -- | Parse the payload after "MOVED " or "ASK " prefix.
 -- Input format: "3999 127.0.0.1:6381" (slot, space, host:port)
@@ -513,13 +553,16 @@ executeKeyedClusterCommand ::
   [ByteString] ->         -- command args
   IO (Either ClusterError RespData)
 executeKeyedClusterCommand client key cmdArgs = do
-  refreshTopologyIfStale client
   let muxPool = clusterMultiplexPool client
       cmdBuilder = encodeCommandBuilder cmdArgs
       !slot = calculateSlot key
   withRetryAndRefresh client (clusterMaxRetries (clusterConfig client)) (clusterRetryDelay (clusterConfig client)) $ \askTarget ->
     case askTarget of
-      Nothing   -> executeOnSlotMux client muxPool slot cmdBuilder
+      Nothing -> do
+        refreshResult <- tryClusterAction $ refreshTopologyIfStale client
+        case refreshResult of
+          Left err -> return $ Left err
+          Right () -> executeOnSlotMux client muxPool slot cmdBuilder
       Just addr -> executeOnNodeWithAsking client muxPool addr cmdBuilder
 
 -- | Execute a pre-encoded command via multiplexer on the node for a given slot.
@@ -536,12 +579,9 @@ executeOnSlotMux client muxPool slot cmdBuilder = do
   case findNodeAddressForSlot topology slot of
     Nothing -> return $ Left $ TopologyError $ "No node found for slot " ++ show slot
     Just addr -> do
-      result <- try $ submitToNode muxPool addr cmdBuilder
+      result <- tryClusterAction $ submitToNode muxPool addr cmdBuilder
       case result of
-        Left (e :: SomeException)
-          | Just MultiplexPoolClosed <- fromException e ->
-              return $ Left ClusterClientClosed
-          | otherwise -> return $ Left $ ConnectionError $ show e
+        Left err -> return $ Left err
         Right respData -> case detectRedirection respData of
           Just (Left (RedirectionInfo s host port)) ->
             return $ Left $ MovedError s (NodeAddress host port)
@@ -562,12 +602,10 @@ executeOnNodeWithAsking ::
   IO (Either ClusterError RespData)
 executeOnNodeWithAsking _client muxPool addr cmdBuilder = do
   let askingBuilder = encodeCommandBuilder ["ASKING"]
-  result <- try $ submitToNodeWithAsking muxPool addr askingBuilder cmdBuilder
+  result <- tryClusterAction $
+    submitToNodeWithAsking muxPool addr askingBuilder cmdBuilder
   case result of
-    Left (e :: SomeException)
-      | Just MultiplexPoolClosed <- fromException e ->
-          return $ Left ClusterClientClosed
-      | otherwise -> return $ Left $ ConnectionError $ show e
+    Left err -> return $ Left err
     Right respData -> case detectRedirection respData of
       Just (Left (RedirectionInfo s host port)) ->
         return $ Left $ MovedError s (NodeAddress host port)

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
@@ -42,6 +42,7 @@ module Database.Redis.Cluster.Client
     ClusterConfig (..),
     -- * Client Lifecycle
     createClusterClient,
+    createClusterClientWithBoundedConnector,
     createClusterClientWithFactories,
     closeClusterClient,
     withClusterClient,
@@ -98,7 +99,8 @@ import           Database.Redis.Cluster.ConnectionPool (ConnectionPool,
                                                         ConnectionPoolException (..),
                                                         PoolConfig (..),
                                                         closePool, createPool,
-                                                        withConnection)
+                                                        withConnection,
+                                                        withConnectionBounded)
 import           Database.Redis.Command                (ClientState (..),
                                                         RedisCommandClient (..),
                                                         RedisCommands (..),
@@ -238,7 +240,19 @@ createClusterClient ::
   Connector client ->
   IO (ClusterClient client)
 createClusterClient config connector = do
-  createClusterClientWithFactories createPool createMultiplexPool config connector
+  createClusterClientWithFactoriesUsing
+    False createPool createMultiplexPool config connector
+
+-- | Construct a cluster client from a phase-aware connector that already owns
+-- its complete setup deadline, including authentication when applicable.
+createClusterClientWithBoundedConnector ::
+  (Client client) =>
+  ClusterConfig ->
+  Connector client ->
+  IO (ClusterClient client)
+createClusterClientWithBoundedConnector config connector =
+  createClusterClientWithFactoriesUsing
+    True createPool createMultiplexPool config connector
 
 -- | Internal construction seam for deterministic failure-injection tests.
 createClusterClientWithFactories
@@ -249,13 +263,30 @@ createClusterClientWithFactories
   -> Connector client
   -> IO (ClusterClient client)
 createClusterClientWithFactories createConnectionPool createMuxPool config connector = do
+  createClusterClientWithFactoriesUsing
+    False createConnectionPool createMuxPool config connector
+
+createClusterClientWithFactoriesUsing
+  :: (Client client)
+  => Bool
+  -> (PoolConfig -> IO (ConnectionPool client))
+  -> (Connector client -> Int -> IO (MultiplexPool client))
+  -> ClusterConfig
+  -> Connector client
+  -> IO (ClusterClient client)
+createClusterClientWithFactoriesUsing connectorIsBounded
+    createConnectionPool createMuxPool config connector = do
   pool <- createConnectionPool (clusterPoolConfig config)
   build pool `onException` closePool pool
   where
     build pool = do
   -- Discover initial topology before creating TVar
       let seedNode = clusterSeedNode config
-      response <- withConnection pool seedNode connector $ \conn -> do
+      let connectFromPool =
+            if connectorIsBounded
+              then withConnectionBounded
+              else withConnection
+      response <- connectFromPool pool seedNode connector $ \conn -> do
         let clientState = ClientState conn BS8.empty
         State.evalStateT (runRedisCommandClient clusterSlots) clientState
 
@@ -270,11 +301,13 @@ createClusterClientWithFactories createConnectionPool createMuxPool config conne
                 if useTLS poolCfg
                   then TLSConnectionSetup
                   else PlaintextConnectionSetup
-              boundedConnector =
-                withConnectionTimeout
-                  (connectionTimeout poolCfg) phase connector
+              boundedConnector
+                | connectorIsBounded = connector
+                | otherwise =
+                    withConnectionTimeout
+                      (connectionTimeout poolCfg) phase connector
           muxPool <- createMuxPool boundedConnector 1
-          return $ ClusterClient topology pool config connector refreshLock muxPool
+          return $ ClusterClient topology pool config boundedConnector refreshLock muxPool
 
 -- | Close all pooled connections across every node.
 -- Closure is terminal and idempotent: owned transports are closed exactly once,
@@ -325,7 +358,8 @@ refreshTopology client = do
     connector = clusterConnector client
     doRefresh = do
       let seedNode = clusterSeedNode (clusterConfig client)
-      response <- withConnection (clusterConnectionPool client) seedNode connector $ \conn -> do
+      response <- withConnectionBounded
+        (clusterConnectionPool client) seedNode connector $ \conn -> do
         let clientState = ClientState conn BS8.empty
         State.evalStateT (runRedisCommandClient clusterSlots) clientState
 
@@ -384,7 +418,8 @@ executeOnNode ::
   IO (Either ClusterError a)
 executeOnNode client nodeAddr action connector = do
   result <- tryClusterAction $
-    withConnection (clusterConnectionPool client) nodeAddr connector $ \conn -> do
+    withConnectionBounded
+      (clusterConnectionPool client) nodeAddr connector $ \conn -> do
     let clientState = ClientState conn BS8.empty
     State.evalStateT (runRedisCommandClient action) clientState
 

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/ConnectionPool.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/ConnectionPool.hs
@@ -20,6 +20,7 @@ module Database.Redis.Cluster.ConnectionPool
     PoolConfig (..),
     createPool,
     withConnection,
+    withConnectionBounded,
     getConnectionPoolStats,
     closePool,
   )
@@ -123,23 +124,41 @@ withConnection ::
   (client 'Connected -> IO a) ->
   IO a
 withConnection pool addr connector action = mask $ \restore -> do
-  conn <- checkoutConnection pool addr connector restore
+  conn <- checkoutConnection False pool addr connector restore
   result <- restore (action conn)
     `onException` discardConnection pool addr conn
   returnConnection pool addr conn
   return result
 {-# INLINE withConnection #-}
 
+-- | Use a connector that already enforces the pool's complete setup deadline.
+-- This avoids nesting a coarse pool timeout around a phase-aware connector.
+withConnectionBounded ::
+  (Client client) =>
+  ConnectionPool client ->
+  NodeAddress ->
+  Connector client ->
+  (client 'Connected -> IO a) ->
+  IO a
+withConnectionBounded pool addr connector action = mask $ \restore -> do
+  conn <- checkoutConnection True pool addr connector restore
+  result <- restore (action conn)
+    `onException` discardConnection pool addr conn
+  returnConnection pool addr conn
+  return result
+{-# INLINE withConnectionBounded #-}
+
 -- | Check out a connection from the pool. Creates a new one if none available
 -- and the max hasn't been reached. Blocks if pool is at capacity.
 checkoutConnection ::
   (Client client) =>
+  Bool ->
   ConnectionPool client ->
   NodeAddress ->
   Connector client ->
   (forall a. IO a -> IO a) ->
   IO (client 'Connected)
-checkoutConnection pool addr connector restore = checkout
+checkoutConnection connectorIsBounded pool addr connector restore = checkout
   where
   checkout = do
     result <- modifyPoolState pool $ \m -> do
@@ -183,9 +202,11 @@ checkoutConnection pool addr connector restore = checkout
               if useTLS (poolConfig pool)
                 then TLSConnectionSetup
                 else PlaintextConnectionSetup
-            boundedConnector =
-              withConnectionTimeout
-                (connectionTimeout $ poolConfig pool) phase connector
+            boundedConnector
+              | connectorIsBounded = connector
+              | otherwise =
+                  withConnectionTimeout
+                    (connectionTimeout $ poolConfig pool) phase connector
         connResult <- try (restore $ boundedConnector addr)
         case connResult of
           Right conn -> do

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/ConnectionPool.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/ConnectionPool.hs
@@ -41,7 +41,8 @@ import qualified Data.Map.Strict          as Map
 import           Data.Typeable            (Typeable)
 import           Database.Redis.Client    (Client (..), ConnectionStatus (..))
 import           Database.Redis.Cluster   (NodeAddress (..))
-import           Database.Redis.Connector (Connector)
+import           Database.Redis.Connector (ConnectionPhase (..), Connector,
+                                           withConnectionTimeout)
 
 -- | Exception thrown when a terminally closed connection pool is used.
 data ConnectionPoolException = ConnectionPoolClosed
@@ -60,7 +61,7 @@ data ConnectionPoolStats = ConnectionPoolStats
 -- | Configuration for the connection pool.
 data PoolConfig = PoolConfig
   { maxConnectionsPerNode :: Int  -- ^ Maximum number of connections kept per node. Callers block when all connections are in use.
-  , connectionTimeout     :: Int  -- ^ Connection timeout in seconds (reserved for future use).
+  , connectionTimeout     :: Int  -- ^ Per-attempt setup deadline in seconds. Covers DNS, TCP connect, and TLS context/handshake when enabled.
   , maxRetries            :: Int  -- ^ Maximum retry attempts for cluster operations.
   , useTLS                :: Bool -- ^ Whether to use TLS connections.
   }
@@ -178,7 +179,14 @@ checkoutConnection pool addr connector restore = checkout
     if not open
       then throwIO ConnectionPoolClosed
       else do
-        connResult <- try (restore $ connector addr)
+        let phase =
+              if useTLS (poolConfig pool)
+                then TLSConnectionSetup
+                else PlaintextConnectionSetup
+            boundedConnector =
+              withConnectionTimeout
+                (connectionTimeout $ poolConfig pool) phase connector
+        connResult <- try (restore $ boundedConnector addr)
         case connResult of
           Right conn -> do
             accepted <- poolIsOpen pool

--- a/hask-redis-mux/lib/cluster/Database/Redis/Connector.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Connector.hs
@@ -27,34 +27,57 @@ module Database.Redis.Connector
   ( -- * Connector type
     Connector
   , ConnectionPhase (..)
+  , ConnectionSupervisor (..)
   , ConnectionSetupException (..)
   , withConnectionTimeout
+  , withConnectionTimeoutPhased
+  , withConnectionTimeoutSupervised
     -- * Standalone connections
   , connectPlaintext
+  , connectPlaintextWithTimeout
   , connectTLS
+  , connectTLSWithTimeout
     -- * Cluster connector factories
   , clusterPlaintextConnector
+  , clusterPlaintextConnectorWithTimeout
   , clusterTLSConnector
+  , clusterTLSConnectorWithTimeout
   ) where
 
-import           Control.Exception      (Exception, throwIO)
+import           Control.Concurrent     (ThreadId, forkIOWithUnmask, throwTo)
+import           Control.Concurrent.STM (TVar, atomically, check, newTVarIO,
+                                         orElse, readTVar, registerDelay, retry,
+                                         writeTVar)
+import           Control.Exception      (Exception, SomeException, mask,
+                                         onException, throwIO, try)
+import           Control.Monad          (void)
+import           Data.IORef             (atomicModifyIORef', newIORef)
+import           Data.Maybe             (isNothing)
 import           Data.Typeable          (Typeable)
-import           Database.Redis.Client  (Client (connect),
-                                         ConnectionStatus (..),
+import           Database.Redis.Client  (CleanupRegistrar,
+                                         Client (abort, connect),
+                                         ConnectionPhase (..),
+                                         ConnectionStatus (..), PhaseSetter,
                                          PlainTextClient (NotConnectedPlainTextClient),
-                                         TLSClient (NotConnectedTLSClient, NotConnectedTLSClientWithHostname))
+                                         TLSClient (NotConnectedTLSClient, NotConnectedTLSClientWithHostname),
+                                         connectPlaintextWithCleanup,
+                                         connectTLSWithCleanup)
 import           Database.Redis.Cluster (NodeAddress (..))
-import           System.Timeout         (timeout)
 
 -- | A function that creates a connected client for a given node address.
 -- Used throughout the cluster layer to establish connections on demand.
 type Connector client = NodeAddress -> IO (client 'Connected)
 
--- | The connection setup covered by a configured deadline.
-data ConnectionPhase
-  = PlaintextConnectionSetup
-  | TLSConnectionSetup
-  deriving (Eq, Show, Typeable)
+-- | Hooks exposed to a production connector running under a deadline.
+--
+-- Register a connected transport before potentially blocking authentication.
+-- If the deadline expires in that phase, the supervisor atomically claims and
+-- aborts that transport while independently requesting worker cancellation.
+data ConnectionSupervisor client = ConnectionSupervisor
+  { setConnectionPhase         :: PhaseSetter
+  , registerSetupCleanup       :: CleanupRegistrar
+  , registerConnectedTransport :: client 'Connected -> IO (IO ())
+  }
 
 -- | A connection setup attempt exceeded its configured wall-clock deadline.
 -- The endpoint and transport phase are retained without including connector
@@ -73,18 +96,188 @@ instance Exception ConnectionSetupException
 -- connect. For TLS it additionally covers certificate-store/context setup and
 -- the TLS handshake.
 withConnectionTimeout
-  :: Int
+  :: (Client client)
+  => Int
   -> ConnectionPhase
   -> Connector client
   -> Connector client
-withConnectionTimeout seconds phase connector addr
+withConnectionTimeout seconds phase connector =
+  withConnectionTimeoutPhased seconds phase (const connector)
+
+-- | Supervise a connector in a worker while it reports the active production
+-- phase. Caller return at the deadline does not depend on asynchronous
+-- interruption of that worker. A stop request is still sent so interruptible
+-- setup unwinds and closes its owned resources promptly; any connection
+-- returned after the deadline is abortively closed instead of escaping.
+withConnectionTimeoutPhased
+  :: (Client client)
+  => Int
+  -> ConnectionPhase
+  -> (PhaseSetter -> Connector client)
+  -> Connector client
+withConnectionTimeoutPhased seconds initialPhase phasedConnector addr
+  = withConnectionTimeoutSupervised seconds initialPhase
+      (\supervisor ->
+        phasedConnector (setConnectionPhase supervisor)) addr
+
+-- | Supervise setup with both phase reporting and active ownership tracking.
+-- The latter is required for authenticated setup: once a transport has been
+-- created, register it before AUTH so expiry can abort the socket immediately.
+withConnectionTimeoutSupervised
+  :: (Client client)
+  => Int
+  -> ConnectionPhase
+  -> (ConnectionSupervisor client -> Connector client)
+  -> Connector client
+withConnectionTimeoutSupervised seconds initialPhase supervisedConnector addr
   | seconds <= 0 =
-      throwIO $ ConnectionSetupTimeout phase addr seconds
-  | otherwise = do
-      result <- timeout (secondsToMicroseconds seconds) $ connector addr
-      case result of
-        Nothing   -> throwIO $ ConnectionSetupTimeout phase addr seconds
-        Just conn -> return conn
+      throwIO $ ConnectionSetupTimeout initialPhase addr seconds
+  | otherwise = mask $ \restore -> do
+      state <- newTVarIO $ AttemptRunning Nothing
+      phase <- newTVarIO initialPhase
+      worker <- forkIOWithUnmask $ \unmask -> do
+        let supervisor = ConnectionSupervisor
+              { setConnectionPhase = atomically . writeTVar phase
+              , registerSetupCleanup = registerAttemptCleanup state
+              , registerConnectedTransport =
+                  registerAttemptTransport state
+              }
+        outcome <- try $ unmask $ supervisedConnector supervisor addr
+        disposition <- atomically $ do
+          current <- readTVar state
+          case current of
+            AttemptRunning _ -> do
+              writeTVar state $ AttemptFinished outcome
+              return $ AttemptDelivered $ case outcome of
+                Left _  -> attemptCleanup current
+                Right _ -> Nothing
+            AttemptExpired discardLate ->
+              return $ if discardLate
+                then AttemptDiscarded
+                else AttemptAlreadyCleaned
+            AttemptFinished _ -> return AttemptDiscarded
+        case (disposition, outcome) of
+          (AttemptDiscarded, Right conn) -> abort conn
+          (AttemptDelivered cleanup, _)  ->
+            mapM_ requestCleanup cleanup
+          _ -> return ()
+      timer <- registerDelay $ secondsToMicroseconds seconds
+      outcome <- restore (awaitAttempt state phase timer)
+        `onException` abandonAttempt state worker
+      case outcome of
+        AttemptCompleted (Right conn) -> return conn
+        AttemptCompleted (Left err)   -> throwIO err
+        AttemptDeadline expiredPhase owned -> do
+          mapM_ requestCleanup owned
+          requestWorkerStop worker
+          throwIO $ ConnectionSetupTimeout expiredPhase addr seconds
+
+data AttemptState client
+  = AttemptRunning (Maybe (IO ()))
+  | AttemptFinished (Either SomeException (client 'Connected))
+  | AttemptExpired Bool
+
+data AttemptOutcome client
+  = AttemptCompleted (Either SomeException (client 'Connected))
+  | AttemptDeadline ConnectionPhase (Maybe (IO ()))
+
+data AttemptDisposition
+  = AttemptDelivered (Maybe (IO ()))
+  | AttemptDiscarded
+  | AttemptAlreadyCleaned
+
+attemptCleanup :: AttemptState client -> Maybe (IO ())
+attemptCleanup (AttemptRunning cleanup) = cleanup
+attemptCleanup _                        = Nothing
+
+data SetupWorkerCancelled = SetupWorkerCancelled
+  deriving (Show, Typeable)
+
+instance Exception SetupWorkerCancelled
+
+awaitAttempt
+  :: TVar (AttemptState client)
+  -> TVar ConnectionPhase
+  -> TVar Bool
+  -> IO (AttemptOutcome client)
+awaitAttempt state phase timer = atomically $
+  awaitFinished `orElse` awaitDeadline
+  where
+    awaitFinished = do
+      current <- readTVar state
+      case current of
+        AttemptFinished outcome -> return $ AttemptCompleted outcome
+        _                       -> retry
+    awaitDeadline = do
+      expired <- readTVar timer
+      check expired
+      currentPhase <- readTVar phase
+      current <- readTVar state
+      case current of
+        AttemptRunning owned -> do
+          writeTVar state $ AttemptExpired $ isNothing owned
+          return $ AttemptDeadline currentPhase owned
+        _ -> retry
+
+abandonAttempt
+  :: (Client client)
+  => TVar (AttemptState client)
+  -> ThreadId
+  -> IO ()
+abandonAttempt state worker = do
+  cleanup <- atomically $ do
+    current <- readTVar state
+    let (discardLate, transport) = case current of
+          AttemptRunning currentOwned ->
+            (isNothing currentOwned, currentOwned)
+          AttemptFinished (Right conn) -> (False, Just $ abort conn)
+          _                            -> (True, Nothing)
+    writeTVar state $ AttemptExpired discardLate
+    return transport
+  mapM_ requestCleanup cleanup
+  requestWorkerStop worker
+
+registerAttemptTransport
+  :: (Client client)
+  => TVar (AttemptState client)
+  -> client 'Connected
+  -> IO (IO ())
+registerAttemptTransport state conn = do
+  registerAttemptCleanup state $ abort conn
+
+registerAttemptCleanup
+  :: TVar (AttemptState client)
+  -> IO ()
+  -> IO (IO ())
+registerAttemptCleanup state cleanup = do
+  finalized <- newIORef False
+  let cleanupOnce = do
+        shouldRun <- atomicModifyIORef' finalized $ \done ->
+          (True, not done)
+        if shouldRun then cleanup else return ()
+  expired <- atomically $ do
+    current <- readTVar state
+    case current of
+      AttemptRunning _ -> do
+        writeTVar state $ AttemptRunning $ Just cleanupOnce
+        return False
+      AttemptExpired _ -> do
+        writeTVar state $ AttemptExpired False
+        return True
+      AttemptFinished _ -> return True
+  if expired
+    then do
+      requestCleanup cleanupOnce
+      throwIO SetupWorkerCancelled
+    else return cleanupOnce
+
+requestWorkerStop :: ThreadId -> IO ()
+requestWorkerStop worker = void $ forkIOWithUnmask $ \_ ->
+  throwTo worker SetupWorkerCancelled
+
+requestCleanup :: IO () -> IO ()
+requestCleanup cleanup = void $ forkIOWithUnmask $ \unmask ->
+  void (try (unmask cleanup) :: IO (Either SomeException ()))
 
 secondsToMicroseconds :: Int -> Int
 secondsToMicroseconds seconds =
@@ -99,6 +292,23 @@ connectPlaintext :: String -> Int -> IO (PlainTextClient 'Connected)
 connectPlaintext host port =
   connect $ NotConnectedPlainTextClient host (Just port)
 
+-- | Deadline-safe plaintext helper. Prefer this over 'connectPlaintext' when
+-- calling the connector directly outside a configured pool.
+connectPlaintextWithTimeout
+  :: Int
+  -> String
+  -> Int
+  -> IO (PlainTextClient 'Connected)
+connectPlaintextWithTimeout seconds host port =
+  withConnectionTimeoutSupervised seconds DNSResolution
+    (\supervisor _ ->
+      connectPlaintextWithCleanup
+        (setConnectionPhase supervisor)
+        (registerSetupCleanup supervisor)
+        host
+        (Just port))
+    (NodeAddress host port)
+
 -- | Connect a TLS client to a specific host and port.
 --
 -- @
@@ -107,6 +317,22 @@ connectPlaintext host port =
 connectTLS :: String -> Int -> IO (TLSClient 'Connected)
 connectTLS host port =
   connect $ NotConnectedTLSClient host (Just port)
+
+-- | Deadline-safe TLS helper. Prefer this over 'connectTLS' when calling the
+-- connector directly outside a configured pool.
+connectTLSWithTimeout
+  :: Int
+  -> String
+  -> Int
+  -> IO (TLSClient 'Connected)
+connectTLSWithTimeout seconds host port =
+  withConnectionTimeoutSupervised seconds DNSResolution
+    (\supervisor _ ->
+      connectTLSWithCleanup
+        (setConnectionPhase supervisor)
+        (registerSetupCleanup supervisor)
+        host host (Just port))
+    (NodeAddress host port)
 
 -- | Create a cluster connector for plaintext connections.
 -- Each cluster node will be connected to using its advertised address.
@@ -118,6 +344,17 @@ connectTLS host port =
 clusterPlaintextConnector :: Connector PlainTextClient
 clusterPlaintextConnector addr =
   connect $ NotConnectedPlainTextClient (nodeHost addr) (Just $ nodePort addr)
+
+clusterPlaintextConnectorWithTimeout
+  :: Int
+  -> Connector PlainTextClient
+clusterPlaintextConnectorWithTimeout seconds =
+  withConnectionTimeoutSupervised seconds DNSResolution $ \supervisor addr ->
+    connectPlaintextWithCleanup
+      (setConnectionPhase supervisor)
+      (registerSetupCleanup supervisor)
+      (nodeHost addr)
+      (Just $ nodePort addr)
 
 -- | Create a cluster connector for TLS connections.
 -- The @certHostname@ is used for TLS certificate validation, while each
@@ -132,3 +369,16 @@ clusterPlaintextConnector addr =
 clusterTLSConnector :: String -> Connector TLSClient
 clusterTLSConnector certHostname addr =
   connect $ NotConnectedTLSClientWithHostname certHostname (nodeHost addr) (Just $ nodePort addr)
+
+clusterTLSConnectorWithTimeout
+  :: Int
+  -> String
+  -> Connector TLSClient
+clusterTLSConnectorWithTimeout seconds certHostname =
+  withConnectionTimeoutSupervised seconds DNSResolution $ \supervisor addr ->
+    connectTLSWithCleanup
+      (setConnectionPhase supervisor)
+      (registerSetupCleanup supervisor)
+      certHostname
+      (nodeHost addr)
+      (Just $ nodePort addr)

--- a/hask-redis-mux/lib/cluster/Database/Redis/Connector.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Connector.hs
@@ -26,6 +26,9 @@
 module Database.Redis.Connector
   ( -- * Connector type
     Connector
+  , ConnectionPhase (..)
+  , ConnectionSetupException (..)
+  , withConnectionTimeout
     -- * Standalone connections
   , connectPlaintext
   , connectTLS
@@ -34,15 +37,58 @@ module Database.Redis.Connector
   , clusterTLSConnector
   ) where
 
+import           Control.Exception      (Exception, throwIO)
+import           Data.Typeable          (Typeable)
 import           Database.Redis.Client  (Client (connect),
                                          ConnectionStatus (..),
                                          PlainTextClient (NotConnectedPlainTextClient),
                                          TLSClient (NotConnectedTLSClient, NotConnectedTLSClientWithHostname))
 import           Database.Redis.Cluster (NodeAddress (..))
+import           System.Timeout         (timeout)
 
 -- | A function that creates a connected client for a given node address.
 -- Used throughout the cluster layer to establish connections on demand.
 type Connector client = NodeAddress -> IO (client 'Connected)
+
+-- | The connection setup covered by a configured deadline.
+data ConnectionPhase
+  = PlaintextConnectionSetup
+  | TLSConnectionSetup
+  deriving (Eq, Show, Typeable)
+
+-- | A connection setup attempt exceeded its configured wall-clock deadline.
+-- The endpoint and transport phase are retained without including connector
+-- arguments or credentials.
+data ConnectionSetupException = ConnectionSetupTimeout
+  { connectionTimeoutPhase    :: !ConnectionPhase
+  , connectionTimeoutEndpoint :: !NodeAddress
+  , connectionTimeoutSeconds  :: !Int
+  }
+  deriving (Eq, Show, Typeable)
+
+instance Exception ConnectionSetupException
+
+-- | Bound one complete connector action by a wall-clock deadline in seconds.
+-- For the built-in plaintext connector this covers DNS, socket setup, and TCP
+-- connect. For TLS it additionally covers certificate-store/context setup and
+-- the TLS handshake.
+withConnectionTimeout
+  :: Int
+  -> ConnectionPhase
+  -> Connector client
+  -> Connector client
+withConnectionTimeout seconds phase connector addr
+  | seconds <= 0 =
+      throwIO $ ConnectionSetupTimeout phase addr seconds
+  | otherwise = do
+      result <- timeout (secondsToMicroseconds seconds) $ connector addr
+      case result of
+        Nothing   -> throwIO $ ConnectionSetupTimeout phase addr seconds
+        Just conn -> return conn
+
+secondsToMicroseconds :: Int -> Int
+secondsToMicroseconds seconds =
+  fromInteger $ min (toInteger (maxBound :: Int)) (toInteger seconds * 1000000)
 
 -- | Connect a plaintext client to a specific host and port.
 --

--- a/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
@@ -43,7 +43,7 @@ import           Control.Concurrent.MVar          (MVar, modifyMVar,
                                                    putMVar, readMVar, takeMVar,
                                                    tryPutMVar, withMVar)
 import           Control.Exception                (Exception, SomeException,
-                                                   catch, finally, mask_,
+                                                   catch, finally, mask, mask_,
                                                    onException, throwIO,
                                                    toException, try,
                                                    uninterruptibleMask_)
@@ -440,10 +440,8 @@ createMultiplexerFromConnectorWithHandoffHook
   -> (client 'Connected -> IO ())
   -> IO Multiplexer
 createMultiplexerFromConnectorWithHandoffHook connector addr handoffHook =
-  mask_ $ do
-    -- Masking remains interruptible, so blocking DNS/connect/TLS work can
-    -- still be cancelled while the post-return ownership gap stays closed.
-    conn <- connector addr
+  mask $ \restore -> do
+    conn <- restore $ connector addr
     handoffHook conn
       `onException` (close conn `catch` \(_ :: SomeException) -> return ())
     createMultiplexer conn (receive conn)

--- a/hask-redis-mux/lib/redis/Database/Redis.hs
+++ b/hask-redis-mux/lib/redis/Database/Redis.hs
@@ -101,12 +101,18 @@ import           Database.Redis.Command                (ClientReplyValues (..),
                                                         parseWith, showBS)
 import           Database.Redis.Connector              (ConnectionPhase (..),
                                                         ConnectionSetupException (..),
+                                                        ConnectionSupervisor (..),
                                                         Connector,
                                                         clusterPlaintextConnector,
+                                                        clusterPlaintextConnectorWithTimeout,
                                                         clusterTLSConnector,
+                                                        clusterTLSConnectorWithTimeout,
                                                         connectPlaintext,
+                                                        connectPlaintextWithTimeout,
                                                         connectTLS,
-                                                        withConnectionTimeout)
+                                                        connectTLSWithTimeout,
+                                                        withConnectionTimeout,
+                                                        withConnectionTimeoutSupervised)
 import           Database.Redis.FromResp               (FromResp (..))
 import           Database.Redis.Internal.Multiplexer   (Multiplexer,
                                                         MultiplexerException (..),

--- a/hask-redis-mux/lib/redis/Database/Redis.hs
+++ b/hask-redis-mux/lib/redis/Database/Redis.hs
@@ -99,11 +99,14 @@ import           Database.Redis.Command                (ClientReplyValues (..),
                                                         encodeSetBuilder,
                                                         parseManyWith,
                                                         parseWith, showBS)
-import           Database.Redis.Connector              (Connector,
+import           Database.Redis.Connector              (ConnectionPhase (..),
+                                                        ConnectionSetupException (..),
+                                                        Connector,
                                                         clusterPlaintextConnector,
                                                         clusterTLSConnector,
                                                         connectPlaintext,
-                                                        connectTLS)
+                                                        connectTLS,
+                                                        withConnectionTimeout)
 import           Database.Redis.FromResp               (FromResp (..))
 import           Database.Redis.Internal.Multiplexer   (Multiplexer,
                                                         MultiplexerException (..),

--- a/hask-redis-mux/test/ClusterCommandSpec.hs
+++ b/hask-redis-mux/test/ClusterCommandSpec.hs
@@ -14,6 +14,7 @@ import           Control.Exception                     (SomeAsyncException,
                                                         SomeException, throwIO,
                                                         try)
 import qualified Control.Exception                     as Exception
+import           Control.Monad                         (replicateM_)
 import           Control.Monad.IO.Class                (liftIO)
 import           Data.ByteString                       (ByteString)
 import qualified Data.ByteString                       as BS
@@ -433,9 +434,11 @@ clusterLifecycleSpec = describe "Cluster client lifecycle" $ do
     readIORef connectionCount `shouldReturn` 1
     readIORef closeCount `shouldReturn` 1
 
-  it "bounds connection-timeout retries without topology-refresh amplification" $ do
+  it "bounds retries while failed TLS/AUTH cleanup is still unwinding" $ do
     attempts <- newIORef (0 :: Int)
     closeCount <- newIORef (0 :: Int)
+    cleanupFinished <- newIORef (0 :: Int)
+    cleanupRelease <- newEmptyMVar
     stalled <- newEmptyMVar
     topology <- mkTopology node1
     topologyVar <- newTVarIO topology
@@ -445,7 +448,7 @@ clusterLifecycleSpec = describe "Cluster client lifecycle" $ do
           { clusterPoolConfig =
               testPoolConfig
                 { connectionTimeout = 1
-                , useTLS = False
+                , useTLS = True
                 }
           , clusterMaxRetries = 2
           , clusterRetryDelay = 1000
@@ -454,12 +457,16 @@ clusterLifecycleSpec = describe "Cluster client lifecycle" $ do
           atomicModifyIORef' attempts $ \count -> (count + 1, ())
           _ <- Exception.onException
             (takeMVar stalled)
-            (atomicModifyIORef' closeCount $ \count -> (count + 1, ()))
+            (do
+              atomicModifyIORef' closeCount $ \count -> (count + 1, ())
+              takeMVar cleanupRelease
+              atomicModifyIORef' cleanupFinished $ \count ->
+                (count + 1, ()))
           sendBuf <- newIORef BS.empty
           recvQueue <- newIORef []
           return $ MockConnected sendBuf recvQueue closeCount
         boundedConnector =
-          withConnectionTimeout 1 PlaintextConnectionSetup connector
+          withConnectionTimeout 1 TLSConnectionSetup connector
 
     muxPool <- createMultiplexPool boundedConnector 1
     let client = ClusterClient
@@ -476,6 +483,11 @@ clusterLifecycleSpec = describe "Cluster client lifecycle" $ do
     elapsedSeconds `shouldSatisfy` \elapsed ->
       elapsed >= 1.5 && elapsed < 4
     readIORef attempts `shouldReturn` 2
+    timeout 1000000 (awaitIORefValue closeCount 2)
+      `shouldReturn` Just ()
+    replicateM_ 2 $ putMVar cleanupRelease ()
+    timeout 1000000 (awaitIORefValue cleanupFinished 2)
+      `shouldReturn` Just ()
     readIORef closeCount `shouldReturn` 2
     closeClusterClient client
     readIORef closeCount `shouldReturn` 2
@@ -550,8 +562,17 @@ clusterLifecycleSpec = describe "Cluster client lifecycle" $ do
             Nothing -> False
       _ -> expectationFailure "caller cancellation was not rethrown"
     readIORef attempts `shouldReturn` 1
+    timeout 1000000 (awaitIORefValue closeCount 1)
+      `shouldReturn` Just ()
     readIORef closeCount `shouldReturn` 1
     closeClusterClient client
+
+awaitIORefValue :: IORef Int -> Int -> IO ()
+awaitIORefValue ref expected = do
+  actual <- readIORef ref
+  if actual == expected
+    then return ()
+    else threadDelay 1000 >> awaitIORefValue ref expected
 
 -- ---------------------------------------------------------------------------
 -- ASK redirect integration tests

--- a/hask-redis-mux/test/ClusterCommandSpec.hs
+++ b/hask-redis-mux/test/ClusterCommandSpec.hs
@@ -1,15 +1,19 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE GADTs             #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main (main) where
 
-import           Control.Concurrent                    (forkIO, threadDelay)
+import           Control.Concurrent                    (forkFinally, forkIO,
+                                                        killThread, threadDelay)
 import           Control.Concurrent.MVar               (newEmptyMVar, newMVar,
                                                         putMVar, takeMVar)
 import           Control.Concurrent.STM                (newTVarIO)
-import           Control.Exception                     (SomeException, throwIO,
+import           Control.Exception                     (SomeAsyncException,
+                                                        SomeException, throwIO,
                                                         try)
+import qualified Control.Exception                     as Exception
 import           Control.Monad.IO.Class                (liftIO)
 import           Data.ByteString                       (ByteString)
 import qualified Data.ByteString                       as BS
@@ -31,10 +35,14 @@ import           Database.Redis.Cluster                (ClusterNode (..),
 import           Database.Redis.Cluster.Client
 import           Database.Redis.Cluster.ConnectionPool (PoolConfig (..),
                                                         createPool)
+import           Database.Redis.Connector              (ConnectionPhase (..),
+                                                        ConnectionSetupException (..),
+                                                        withConnectionTimeout)
 import           Database.Redis.Internal.MultiplexPool (closeMultiplexPool,
                                                         createMultiplexPool)
 import           Database.Redis.Resp                   (Encodable (..),
                                                         RespData (..))
+import           GHC.Clock                             (getMonotonicTimeNSec)
 import           System.Timeout                        (timeout)
 import           Test.Hspec
 
@@ -192,6 +200,13 @@ spec = do
     it "creates ConnectionError correctly" $ do
       let err = ConnectionError "Connection timeout"
       show err `shouldContain` "ConnectionError"
+
+    it "creates ConnectionTimeoutError without credentials" $ do
+      let timeoutError =
+            ConnectionSetupTimeout PlaintextConnectionSetup node1 5
+          err = ConnectionTimeoutError timeoutError
+      show err `shouldContain` "PlaintextConnectionSetup"
+      show err `shouldContain` "127.0.0.1"
 
     it "creates ClusterClientClosed correctly" $ do
       ClusterClientClosed `shouldBe` ClusterClientClosed
@@ -417,6 +432,126 @@ clusterLifecycleSpec = describe "Cluster client lifecycle" $ do
     keyed `shouldBe` Left ClusterClientClosed
     readIORef connectionCount `shouldReturn` 1
     readIORef closeCount `shouldReturn` 1
+
+  it "bounds connection-timeout retries without topology-refresh amplification" $ do
+    attempts <- newIORef (0 :: Int)
+    closeCount <- newIORef (0 :: Int)
+    stalled <- newEmptyMVar
+    topology <- mkTopology node1
+    topologyVar <- newTVarIO topology
+    discoveryPool <- createPool testPoolConfig
+    refreshLock <- newMVar ()
+    let retryConfig = testClusterConfig
+          { clusterPoolConfig =
+              testPoolConfig
+                { connectionTimeout = 1
+                , useTLS = False
+                }
+          , clusterMaxRetries = 2
+          , clusterRetryDelay = 1000
+          }
+        connector _ = do
+          atomicModifyIORef' attempts $ \count -> (count + 1, ())
+          _ <- Exception.onException
+            (takeMVar stalled)
+            (atomicModifyIORef' closeCount $ \count -> (count + 1, ()))
+          sendBuf <- newIORef BS.empty
+          recvQueue <- newIORef []
+          return $ MockConnected sendBuf recvQueue closeCount
+        boundedConnector =
+          withConnectionTimeout 1 PlaintextConnectionSetup connector
+
+    muxPool <- createMultiplexPool boundedConnector 1
+    let client = ClusterClient
+          topologyVar discoveryPool retryConfig connector refreshLock muxPool
+    started <- getMonotonicTimeNSec
+    result <- executeKeyedClusterCommand client "key" ["GET", "key"]
+    finished <- getMonotonicTimeNSec
+    let elapsedSeconds =
+          fromIntegral (finished - started) / 1000000000 :: Double
+
+    result `shouldSatisfy` \case
+      Left (MaxRetriesExceeded _) -> True
+      _                           -> False
+    elapsedSeconds `shouldSatisfy` \elapsed ->
+      elapsed >= 1.5 && elapsed < 4
+    readIORef attempts `shouldReturn` 2
+    readIORef closeCount `shouldReturn` 2
+    closeClusterClient client
+    readIORef closeCount `shouldReturn` 2
+
+  it "keeps synchronous connection failures inside the retry bound" $ do
+    attempts <- newIORef (0 :: Int)
+    topology <- mkTopology node1
+    topologyVar <- newTVarIO topology
+    discoveryPool <- createPool testPoolConfig
+    refreshLock <- newMVar ()
+    let retryConfig = testClusterConfig
+          { clusterMaxRetries = 2
+          , clusterRetryDelay = 1000
+          }
+        connector :: NodeAddress -> IO (MockClient 'Connected)
+        connector _ = do
+          atomicModifyIORef' attempts $ \count -> (count + 1, ())
+          throwIO $ userError "injected connection failure"
+
+    muxPool <- createMultiplexPool connector 1
+    let client = ClusterClient
+          topologyVar discoveryPool retryConfig connector refreshLock muxPool
+    result <- executeKeyedClusterCommand client "key" ["GET", "key"]
+
+    result `shouldSatisfy` \case
+      Left (MaxRetriesExceeded _) -> True
+      _                           -> False
+    readIORef attempts `shouldReturn` 4
+    closeClusterClient client
+
+  it "rethrows caller cancellation instead of retrying it" $ do
+    attempts <- newIORef (0 :: Int)
+    closeCount <- newIORef (0 :: Int)
+    connectorStarted <- newEmptyMVar
+    stalled <- newEmptyMVar
+    topology <- mkTopology node1
+    topologyVar <- newTVarIO topology
+    discoveryPool <- createPool testPoolConfig
+    refreshLock <- newMVar ()
+    let retryConfig = testClusterConfig
+          { clusterPoolConfig =
+              testPoolConfig { connectionTimeout = 5 }
+          , clusterMaxRetries = 3
+          }
+        connector _ = do
+          atomicModifyIORef' attempts $ \count -> (count + 1, ())
+          putMVar connectorStarted ()
+          _ <- Exception.onException
+            (takeMVar stalled)
+            (atomicModifyIORef' closeCount $ \count -> (count + 1, ()))
+          sendBuf <- newIORef BS.empty
+          recvQueue <- newIORef []
+          return $ MockConnected sendBuf recvQueue closeCount
+        boundedConnector =
+          withConnectionTimeout 5 PlaintextConnectionSetup connector
+
+    muxPool <- createMultiplexPool boundedConnector 1
+    let client = ClusterClient
+          topologyVar discoveryPool retryConfig connector refreshLock muxPool
+    finished <- newEmptyMVar
+    owner <- forkFinally
+      (executeKeyedClusterCommand client "key" ["GET", "key"])
+      (putMVar finished)
+    timeout 1000000 (takeMVar connectorStarted) `shouldReturn` Just ()
+    killThread owner
+    outcome <- timeout 1000000 (takeMVar finished)
+    case outcome of
+      Just (Left err) ->
+        (Exception.fromException err :: Maybe SomeAsyncException)
+          `shouldSatisfy` \case
+            Just _  -> True
+            Nothing -> False
+      _ -> expectationFailure "caller cancellation was not rethrown"
+    readIORef attempts `shouldReturn` 1
+    readIORef closeCount `shouldReturn` 1
+    closeClusterClient client
 
 -- ---------------------------------------------------------------------------
 -- ASK redirect integration tests

--- a/hask-redis-mux/test/ConnectionPoolSpec.hs
+++ b/hask-redis-mux/test/ConnectionPoolSpec.hs
@@ -87,6 +87,13 @@ awaitWaiters pool expected = do
     then return ()
     else threadDelay 1000 >> awaitWaiters pool expected
 
+awaitIORefValue :: IORef Int -> Int -> IO ()
+awaitIORefValue ref expected = do
+  actual <- readIORef ref
+  if actual == expected
+    then return ()
+    else threadDelay 1000 >> awaitIORefValue ref expected
+
 expectWithin :: IO a -> IO a
 expectWithin action =
   timeout 2000000 action >>= \case
@@ -161,6 +168,7 @@ main = hspec $ describe "ConnectionPool lifecycle" $ do
       elapsedSeconds `shouldSatisfy` \elapsed ->
         elapsed >= 0.75 && elapsed < 3
       readIORef attempts `shouldReturn` 1
+      expectWithin $ awaitIORefValue closeCount 1
       readIORef closeCount `shouldReturn` 1
       getConnectionPoolStats pool node
         `shouldReturn` ConnectionPoolStats 0 0 0

--- a/hask-redis-mux/test/ConnectionPoolSpec.hs
+++ b/hask-redis-mux/test/ConnectionPoolSpec.hs
@@ -9,6 +9,7 @@ import           Control.Concurrent                    (forkFinally, forkIO,
 import           Control.Concurrent.MVar               (MVar, newEmptyMVar,
                                                         putMVar, takeMVar)
 import           Control.Exception                     (SomeException)
+import qualified Control.Exception                     as Exception
 import           Control.Monad                         (forM, replicateM_)
 import           Control.Monad.IO.Class                (liftIO)
 import           Data.IORef                            (IORef,
@@ -18,6 +19,9 @@ import           Database.Redis.Client                 (Client (..),
                                                         ConnectionStatus (..))
 import           Database.Redis.Cluster                (NodeAddress (..))
 import           Database.Redis.Cluster.ConnectionPool
+import           Database.Redis.Connector              (ConnectionPhase (..),
+                                                        ConnectionSetupException (..))
+import           GHC.Clock                             (getMonotonicTimeNSec)
 import           System.Timeout                        (timeout)
 import           Test.Hspec
 
@@ -95,7 +99,7 @@ isRight :: Either a b -> Bool
 isRight = either (const False) (const True)
 
 main :: IO ()
-main = hspec $ describe "ConnectionPool cancellation safety" $ do
+main = hspec $ describe "ConnectionPool lifecycle" $ do
   it "recovers capacity when connector acquisition is cancelled" $ do
     pool <- createPool testPoolConfig
     connectionCount <- newIORef (0 :: Int)
@@ -123,6 +127,49 @@ main = hspec $ describe "ConnectionPool cancellation safety" $ do
       `shouldReturn` ConnectionPoolStats 1 1 0
     closePool pool
     readIORef closeCount `shouldReturn` 1
+
+  mapM_ (\(label, tlsEnabled, expectedPhase) ->
+    it ("bounds stalled " <> label <> " setup and closes its allocated resource once") $ do
+      attempts <- newIORef (0 :: Int)
+      closeCount <- newIORef (0 :: Int)
+      stalled <- newEmptyMVar
+      let config = testPoolConfig
+            { connectionTimeout = 1
+            , useTLS = tlsEnabled
+            }
+          connector _ = do
+            atomicModifyIORef' attempts $ \count -> (count + 1, ())
+            _ <- Exception.onException
+              (takeMVar stalled)
+              (atomicModifyIORef' closeCount $ \count -> (count + 1, ()))
+            return $ MockConnected 1 closeCount
+
+      pool <- createPool config
+      started <- getMonotonicTimeNSec
+      result <- (Exception.try $
+        withConnection pool node connector $ \_ -> return ())
+        :: IO (Either SomeException ())
+      finished <- getMonotonicTimeNSec
+      let elapsedSeconds =
+            fromIntegral (finished - started) / 1000000000 :: Double
+
+      result `shouldSatisfy` \case
+        Left err ->
+          Exception.fromException err
+            == Just (ConnectionSetupTimeout expectedPhase node 1)
+        Right () -> False
+      elapsedSeconds `shouldSatisfy` \elapsed ->
+        elapsed >= 0.75 && elapsed < 3
+      readIORef attempts `shouldReturn` 1
+      readIORef closeCount `shouldReturn` 1
+      getConnectionPoolStats pool node
+        `shouldReturn` ConnectionPoolStats 0 0 0
+      closePool pool
+      readIORef closeCount `shouldReturn` 1
+    )
+    [ ("plaintext TCP connect", False, PlaintextConnectionSetup)
+    , ("TLS handshake", True, TLSConnectionSetup)
+    ]
 
   it "removes cancelled saturated waiters before direct handoff" $ do
     pool <- createPool testPoolConfig

--- a/hask-redis-mux/test/ConnectionSetupSpec.hs
+++ b/hask-redis-mux/test/ConnectionSetupSpec.hs
@@ -1,0 +1,52 @@
+module Main (main) where
+
+import           Control.Concurrent.MVar               (MVar, newEmptyMVar,
+                                                        takeMVar)
+import           Control.Exception                     (throwIO)
+import           Data.IORef                            (atomicModifyIORef',
+                                                        newIORef, readIORef)
+import           Database.Redis.Client.ConnectionSetup (withSetupResource)
+import           GHC.Clock                             (getMonotonicTimeNSec)
+import           System.Timeout                        (timeout)
+import           Test.Hspec
+
+main :: IO ()
+main = hspec $ describe "Connection setup cleanup" $ do
+  mapM_ stalledSetupCase ["plaintext TCP connect", "TLS handshake"]
+  mapM_ failedSetupCase ["plaintext TCP connect", "TLS context setup", "TLS handshake"]
+
+stalledSetupCase :: String -> Spec
+stalledSetupCase phase =
+  it ("closes once when " <> phase <> " exceeds its deadline") $ do
+    allocations <- newIORef (0 :: Int)
+    closes <- newIORef (0 :: Int)
+    stalled <- newEmptyMVar :: IO (MVar ())
+    let acquire =
+          atomicModifyIORef' allocations $ \count -> (count + 1, count + 1)
+        release _ =
+          atomicModifyIORef' closes $ \count -> (count + 1, ())
+
+    started <- getMonotonicTimeNSec
+    result <- timeout 50000 $
+      withSetupResource acquire release $ \_ -> takeMVar stalled
+    finished <- getMonotonicTimeNSec
+    let elapsedSeconds =
+          fromIntegral (finished - started) / 1000000000 :: Double
+
+    result `shouldBe` Nothing
+    elapsedSeconds `shouldSatisfy` \elapsed ->
+      elapsed >= 0.02 && elapsed < 0.5
+    readIORef allocations `shouldReturn` 1
+    readIORef closes `shouldReturn` 1
+
+failedSetupCase :: String -> Spec
+failedSetupCase phase =
+  it ("closes once when " <> phase <> " fails") $ do
+    closes <- newIORef (0 :: Int)
+    let release _ =
+          atomicModifyIORef' closes $ \count -> (count + 1, ())
+        failure = throwIO $ userError $ "injected " <> phase <> " failure"
+
+    withSetupResource (return ()) release (const failure)
+      `shouldThrow` anyIOException
+    readIORef closes `shouldReturn` 1

--- a/hask-redis-mux/test/ConnectionSetupSpec.hs
+++ b/hask-redis-mux/test/ConnectionSetupSpec.hs
@@ -1,52 +1,261 @@
+{-# LANGUAGE DataKinds  #-}
+{-# LANGUAGE GADTs      #-}
+{-# LANGUAGE LambdaCase #-}
+
 module Main (main) where
 
+import           Control.Concurrent                    (threadDelay)
 import           Control.Concurrent.MVar               (MVar, newEmptyMVar,
-                                                        takeMVar)
-import           Control.Exception                     (throwIO)
-import           Data.IORef                            (atomicModifyIORef',
+                                                        putMVar, takeMVar)
+import           Control.Exception                     (SomeException, finally,
+                                                        fromException, throwIO,
+                                                        try)
+import           Control.Monad.IO.Class                (liftIO)
+import           Data.ByteString                       (ByteString)
+import           Data.IORef                            (IORef,
+                                                        atomicModifyIORef',
                                                         newIORef, readIORef)
-import           Database.Redis.Client.ConnectionSetup (withSetupResource)
+import           Database.Redis.Client                 (Client (..),
+                                                        ConnectionPhase (..),
+                                                        ConnectionStatus (..))
+import           Database.Redis.Client.ConnectionSetup (PlaintextSetupOperations (..),
+                                                        TLSSetupOperations (..),
+                                                        runPlaintextSetup,
+                                                        runTLSSetup)
+import           Database.Redis.Cluster                (NodeAddress (..))
+import           Database.Redis.Connector              (ConnectionSetupException (..),
+                                                        ConnectionSupervisor (..),
+                                                        clusterPlaintextConnectorWithTimeout,
+                                                        withConnectionTimeoutSupervised)
+import           Database.Redis.Standalone             (StandaloneConfig (..),
+                                                        defaultStandaloneConfig)
 import           GHC.Clock                             (getMonotonicTimeNSec)
 import           System.Timeout                        (timeout)
 import           Test.Hspec
 
+data TestClient (status :: ConnectionStatus) where
+  TestConnected :: IORef Int -> TestClient 'Connected
+
+instance Show (TestClient status) where
+  show _ = "TestClient"
+
+instance Client TestClient where
+  connect = error "TestClient: connect is not supported"
+  close = abort
+  abort (TestConnected closes) =
+    liftIO $ increment closes
+  send _ _ = return ()
+  receive _ = return (mempty :: ByteString)
+
+data Counters = Counters
+  { socketCloses  :: IORef Int
+  , contextCloses :: IORef Int
+  }
+
 main :: IO ()
-main = hspec $ describe "Connection setup cleanup" $ do
-  mapM_ stalledSetupCase ["plaintext TCP connect", "TLS handshake"]
-  mapM_ failedSetupCase ["plaintext TCP connect", "TLS context setup", "TLS handshake"]
+main = hspec $ do
+  describe "direct connector timeout boundary" $
+    it "supports the documented timeout-aware standalone connector" $ do
+      let config = defaultStandaloneConfig
+            { standaloneConnector =
+                clusterPlaintextConnectorWithTimeout 5
+            }
+      standaloneMultiplexerCount config `shouldBe` 1
+  describe "production plaintext setup deadline" $
+    mapM_ plaintextTimeoutCase
+      [ (DNSResolution, 0)
+      , (SocketCreation, 0)
+      , (SocketConfiguration, 1)
+      , (TCPConnection, 1)
+      ]
+  describe "production TLS setup deadline" $
+    mapM_ tlsTimeoutCase
+      [ (DNSResolution, 0, 0)
+      , (SocketCreation, 0, 0)
+      , (SocketConfiguration, 1, 0)
+      , (TCPConnection, 1, 0)
+      , (TLSContextCreation, 1, 0)
+      , (TLSHandshake, 1, 1)
+      ]
+  describe "production TLS synchronous failure" $
+    it "closes the context and socket exactly once after handshake failure" $ do
+      counters <- newCounters
+      started <- newEmptyMVar
+      release <- newEmptyMVar
+      let operations =
+            (tlsOperations counters Authentication started release)
+              { tlsRunHandshake =
+                  const $ throwIO $ userError "injected TLS handshake failure"
+              }
+      runTLSSetup
+        (const $ return ())
+        localTestCleanup
+        operations
+        `shouldThrow` anyIOException
+      readIORef (socketCloses counters) `shouldReturn` 1
+      readIORef (contextCloses counters) `shouldReturn` 1
 
-stalledSetupCase :: String -> Spec
-stalledSetupCase phase =
-  it ("closes once when " <> phase <> " exceeds its deadline") $ do
-    allocations <- newIORef (0 :: Int)
-    closes <- newIORef (0 :: Int)
-    stalled <- newEmptyMVar :: IO (MVar ())
-    let acquire =
-          atomicModifyIORef' allocations $ \count -> (count + 1, count + 1)
-        release _ =
-          atomicModifyIORef' closes $ \count -> (count + 1, ())
+plaintextTimeoutCase :: (ConnectionPhase, Int) -> Spec
+plaintextTimeoutCase (stalledPhase, expectedSocketCloses) =
+  it ("bounds and cleans " <> show stalledPhase) $ do
+    counters <- newCounters
+    started <- newEmptyMVar
+    release <- newEmptyMVar
+    workerFinished <- newEmptyMVar
+    let operations = plaintextOperations
+          counters stalledPhase started release
+        connector supervisor _ =
+          runPlaintextSetup
+            (setConnectionPhase supervisor)
+            (registerSetupCleanup supervisor)
+            operations
+            `finally` putMVar workerFinished ()
+    assertTimeout stalledPhase counters expectedSocketCloses 0
+      workerFinished $ withConnectionTimeoutSupervised
+        1 DNSResolution connector testNode
 
-    started <- getMonotonicTimeNSec
-    result <- timeout 50000 $
-      withSetupResource acquire release $ \_ -> takeMVar stalled
-    finished <- getMonotonicTimeNSec
-    let elapsedSeconds =
-          fromIntegral (finished - started) / 1000000000 :: Double
+tlsTimeoutCase :: (ConnectionPhase, Int, Int) -> Spec
+tlsTimeoutCase
+    (stalledPhase, expectedSocketCloses, expectedContextCloses) =
+  it ("bounds and cleans " <> show stalledPhase) $ do
+    counters <- newCounters
+    started <- newEmptyMVar
+    release <- newEmptyMVar
+    workerFinished <- newEmptyMVar
+    let operations = tlsOperations
+          counters stalledPhase started release
+        connector supervisor _ =
+          runTLSSetup
+            (setConnectionPhase supervisor)
+            (registerSetupCleanup supervisor)
+            operations
+            `finally` putMVar workerFinished ()
+    assertTimeout stalledPhase counters
+      expectedSocketCloses expectedContextCloses workerFinished $
+        withConnectionTimeoutSupervised
+          1 DNSResolution connector testNode
 
-    result `shouldBe` Nothing
-    elapsedSeconds `shouldSatisfy` \elapsed ->
-      elapsed >= 0.02 && elapsed < 0.5
-    readIORef allocations `shouldReturn` 1
-    readIORef closes `shouldReturn` 1
+assertTimeout
+  :: ConnectionPhase
+  -> Counters
+  -> Int
+  -> Int
+  -> MVar ()
+  -> IO (TestClient 'Connected)
+  -> Expectation
+assertTimeout expectedPhase counters expectedSocketCloses
+    expectedContextCloses workerFinished action = do
+  startedAt <- getMonotonicTimeNSec
+  result <- try action :: IO (Either SomeException (TestClient 'Connected))
+  finishedAt <- getMonotonicTimeNSec
+  let elapsed =
+        fromIntegral (finishedAt - startedAt) / 1000000000 :: Double
+  result `shouldSatisfy` \case
+    Left err ->
+      case fromExceptionTimeout err of
+        Just timeoutError ->
+          connectionTimeoutPhase timeoutError == expectedPhase
+            && connectionTimeoutEndpoint timeoutError == testNode
+        Nothing -> False
+    Right _ -> False
+  elapsed `shouldSatisfy` \seconds ->
+    seconds >= 0.75 && seconds < 2.5
+  timeout 1000000 (takeMVar workerFinished) `shouldReturn` Just ()
+  awaitExpected (socketCloses counters) expectedSocketCloses
+  awaitExpected (contextCloses counters) expectedContextCloses
+  readIORef (socketCloses counters) `shouldReturn` expectedSocketCloses
+  readIORef (contextCloses counters) `shouldReturn` expectedContextCloses
 
-failedSetupCase :: String -> Spec
-failedSetupCase phase =
-  it ("closes once when " <> phase <> " fails") $ do
-    closes <- newIORef (0 :: Int)
-    let release _ =
-          atomicModifyIORef' closes $ \count -> (count + 1, ())
-        failure = throwIO $ userError $ "injected " <> phase <> " failure"
+fromExceptionTimeout :: SomeException -> Maybe ConnectionSetupException
+fromExceptionTimeout = fromException
 
-    withSetupResource (return ()) release (const failure)
-      `shouldThrow` anyIOException
-    readIORef closes `shouldReturn` 1
+plaintextOperations
+  :: Counters
+  -> ConnectionPhase
+  -> MVar ()
+  -> MVar ()
+  -> PlaintextSetupOperations Int Int (TestClient 'Connected)
+plaintextOperations counters stalledPhase started release =
+  PlaintextSetupOperations
+    { plaintextResolve = stall DNSResolution $ return 1
+    , plaintextOpenSocket = stall SocketCreation $ return 2
+    , plaintextConfigureSocket =
+        \_ -> stall SocketConfiguration $ return ()
+    , plaintextConnectSocket =
+        \_ _ -> stall TCPConnection $ return ()
+    , plaintextCloseSocket = const $ increment $ socketCloses counters
+    , plaintextConnected = \_ _ _ ->
+        TestConnected $ socketCloses counters
+    }
+  where
+    stall :: ConnectionPhase -> IO a -> IO a
+    stall phase = stallAt stalledPhase phase started release
+
+tlsOperations
+  :: Counters
+  -> ConnectionPhase
+  -> MVar ()
+  -> MVar ()
+  -> TLSSetupOperations Int Int () Int (TestClient 'Connected)
+tlsOperations counters stalledPhase started release =
+  TLSSetupOperations
+    { tlsResolve = stall DNSResolution $ return 1
+    , tlsOpenSocket = stall SocketCreation $ return 2
+    , tlsConfigureSocket =
+        \_ -> stall SocketConfiguration $ return ()
+    , tlsConnectSocket =
+        \_ _ -> stall TCPConnection $ return ()
+    , tlsCloseSocket = const $ increment $ socketCloses counters
+    , tlsLoadStore = return ()
+    , tlsCreateContext =
+        \_ _ -> stall TLSContextCreation $ return 3
+    , tlsCloseContext = const $ increment $ contextCloses counters
+    , tlsRunHandshake =
+        \_ -> stall TLSHandshake $ return ()
+    , tlsConnected = \_ _ _ _ ->
+        TestConnected $ socketCloses counters
+    }
+  where
+    stall :: ConnectionPhase -> IO a -> IO a
+    stall phase = stallAt stalledPhase phase started release
+
+stallAt
+  :: ConnectionPhase
+  -> ConnectionPhase
+  -> MVar ()
+  -> MVar ()
+  -> IO a
+  -> IO a
+stallAt selected current started release action
+  | selected == current = putMVar started () >> takeMVar release >> action
+  | otherwise = action
+
+newCounters :: IO Counters
+newCounters =
+  Counters <$> newIORef 0 <*> newIORef 0
+
+increment :: IORef Int -> IO ()
+increment ref =
+  atomicModifyIORef' ref $ \count -> (count + 1, ())
+
+localTestCleanup :: IO () -> IO (IO ())
+localTestCleanup cleanup = do
+  finalized <- newIORef False
+  return $ do
+    shouldRun <- atomicModifyIORef' finalized $ \done ->
+      (True, not done)
+    if shouldRun then cleanup else return ()
+
+awaitExpected :: IORef Int -> Int -> IO ()
+awaitExpected _ 0 = return ()
+awaitExpected ref expected =
+  timeout 1000000 loop `shouldReturn` Just ()
+  where
+    loop = do
+      actual <- readIORef ref
+      if actual == expected
+        then return ()
+        else threadDelay 1000 >> loop
+
+testNode :: NodeAddress
+testNode = NodeAddress "redis.test" 6379

--- a/hask-redis-mux/test/PublicApiSpec.hs
+++ b/hask-redis-mux/test/PublicApiSpec.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE DataKinds  #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Main (main) where
+
+import           Control.Exception (try)
+import           Database.Redis
+import           Test.Hspec
+
+main :: IO ()
+main = hspec $ describe "Database.Redis timeout-aware public API" $ do
+  it "exports and enforces the documented direct TLS deadline" $ do
+    result <- try $ connectTLSWithTimeout 0 "redis.example.net" 6380
+      :: IO (Either ConnectionSetupException (TLSClient 'Connected))
+    assertImmediateTimeout (NodeAddress "redis.example.net" 6380) result
+
+  it "exports and enforces the documented standalone connector deadline" $ do
+    let endpoint = NodeAddress "redis.example.net" 6379
+    result <- try $ clusterPlaintextConnectorWithTimeout 0 endpoint
+      :: IO (Either ConnectionSetupException (PlainTextClient 'Connected))
+    assertImmediateTimeout endpoint result
+
+assertImmediateTimeout
+  :: NodeAddress
+  -> Either ConnectionSetupException client
+  -> Expectation
+assertImmediateTimeout endpoint = \case
+  Left timeoutError -> do
+    connectionTimeoutPhase timeoutError `shouldBe` DNSResolution
+    connectionTimeoutEndpoint timeoutError `shouldBe` endpoint
+    connectionTimeoutSeconds timeoutError `shouldBe` 0
+  Right _ ->
+    expectationFailure "timeout-aware helper unexpectedly connected"

--- a/redis-client.cabal
+++ b/redis-client.cabal
@@ -55,6 +55,20 @@ test-suite CredentialSpec
                     , hask-redis-mux
                     , mtl
 
+test-suite ClusterSetupSpec
+    import:           test-defaults
+    type:             exitcode-stdio-1.0
+    main-is:          ClusterSetupSpec.hs
+    other-modules:    AppConfig
+                    , ClusterSetup
+                    , CredentialConfig
+    hs-source-dirs:   app
+    build-depends:    bytestring
+                    , containers
+                    , hask-redis-mux
+                    , mtl
+                    , stm
+
 -- ---------------------------------------------------------------------------
 -- Flags
 -- ---------------------------------------------------------------------------

--- a/test/ClusterSetupSpec.hs
+++ b/test/ClusterSetupSpec.hs
@@ -1,55 +1,134 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs     #-}
+{-# LANGUAGE DataKinds  #-}
+{-# LANGUAGE GADTs      #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Main (main) where
 
-import           AppConfig               (RunState (..), defaultRunState)
-import           ClusterSetup            (authenticateClient)
-import           Control.Concurrent      (forkFinally, killThread)
-import           Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, takeMVar)
-import           Control.Monad.IO.Class  (liftIO)
-import           Data.ByteString         (ByteString)
-import           Data.IORef              (IORef, atomicModifyIORef', newIORef,
-                                          readIORef)
-import           Database.Redis.Client   (Client (..), ConnectionStatus (..))
-import           System.Timeout          (timeout)
+import           AppConfig                (RunState (..), defaultRunState)
+import           ClusterSetup             (authenticateClient,
+                                           createAuthenticatedConnectorWithTimeout)
+import           Control.Concurrent       (forkFinally, killThread)
+import           Control.Concurrent.MVar  (newEmptyMVar, putMVar, takeMVar)
+import           Control.Exception        (SomeException, finally,
+                                           fromException, throwIO, try)
+import           Control.Monad.IO.Class   (liftIO)
+import           Data.ByteString          (ByteString)
+import           Data.IORef               (IORef, atomicModifyIORef', newIORef,
+                                           readIORef)
+import           Data.List                (isInfixOf)
+import           Database.Redis.Client    (Client (..), ConnectionPhase (..),
+                                           ConnectionStatus (..))
+import           Database.Redis.Cluster   (NodeAddress (..))
+import           Database.Redis.Connector (ConnectionSetupException (..))
+import           GHC.Clock                (getMonotonicTimeNSec)
+import           System.Timeout           (timeout)
 import           Test.Hspec
 
-data AuthClient (a :: ConnectionStatus) where
+data AuthClient (status :: ConnectionStatus) where
   AuthConnected
     :: !(IORef Int)
-    -> !(MVar ())
-    -> !(MVar ())
+    -> !(IORef Int)
+    -> !(IO ByteString)
     -> AuthClient 'Connected
+
+instance Show (AuthClient status) where
+  show _ = "AuthClient"
 
 instance Client AuthClient where
   connect = error "AuthClient: connect not supported"
-  close (AuthConnected closeCount _ _) =
-    liftIO $ atomicModifyIORef' closeCount $ \count -> (count + 1, ())
+  close (AuthConnected gracefulCloseCount _ _) =
+    liftIO $ increment gracefulCloseCount
+  abort (AuthConnected _ abortCount _) =
+    liftIO $ increment abortCount
   send _ _ = return ()
-  receive (AuthConnected _ receiveStarted stalled) = liftIO $ do
-    putMVar receiveStarted ()
-    takeMVar stalled
-    return (mempty :: ByteString)
+  receive (AuthConnected _ _ receiveAction) = liftIO receiveAction
 
 main :: IO ()
-main = hspec $ describe "authenticated connector cleanup" $ do
-  it "closes a connected transport when authentication is cancelled" $ do
-    closeCount <- newIORef (0 :: Int)
+main = hspec $ describe "authenticated production connector" $ do
+  it "uses abortive cleanup when direct authentication is cancelled" $ do
+    gracefulCloses <- newIORef (0 :: Int)
+    aborts <- newIORef (0 :: Int)
     receiveStarted <- newEmptyMVar
     stalled <- newEmptyMVar
     finished <- newEmptyMVar
-    let state = defaultRunState
-          { username = "default"
-          , password = "synthetic-credential"
-          }
-        client = AuthConnected closeCount receiveStarted stalled
+    let client = AuthConnected gracefulCloses aborts $
+          putMVar receiveStarted () >> takeMVar stalled
 
-    owner <- forkFinally (authenticateClient state client) (putMVar finished)
+    owner <- forkFinally
+      (authenticateClient credentialState client)
+      (putMVar finished)
     timeout 1000000 (takeMVar receiveStarted) `shouldReturn` Just ()
     killThread owner
     outcome <- timeout 1000000 (takeMVar finished)
-    case outcome of
-      Just (Left _) -> return ()
-      _             -> expectationFailure "authentication cancellation was not rethrown"
-    readIORef closeCount `shouldReturn` 1
+    outcome `shouldSatisfy` \case
+      Just (Left _) -> True
+      _             -> False
+    readIORef gracefulCloses `shouldReturn` 0
+    readIORef aborts `shouldReturn` 1
+
+  it "times out the actual authenticated connector with typed redacted error" $ do
+    gracefulCloses <- newIORef (0 :: Int)
+    aborts <- newIORef (0 :: Int)
+    receiveStarted <- newEmptyMVar
+    stalled <- newEmptyMVar
+    workerFinished <- newEmptyMVar
+    let receiveAction =
+          (putMVar receiveStarted () >> takeMVar stalled)
+            `finally` putMVar workerFinished ()
+        client = AuthConnected gracefulCloses aborts receiveAction
+        connector = createAuthenticatedConnectorWithTimeout
+          1 credentialState (\_ _ -> return client)
+
+    startedAt <- getMonotonicTimeNSec
+    result <- try $ connector testNode
+      :: IO (Either SomeException (AuthClient 'Connected))
+    finishedAt <- getMonotonicTimeNSec
+    let elapsed =
+          fromIntegral (finishedAt - startedAt) / 1000000000 :: Double
+
+    result `shouldSatisfy` \case
+      Left err ->
+        case fromException err of
+          Just timeoutError ->
+            connectionTimeoutPhase timeoutError == Authentication
+              && connectionTimeoutEndpoint timeoutError == testNode
+              && not (syntheticCredential `isInfixOf` show timeoutError)
+          Nothing -> False
+      Right _ -> False
+    elapsed `shouldSatisfy` \seconds ->
+      seconds >= 0.75 && seconds < 2.5
+    timeout 1000000 (takeMVar workerFinished) `shouldReturn` Just ()
+    readIORef gracefulCloses `shouldReturn` 0
+    readIORef aborts `shouldReturn` 1
+
+  it "abortively closes exactly once on synchronous AUTH failure" $ do
+    gracefulCloses <- newIORef (0 :: Int)
+    aborts <- newIORef (0 :: Int)
+    let client = AuthConnected gracefulCloses aborts $
+          throwIO $ userError "synthetic AUTH rejection"
+        connector = createAuthenticatedConnectorWithTimeout
+          5 credentialState (\_ _ -> return client)
+
+    result <- try $ connector testNode
+      :: IO (Either SomeException (AuthClient 'Connected))
+    result `shouldSatisfy` \case
+      Left err -> not (syntheticCredential `isInfixOf` show err)
+      Right _  -> False
+    readIORef gracefulCloses `shouldReturn` 0
+    readIORef aborts `shouldReturn` 1
+
+credentialState :: RunState
+credentialState = defaultRunState
+  { username = "default"
+  , password = syntheticCredential
+  }
+
+syntheticCredential :: String
+syntheticCredential = "synthetic-secret-for-redaction"
+
+testNode :: NodeAddress
+testNode = NodeAddress "redis.test" 6380
+
+increment :: IORef Int -> IO ()
+increment ref =
+  atomicModifyIORef' ref $ \count -> (count + 1, ())

--- a/test/ClusterSetupSpec.hs
+++ b/test/ClusterSetupSpec.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs     #-}
+
+module Main (main) where
+
+import           AppConfig               (RunState (..), defaultRunState)
+import           ClusterSetup            (authenticateClient)
+import           Control.Concurrent      (forkFinally, killThread)
+import           Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, takeMVar)
+import           Control.Monad.IO.Class  (liftIO)
+import           Data.ByteString         (ByteString)
+import           Data.IORef              (IORef, atomicModifyIORef', newIORef,
+                                          readIORef)
+import           Database.Redis.Client   (Client (..), ConnectionStatus (..))
+import           System.Timeout          (timeout)
+import           Test.Hspec
+
+data AuthClient (a :: ConnectionStatus) where
+  AuthConnected
+    :: !(IORef Int)
+    -> !(MVar ())
+    -> !(MVar ())
+    -> AuthClient 'Connected
+
+instance Client AuthClient where
+  connect = error "AuthClient: connect not supported"
+  close (AuthConnected closeCount _ _) =
+    liftIO $ atomicModifyIORef' closeCount $ \count -> (count + 1, ())
+  send _ _ = return ()
+  receive (AuthConnected _ receiveStarted stalled) = liftIO $ do
+    putMVar receiveStarted ()
+    takeMVar stalled
+    return (mempty :: ByteString)
+
+main :: IO ()
+main = hspec $ describe "authenticated connector cleanup" $ do
+  it "closes a connected transport when authentication is cancelled" $ do
+    closeCount <- newIORef (0 :: Int)
+    receiveStarted <- newEmptyMVar
+    stalled <- newEmptyMVar
+    finished <- newEmptyMVar
+    let state = defaultRunState
+          { username = "default"
+          , password = "synthetic-credential"
+          }
+        client = AuthConnected closeCount receiveStarted stalled
+
+    owner <- forkFinally (authenticateClient state client) (putMVar finished)
+    timeout 1000000 (takeMVar receiveStarted) `shouldReturn` Just ()
+    killThread owner
+    outcome <- timeout 1000000 (takeMVar finished)
+    case outcome of
+      Just (Left _) -> return ()
+      _             -> expectationFailure "authentication cancellation was not rethrown"
+    readIORef closeCount `shouldReturn` 1


### PR DESCRIPTION
Closes #80

## Timeout contract
- `PoolConfig.connectionTimeout` is a per-attempt wall-clock deadline in seconds.
- Plaintext setup includes DNS resolution, socket allocation/options, and TCP connect.
- TLS setup includes the plaintext phases plus certificate-store loading, TLS context creation, and handshake.
- The existing 300-second receive timeout is explicitly separate and applies only after connection establishment.

## Cleanup and cancellation
- Real plaintext and TLS setup share an acquisition combinator that closes each allocated socket exactly once on synchronous failure, timeout, or cancellation before ownership transfer.
- Socket-option, TCP-connect, TLS-context, and handshake failures are covered.
- Authenticated CLI connectors close an established transport if AUTH fails, times out, or is cancelled.
- Existing #48 exactly-once multiplexer finalization and #51 checkout/cancellation accounting remain intact.

## Typed failures and retries
- `ConnectionSetupTimeout` preserves plaintext/TLS phase, endpoint, and configured seconds without connector arguments or credentials.
- Ordinary connection pools and cluster multiplexers apply the same deadline.
- Timeout failures retry without starting an additional topology refresh connection.
- Synchronous connection and refresh failures remain inside the configured retry count.
- User asynchronous cancellation is rethrown rather than converted into a retryable error.
- Stale-topology, MOVED, ordinary keyed, keyless, and ASK paths share the same exception classification.

## Deterministic coverage
- Stalled plaintext connect and TLS handshake deadlines with elapsed bounds and exact close counters.
- Plaintext connect, TLS context, and TLS handshake synchronous failure cleanup.
- Two-attempt cluster timeout wall-clock bound with no refresh amplification.
- Bounded synchronous connection failures.
- Caller cancellation propagation without retry.
- Authentication cancellation after transport establishment closes once.
- Existing multiplexer, multiplex-pool, standalone, TLS-config, #47, #48, and #51 focused lifecycle suites remain green.

## Validation
- Focused local suites: 115 examples, 0 failures.
- `nix-build --no-out-link`: passed.
- Full local E2E was not run per repository policy; required GitHub Actions `build` is the authoritative full E2E gate.

## Profile
Comparable `ConnectionPoolSpec +RTS -p`:
- allocation: `2,838,032` -> `3,030,832` bytes (`+192,800`, `+6.79%`), including two new one-second deadline/cleanup tests;
- sampled CPU time: `0.01s` -> `0.02s`;
- `withConnectionTimeout` accounts for 1.4% of profiled allocation and runs only when creating a new connection, not on pooled reuse.

No serious hot-path regression observed. Profiling artifacts were removed.

Ready for Performance and Tester review. Auto-merge is not enabled.