### PR TITLE
Encode RESP3 maps with the percent marker

### DIFF
--- a/hask-redis-mux/lib/resp/Database/Redis/Resp.hs
+++ b/hask-redis-mux/lib/resp/Database/Redis/Resp.hs
@@ -63,7 +63,7 @@ instance Encodable RespData where
   encode RespNullBulkString = Builder.byteString "$-1\r\n"
   encode (RespArray !xs) = Builder.char8 '*' <> Builder.intDec (length xs) <> Builder.byteString "\r\n" <> foldMap encode xs
   encode (RespSet !s) = Builder.char8 '~' <> Builder.intDec (S.size s) <> Builder.byteString "\r\n" <> foldMap encode (S.toList s)
-  encode (RespMap !m) = Builder.char8 '*' <> Builder.intDec (M.size m) <> Builder.byteString "\r\n" <> foldMap encodePair (M.toList m)
+  encode (RespMap !m) = Builder.char8 '%' <> Builder.intDec (M.size m) <> Builder.byteString "\r\n" <> foldMap encodePair (M.toList m)
     where
       encodePair (k, v) = encode k <> encode v
 

--- a/hask-redis-mux/test/Spec.hs
+++ b/hask-redis-mux/test/Spec.hs
@@ -38,8 +38,8 @@ main = hspec $ do
 
     it "encodes maps correctly" $ do
       let mapData = M.fromList [(RespSimpleString "first", RespInteger 1), (RespSimpleString "second", RespBulkString "bulkString")]
-      Builder.toLazyByteString (encode (RespMap mapData)) `shouldBe` "*2\r\n+first\r\n:1\r\n+second\r\n$10\r\nbulkString\r\n"
-      Builder.toLazyByteString (encode (RespMap M.empty)) `shouldBe` "*0\r\n"
+      Builder.toLazyByteString (encode (RespMap mapData)) `shouldBe` "%2\r\n+first\r\n:1\r\n+second\r\n$10\r\nbulkString\r\n"
+      Builder.toLazyByteString (encode (RespMap M.empty)) `shouldBe` "%0\r\n"
 
     it "encodes sets correctly" $ do
       let setData = S.fromList [RespSimpleString "Hello", RespInteger 5, RespBulkString "im very long"]
@@ -175,6 +175,25 @@ main = hspec $ do
       let mapData = M.fromList [(RespSimpleString "first", RespInteger 1), (RespSimpleString "second", RespBulkString "bulkString")]
       parseOnly parseRespData "%2\r\n+first\r\n:1\r\n+second\r\n$10\r\nbulkString\r\n" `shouldBe` Right (RespMap mapData)
       parseOnly parseRespData "%0\r\n" `shouldBe` Right (RespMap M.empty)
+
+    it "roundtrips empty maps" $ do
+      let respMap = RespMap M.empty
+          encoded = Builder.toLazyByteString (encode respMap)
+      encoded `shouldBe` "%0\r\n"
+      parseOnly parseRespData (LBS.toStrict encoded) `shouldBe` Right respMap
+
+    it "roundtrips non-empty maps" $ do
+      let respMap = RespMap (M.fromList [(RespSimpleString "key", RespInteger 1)])
+          encoded = Builder.toLazyByteString (encode respMap)
+      encoded `shouldBe` "%1\r\n+key\r\n:1\r\n"
+      parseOnly parseRespData (LBS.toStrict encoded) `shouldBe` Right respMap
+
+    it "roundtrips nested maps" $ do
+      let innerMap = RespMap (M.fromList [(RespSimpleString "inner", RespArray [RespInteger 1, RespInteger 2])])
+          respMap = RespMap (M.fromList [(RespSimpleString "outer", innerMap)])
+          encoded = Builder.toLazyByteString (encode respMap)
+      encoded `shouldBe` "%1\r\n+outer\r\n%1\r\n+inner\r\n*2\r\n:1\r\n:2\r\n"
+      parseOnly parseRespData (LBS.toStrict encoded) `shouldBe` Right respMap
 
     it "parses sets correctly" $ do
       let setData = S.fromList [RespSimpleString "Hello", RespInteger 5, RespBulkString "im very long"]


### PR DESCRIPTION
## Summary
- encode public `RespMap` values with the RESP3 `%` marker
- declare map aggregate lengths as entry counts while encoding one key and one value per entry
- retain existing RESP array `*` encoding and add exact empty, populated, and nested map round trips

## Scope
This is a correctness fix for the already-public RESP3 value encoder. It does not add RESP3 negotiation or broaden the RESP2-first protocol contract accepted in #93.

## Validation
- `nix-build --no-out-link`
- `nix-shell --run "cabal test hask-redis-mux:RespSpec --test-show-details=direct"` — 49 examples, 0 failures
- Tester review: approved
- Fact Checker review: approved

## Profiling
No comparable before/after profile was captured: the repository has no RESP encoding benchmark or executable whose workload meaningfully exercises this one-byte marker correction. `ConnectionPoolBench` measures connection-pool behavior, and the CLI benchmark exercises network command throughput, so either would be an unrelated proxy.

## Risk
Low and localized. Exact wire tests cover map markers/counts and parser symmetry; no live RESP3-server interoperability test was added.

Closes #46