### PR TITLE
Enforce strict RESP frame delimiters

### DIFF
--- a/app/ClusterTunnel.hs
+++ b/app/ClusterTunnel.hs
@@ -5,6 +5,7 @@
 module ClusterTunnel
   ( serveSmartProxy
   , servePinnedProxy
+  , rewriteClusterResponse
   ) where
 
 import           Control.Concurrent              (MVar, forkIO, newEmptyMVar,

--- a/hask-redis-mux/lib/resp/Database/Redis/Resp.hs
+++ b/hask-redis-mux/lib/resp/Database/Redis/Resp.hs
@@ -87,31 +87,29 @@ parseRespData =
 
 parseSimpleString :: Char8.Parser RespData
 parseSimpleString = do
-  !s <- Char8.takeTill (== '\r')
-  _ <- Char8.take 2
+  !s <- parseLine
   return $ RespSimpleString s
 {-# INLINE parseSimpleString #-}
 
 parseError :: Char8.Parser RespData
 parseError = do
-  !s <- Char8.takeTill (== '\r')
-  _ <- Char8.take 2
+  !s <- parseLine
   return $ RespError s
 {-# INLINE parseError #-}
 
 parseInteger :: Char8.Parser RespData
 parseInteger = do
   !i <- Char8.signed Char8.decimal
-  _ <- Char8.endOfLine
+  parseCRLF
   return $ RespInteger i
 {-# INLINE parseInteger #-}
 
 parseBulkString :: Char8.Parser RespData
 parseBulkString = do
   !len <- Char8.decimal
-  _ <- Char8.endOfLine
+  parseCRLF
   !s <- Char8.take len
-  _ <- Char8.endOfLine
+  parseCRLF
   return $ RespBulkString s
 {-# INLINE parseBulkString #-}
 
@@ -119,27 +117,27 @@ parseNullBulkString :: Char8.Parser RespData
 parseNullBulkString = do
   _ <- Char8.char '-'
   _ <- Char8.char '1'
-  _ <- Char8.endOfLine
+  parseCRLF
   return RespNullBulkString
 
 parseArray :: Char8.Parser RespData
 parseArray = do
   !len <- Char8.decimal
-  _ <- Char8.endOfLine
+  parseCRLF
   !xs <- Char8.count len parseRespData
   return $ RespArray xs
 
 parseSet :: Char8.Parser RespData
 parseSet = do
   !len <- Char8.decimal
-  _ <- Char8.endOfLine
+  parseCRLF
   !xs <- Char8.count len parseRespData
   return $ RespSet (S.fromList xs)
 
 parseMap :: Char8.Parser RespData
 parseMap = do
   !len <- Char8.decimal
-  _ <- Char8.endOfLine
+  parseCRLF
   !pairs <- Char8.count len parsePair
   return $ RespMap (M.fromList pairs)
   where
@@ -148,6 +146,20 @@ parseMap = do
       v <- parseRespData
       return (k, v)
 
--- | Parse strict ByteString into RespData
+parseLine :: Char8.Parser ByteString
+parseLine = do
+  !line <- Char8.takeTill (\c -> c == '\r' || c == '\n')
+  parseCRLF
+  return line
+{-# INLINE parseLine #-}
+
+parseCRLF :: Char8.Parser ()
+parseCRLF = do
+  _ <- Char8.char '\r'
+  _ <- Char8.char '\n'
+  return ()
+{-# INLINE parseCRLF #-}
+
+-- | Parse exactly one complete RESP value with no trailing bytes.
 parseStrict :: BS8.ByteString -> Either String RespData
-parseStrict = StrictParse.parseOnly parseRespData
+parseStrict = StrictParse.parseOnly (parseRespData <* StrictParse.endOfInput)

--- a/hask-redis-mux/test/MultiplexerSpec.hs
+++ b/hask-redis-mux/test/MultiplexerSpec.hs
@@ -319,6 +319,34 @@ commandQueueBatchingSpec = describe "Command queue batching" $ do
     length rs `shouldBe` n
     destroyMultiplexer mux
 
+  it "consumes concatenated response frames from the parser remainder" $ do
+    pool <- createSlotPool 2
+    (client, addRecv) <- createMockClient
+    mux <- createMultiplexer client (receive client)
+    firstSlot <- submitCommandAsync pool mux (encodeCmd ["PING"])
+    secondSlot <- submitCommandAsync pool mux (encodeCmd ["GET", "key"])
+
+    addRecv $ encodeResp (RespSimpleString "PONG") <> encodeResp (RespInteger 1)
+
+    first <- timeout 1000000 (waitSlot pool firstSlot)
+    second <- timeout 1000000 (waitSlot pool secondSlot)
+    first `shouldBe` Just (RespSimpleString "PONG")
+    second `shouldBe` Just (RespInteger 1)
+    destroyMultiplexer mux
+
+  it "fails promptly when a response has a malformed CRLF delimiter" $ do
+    pool <- createSlotPool 1
+    (client, addRecv) <- createMockClient
+    mux <- createMultiplexer client (receive client)
+    slot <- submitCommandAsync pool mux (encodeCmd ["PING"])
+
+    addRecv "+OK\rX"
+
+    result <- timeout 1000000
+      (try (waitSlot pool slot) :: IO (Either SomeException RespData))
+    result `shouldSatisfy` isTimedMultiplexerParseFailure
+    destroyMultiplexer mux
+
 multiplexerLifecycleSpec :: Spec
 multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
   it "create and submit returns correct response" $ do
@@ -655,6 +683,15 @@ isMultiplexerFailure (Left e) =
     Just MultiplexerConnectionClosed -> True
     Nothing                          -> False
 isMultiplexerFailure (Right _) = False
+
+isTimedMultiplexerParseFailure
+  :: Maybe (Either SomeException RespData)
+  -> Bool
+isTimedMultiplexerParseFailure (Just (Left e)) =
+  case fromException e of
+    Just (MultiplexerParseError _) -> True
+    _                              -> False
+isTimedMultiplexerParseFailure _ = False
 
 isOkResponse :: Either SomeException RespData -> Bool
 isOkResponse (Right (RespSimpleString "OK")) = True

--- a/hask-redis-mux/test/Spec.hs
+++ b/hask-redis-mux/test/Spec.hs
@@ -2,6 +2,7 @@
 
 module Main where
 
+import qualified Data.Attoparsec.ByteString       as StrictParse
 import           Data.Attoparsec.ByteString.Char8 (parseOnly)
 import qualified Data.ByteString.Builder          as Builder
 import qualified Data.ByteString.Char8            as BS8
@@ -225,3 +226,84 @@ main = hspec $ do
     it "fails on incomplete RESP data" $ do
       parseOnly parseRespData "+OK" `shouldSatisfy` isLeft
       parseOnly parseRespData "$6\r\nfoo" `shouldSatisfy` isLeft
+
+  describe "Strict RESP framing" $ do
+    it "rejects malformed simple string and error terminators" $ do
+      mapM_
+        (\input -> parseStrict input `shouldSatisfy` isLeft)
+        [ "+OK\n",
+          "+OK\rX",
+          "+OK\r",
+          "-ERR\n",
+          "-ERR\rX",
+          "-ERR\r"
+        ]
+
+    it "rejects malformed integer and bulk string terminators" $ do
+      mapM_
+        (\input -> parseStrict input `shouldSatisfy` isLeft)
+        [ ":1\n",
+          ":1\rX",
+          ":1\r",
+          "$3\nfoo\r\n",
+          "$3\rXfoo\r\n",
+          "$3\r\nfoo\n",
+          "$3\r\nfoo\rX",
+          "$3\r\nfoo\r",
+          "$-1\n",
+          "$-1\rX",
+          "$-1\r"
+        ]
+
+    it "rejects malformed aggregate length terminators" $ do
+      mapM_
+        (\input -> parseStrict input `shouldSatisfy` isLeft)
+        [ "*0\n",
+          "*0\rX",
+          "*0\r",
+          "~0\n",
+          "~0\rX",
+          "~0\r",
+          "%0\n",
+          "%0\rX",
+          "%0\r",
+          "*1\r\n+OK\n"
+        ]
+
+    it "accepts exactly one complete value" $ do
+      parseStrict "+OK\r\n" `shouldBe` Right (RespSimpleString "OK")
+      parseStrict "+OK\r\ntrailing" `shouldSatisfy` isLeft
+      parseStrict "+OK\r\n:1\r\n" `shouldSatisfy` isLeft
+
+    it "preserves valid remainders for incremental parsing" $ do
+      case StrictParse.parse parseRespData "+OK\r\n:1\r\n" of
+        StrictParse.Done remainder first -> do
+          first `shouldBe` RespSimpleString "OK"
+          case StrictParse.parse parseRespData remainder of
+            StrictParse.Done finalRemainder second -> do
+              finalRemainder `shouldBe` ""
+              second `shouldBe` RespInteger 1
+            _ -> expectationFailure "second concatenated frame did not parse"
+        _ -> expectationFailure "first concatenated frame did not parse"
+
+    it "fails immediately when an invalid delimiter byte is available" $ do
+      assertImmediateFailure "+OK\n"
+      assertImmediateFailure ":1\rX"
+      assertImmediateFailure "$3\r\nfoo\rX"
+
+    it "resumes a truncated CRLF when the missing byte arrives" $ do
+      case StrictParse.parse parseRespData "+OK\r" of
+        StrictParse.Partial continue ->
+          case continue "\n" of
+            StrictParse.Done remainder value -> do
+              remainder `shouldBe` ""
+              value `shouldBe` RespSimpleString "OK"
+            _ -> expectationFailure "valid CRLF continuation did not complete"
+        _ -> expectationFailure "truncated CRLF was not treated as partial input"
+
+assertImmediateFailure :: BS8.ByteString -> Expectation
+assertImmediateFailure input =
+  case StrictParse.parse parseRespData input of
+    StrictParse.Fail {} -> return ()
+    StrictParse.Partial _ -> expectationFailure "malformed delimiter waited for more input"
+    StrictParse.Done {} -> expectationFailure "malformed delimiter parsed successfully"

--- a/redis-client.cabal
+++ b/redis-client.cabal
@@ -69,6 +69,20 @@ test-suite ClusterSetupSpec
                     , mtl
                     , stm
 
+test-suite ClusterTunnelSpec
+    import:           test-defaults
+    type:             exitcode-stdio-1.0
+    main-is:          ClusterTunnelSpec.hs
+    other-modules:    ClusterTunnel
+    hs-source-dirs:   test
+                    , app
+    build-depends:    bytestring
+                    , containers
+                    , hask-redis-mux
+                    , mtl
+                    , network
+                    , stm
+
 -- ---------------------------------------------------------------------------
 -- Flags
 -- ---------------------------------------------------------------------------

--- a/test/ClusterTunnelSpec.hs
+++ b/test/ClusterTunnelSpec.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import           ClusterTunnel (rewriteClusterResponse)
+import           Test.Hspec
+
+main :: IO ()
+main = hspec $ do
+  describe "rewriteClusterResponse" $ do
+    it "rewrites exactly one complete RESP response" $ do
+      rewriteClusterResponse "-MOVED 3999 redis.example:6381\r\n"
+        `shouldBe` "-MOVED 3999 127.0.0.1:6381\r\n"
+
+    it "does not drop a concatenated response" $ do
+      let responses = "-MOVED 3999 redis.example:6381\r\n+OK\r\n"
+      rewriteClusterResponse responses `shouldBe` responses
+
+    it "leaves malformed framing unchanged" $ do
+      let malformed = "-MOVED 3999 redis.example:6381\rX"
+      rewriteClusterResponse malformed `shouldBe` malformed


### PR DESCRIPTION
## Summary
- require exact CRLF delimiters for RESP lines, lengths, aggregate headers, and bulk payload terminators
- make public `parseStrict` accept exactly one complete frame with no trailing bytes
- retain remainder-aware `parseRespData` behavior for incremental command and multiplexer parsing
- cover ClusterTunnel one-shot behavior so concatenated responses are preserved instead of partially rewritten and truncated

## Parser contract
- `parseRespData`: composable incremental parser; returns unconsumed bytes through Attoparsec `Done`
- `parseStrict`: one-shot parser for exactly one complete value; rejects incomplete input and any remainder
- malformed LF-only or wrong CRLF bytes fail as soon as the invalid byte is available; a trailing CR remains partial for incremental callers until the next byte arrives

## Validation
- `nix-build --no-out-link`
- `RespSpec`: 56 examples, 0 failures
- `MultiplexerSpec`: 24 examples, 0 failures
- `ClusterTunnelSpec`: 3 examples, 0 failures
- Tester review: approved
- Performance review: approved

## Profiling
No comparable `-p` profile was captured because the repository has no parser-specific benchmark or executable. `ConnectionPoolBench` does not parse RESP, while CLI/fill benchmarks are dominated by network, Redis, routing, and workload generation, so they would not isolate this delimiter change.

## Risks and follow-up boundary
The multiplexer keeps its existing incremental remainder path and now fails malformed delimiters promptly. ClusterTunnel remains chunk-oriented: concatenated or fragmented commands are rejected/preserved rather than silently truncated, but full stream reassembly and response transformation remain follow-up work in #83/#84.

This keeps the accepted RESP2-first scope and does not add wire types.

Closes #89