### PR TITLE
Honor Redis hash tags after key prefixes

### DIFF
--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster.hs
@@ -74,35 +74,34 @@ data ClusterTopology = ClusterTopology
   deriving (Show)
 
 -- | Calculate the hash slot (0–16383) for a Redis key.
--- Respects hash tags: if the key starts with @{tag}@, only @tag@ is hashed.
+-- Respects hash tags: non-empty bytes inside the first brace candidate are hashed.
 calculateSlot :: ByteString -> Word16
 calculateSlot key =
   let !hashKey = extractHashTag key
   in crc16 hashKey
 {-# INLINE calculateSlot #-}
 
--- | Extract hash tag from a key if present
--- Pattern: {tag} - returns the content within the first valid {} pair
+-- | Extract the Redis Cluster hash tag from a key, if present.
+-- The first opening brace and the first closing brace after it form the only
+-- candidate. The enclosed bytes are used when non-empty; otherwise the full key
+-- is returned.
 -- Examples:
 --   "{user}:profile" -> "user"
+--   "prefix{user}:profile" -> "user"
 --   "key" -> "key"
 --   "{}" -> "{}"
 --   "{user" -> "{user"
---   "key{tag}" -> "key{tag}" (no tag at end)
+--   "foo{}{bar}" -> "foo{}{bar}"
 extractHashTag :: ByteString -> ByteString
 extractHashTag key =
-  case BS.breakSubstring "{" key of
-    (before, rest)
-      | not (BS.null rest) && not (BS.null before) ->
-          -- Found { but there's content before it - no valid tag
-          key
-      | not (BS.null rest) ->
-          -- Found { at start, check for closing }
-          case BS.breakSubstring "}" (BS.tail rest) of
-            (tag, after)
-              | not (BS.null after) && not (BS.null tag) -> tag
+  case BS.break (== 0x7b) key of
+    (_, rest)
+      | BS.null rest -> key
+      | otherwise ->
+          case BS.break (== 0x7d) (BS.tail rest) of
+            (tag, closing)
+              | not (BS.null tag) && not (BS.null closing) -> tag
               | otherwise -> key
-      | otherwise -> key
 
 -- | Parse the RESP response from @CLUSTER SLOTS@ into a 'ClusterTopology'.
 -- Returns 'Left' with an error message if the response format is unexpected.

--- a/hask-redis-mux/test/ClusterSpec.hs
+++ b/hask-redis-mux/test/ClusterSpec.hs
@@ -2,6 +2,7 @@
 
 module Main (main) where
 
+import qualified Data.ByteString        as BS
 import qualified Data.ByteString.Char8  as BS8
 import           Data.Time.Clock        (getCurrentTime)
 import           Database.Redis.Cluster
@@ -17,37 +18,62 @@ spec = do
     it "extracts hash tag from valid key" $ do
       extractHashTag "{user}:profile" `shouldBe` "user"
       extractHashTag "{user}:settings" `shouldBe` "user"
+      extractHashTag "prefix{user}:profile" `shouldBe` "user"
+      extractHashTag "prefix{user}" `shouldBe` "user"
 
     it "returns full key when no hash tag present" $ do
       extractHashTag "simple-key" `shouldBe` "simple-key"
       extractHashTag "key:with:colons" `shouldBe` "key:with:colons"
 
-    it "handles edge cases correctly" $ do
-      -- Empty tag
-      extractHashTag "{}" `shouldBe` "{}"
-      -- No closing brace
-      extractHashTag "{user" `shouldBe` "{user"
-      -- No opening brace
-      extractHashTag "user}" `shouldBe` "user}"
-      -- Multiple braces - uses first valid pair
+    it "uses only the first brace candidate" $ do
       extractHashTag "{first}{second}" `shouldBe` "first"
-      -- Braces at end
-      extractHashTag "key{tag}" `shouldBe` "key{tag}"
+      extractHashTag "prefix{first}{second}" `shouldBe` "first"
+      extractHashTag "prefix{}{second}" `shouldBe` "prefix{}{second}"
+      extractHashTag "prefix{{first}}suffix" `shouldBe` "{first"
+
+    it "falls back to the full key for empty or unmatched tags" $ do
+      extractHashTag "{}" `shouldBe` "{}"
+      extractHashTag "prefix{}suffix" `shouldBe` "prefix{}suffix"
+      extractHashTag "{user" `shouldBe` "{user"
+      extractHashTag "prefix{user" `shouldBe` "prefix{user"
+      extractHashTag "user}" `shouldBe` "user}"
 
     it "handles special characters in hash tags" $ do
       extractHashTag "{user:1}" `shouldBe` "user:1"
       extractHashTag "{a-b}" `shouldBe` "a-b"
       extractHashTag "{tag.with.dots}" `shouldBe` "tag.with.dots"
 
+    it "handles binary bytes without text decoding" $ do
+      extractHashTag (BS.pack [0x00, 0x7b, 0xff, 0x7d, 0x01])
+        `shouldBe` BS.singleton 0xff
+
   describe "Slot calculation" $ do
-    it "calculates slot within valid range" $ do
-      let slot = calculateSlot "test-key"
-      slot `shouldSatisfy` (< 16384)
+    it "matches Redis CLUSTER KEYSLOT vectors" $ do
+      let vectors =
+            [ ("simple-key", 6985),
+              ("foo{bar}zap", 5061),
+              ("{bar}zap", 5061),
+              ("foo{}{bar}", 8363),
+              ("foo{bar", 15278),
+              ("foo}bar", 7223),
+              ("foo{bar}{zap}", 5061),
+              ("foo{{bar}}zap", 4015),
+              ("a{tag}", 8338),
+              ("b{tag}", 8338)
+            ]
+      mapM_ (\(key, slot) -> calculateSlot key `shouldBe` slot) vectors
+
+    it "matches Redis CLUSTER KEYSLOT for binary keys" $ do
+      calculateSlot (BS.pack [0x00, 0x7b, 0xff, 0x7d, 0x01])
+        `shouldBe` 7920
 
     it "calculates same slot for keys with same hash tag" $ do
       let slot1 = calculateSlot "{user}:profile"
           slot2 = calculateSlot "{user}:settings"
       slot1 `shouldBe` slot2
+
+    it "co-locates prefixed keys for multi-key routing" $ do
+      calculateSlot "user:1{tenant}" `shouldBe` calculateSlot "user:2{tenant}"
 
     it "calculates different slots for different keys (usually)" $ do
       let slot1 = calculateSlot "key1"


### PR DESCRIPTION
## Summary
- implement Redis-compatible hash-tag extraction using the first opening brace anywhere in the key and the first closing brace after it
- hash enclosed bytes only when non-empty; otherwise retain full-key hashing
- add exact Redis `CLUSTER KEYSLOT` vectors for prefixes, suffixes, empty/unmatched tags, multiple candidates, and binary bytes

## Routing scope
`calculateSlot` is the shared routing boundary. Cluster multi-key commands currently route using their first key and rely on Redis for CROSSSLOT enforcement; this patch corrects their initial node selection for prefixed same-tag keys but does not add local multi-key planning or validation.

## Redis oracle
Cross-checked against `redis:7-alpine` with cluster mode enabled:

| Key | Slot |
|---|---:|
| `simple-key` | 6985 |
| `foo{bar}zap` | 5061 |
| `{bar}zap` | 5061 |
| `foo{}{bar}` | 8363 |
| `foo{bar` | 15278 |
| `foo}bar` | 7223 |
| `foo{bar}{zap}` | 5061 |
| `foo{{bar}}zap` | 4015 |
| `a{tag}` / `b{tag}` | 8338 |
| bytes `00 7b ff 7d 01` | 7920 |

## Validation
- `nix-build --no-out-link`
- `nix-shell --run "cabal test hask-redis-mux:ClusterSpec --test-show-details=direct"` — 18 examples, 0 failures
- Tester review: approved
- Fact Checker review: approved

## Profiling
No comparable `-p` profile was captured because the repository has no slot-calculation or CRC/hash-tag benchmark. `ConnectionPoolBench` measures pool contention and the CLI benchmark measures network command throughput, so neither meaningfully profiles this byte-scan correction.

## Risk
Low and localized. The implementation is byte-oriented and matches Redis oracle vectors. No live cluster multi-key E2E was added; shared slot calculation provides the narrow regression boundary.

Closes #50