### PR TITLE
Validate complete CLUSTER SLOTS topologies

### DIFF
--- a/hask-redis-mux/hask-redis-mux.cabal
+++ b/hask-redis-mux/hask-redis-mux.cabal
@@ -201,8 +201,10 @@ test-suite ClusterSpec
     main-is:          ClusterSpec.hs
     build-depends:    bytestring >=0.12 && <0.13
                     , cluster
+                    , containers >=0.6 && <0.8
                     , resp
                     , time >=1.12 && <1.13
+                    , vector >=0.13 && <0.14
 
 test-suite ClusterCommandSpec
     import:           test-defaults

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster.hs
@@ -21,9 +21,12 @@ module Database.Redis.Cluster
   )
 where
 
+import           Control.Monad         (foldM)
 import           Data.ByteString       (ByteString)
 import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Char8 as BS8
+import           Data.Either           (isRight)
+import           Data.List             (find)
 import           Data.Map.Strict       (Map)
 import qualified Data.Map.Strict       as Map
 import           Data.Time             (UTCTime)
@@ -103,87 +106,213 @@ extractHashTag key =
               | not (BS.null tag) && not (BS.null closing) -> tag
               | otherwise -> key
 
--- | Parse the RESP response from @CLUSTER SLOTS@ into a 'ClusterTopology'.
--- Returns 'Left' with an error message if the response format is unexpected.
+-- | Parse and validate a complete @CLUSTER SLOTS@ response.
+--
+-- Successful topologies must cover every slot exactly once. Gaps and all
+-- overlaps, including duplicate ranges for the same node, are rejected because
+-- they represent incomplete or ambiguous routing snapshots. A node may own
+-- multiple disjoint ranges when its address and role remain consistent.
+-- Node records require a non-empty printable ASCII endpoint other than @?@, a
+-- port in @1-65535@, and a non-empty node ID. Additional node metadata fields
+-- are accepted and ignored.
 parseClusterSlots :: RespData -> UTCTime -> Either String ClusterTopology
 parseClusterSlots (RespArray slots) currentTime = do
-  ranges <- mapM parseSlotRange slots
-  let (slotMap, nodeMap) = buildTopology ranges
-      addrMap = buildAddressVector slotMap nodeMap
-  return $ ClusterTopology slotMap addrMap nodeMap currentTime
+  ranges <- mapM (uncurry parseSlotRange) (zip [0 :: Int ..] slots)
+  slotAssignments <- foldM assignSlots emptySlotAssignments ranges
+  slotMap <- case sequenceA slotAssignments of
+    Left missingSlot ->
+      Left $ "CLUSTER SLOTS response does not cover slot " ++ show missingSlot
+    Right assignments -> Right assignments
+  nodeMap <- foldM buildNodeMap Map.empty ranges
+  addressMap <- buildAddressVector slotMap nodeMap
+  return $ ClusterTopology slotMap addressMap nodeMap currentTime
   where
-    parseSlotRange :: RespData -> Either String (SlotRange, [(ByteString, NodeAddress)])
-    parseSlotRange (RespArray (RespInteger start : RespInteger end : masterInfo : replicaInfos)) = do
-      master <- parseNodeInfo masterInfo
-      replicas <- mapM parseNodeInfo replicaInfos
+    parseSlotRange
+      :: Int
+      -> RespData
+      -> Either String (SlotRange, (ByteString, NodeAddress), [(ByteString, NodeAddress)])
+    parseSlotRange rangeIndex (RespArray (RespInteger start : RespInteger end : masterInfo : replicaInfos)) = do
+      (startSlot, endSlot) <- validateSlotRange rangeIndex start end
+      master <- parseNodeInfo ("master in slot range " ++ show start ++ "-" ++ show end) masterInfo
+      replicas <- mapM
+        (uncurry $ parseIndexedReplica start end)
+        (zip [0 :: Int ..] replicaInfos)
+      let replicaIds = unique (map fst replicas)
       let range = SlotRange
-            { slotStart = fromIntegral start,
-              slotEnd = fromIntegral end,
+            { slotStart = startSlot,
+              slotEnd = endSlot,
               slotMaster = fst master,
-              slotReplicas = map fst replicas
+              slotReplicas = replicaIds
             }
-      return (range, master : replicas)
-    parseSlotRange other = Left $ "Invalid slot range format: " ++ show other
+      return (range, master, replicas)
+    parseSlotRange rangeIndex other =
+      Left $
+        "CLUSTER SLOTS entry " ++ show rangeIndex
+          ++ " must be an array containing start, end, and a master node: "
+          ++ show other
 
-    parseNodeInfo :: RespData -> Either String (ByteString, NodeAddress)
-    parseNodeInfo (RespArray (RespBulkString host : RespInteger port : RespBulkString nodeIdBS : _)) =
-      Right (nodeIdBS, NodeAddress (BS8.unpack host) (fromIntegral port))
-    parseNodeInfo other = Left $ "Invalid node info format: " ++ show other
+    parseIndexedReplica
+      :: Integer
+      -> Integer
+      -> Int
+      -> RespData
+      -> Either String (ByteString, NodeAddress)
+    parseIndexedReplica start end replicaIndex =
+      parseNodeInfo $
+        "replica " ++ show replicaIndex
+          ++ " in slot range " ++ show start ++ "-" ++ show end
 
-    buildTopology :: [(SlotRange, [(ByteString, NodeAddress)])] -> (Vector ByteString, Map ByteString ClusterNode)
-    buildTopology rangesWithNodes =
-      let slotVector = V.replicate 16384 ""
-          slotMap = foldl (\v (range, _) -> assignSlots v range) slotVector rangesWithNodes
-          nodeMap = foldl buildNodeMap Map.empty rangesWithNodes
-       in (slotMap, nodeMap)
+    validateSlotRange :: Int -> Integer -> Integer -> Either String (Word16, Word16)
+    validateSlotRange rangeIndex start end
+      | start < 0 =
+          Left $ rangeError rangeIndex $ "start slot is negative: " ++ show start
+      | end < 0 =
+          Left $ rangeError rangeIndex $ "end slot is negative: " ++ show end
+      | start > end =
+          Left $
+            rangeError rangeIndex $
+              "start slot " ++ show start ++ " exceeds end slot " ++ show end
+      | end >= fromIntegral slotCount =
+          Left $
+            rangeError rangeIndex $
+              "end slot " ++ show end ++ " is outside 0-" ++ show (slotCount - 1)
+      | otherwise = Right (fromInteger start, fromInteger end)
 
-    assignSlots :: Vector ByteString -> SlotRange -> Vector ByteString
-    assignSlots vec range =
-      foldl
-        (\v slot -> v V.// [(fromIntegral slot, slotMaster range)])
-        vec
-        [slotStart range .. slotEnd range]
+    rangeError :: Int -> String -> String
+    rangeError rangeIndex message =
+      "CLUSTER SLOTS entry " ++ show rangeIndex ++ " has invalid range: " ++ message
 
-    buildNodeMap :: Map ByteString ClusterNode -> (SlotRange, [(ByteString, NodeAddress)]) -> Map ByteString ClusterNode
-    buildNodeMap nodeMap (range, nodeInfos) =
-      case nodeInfos of
-        [] -> nodeMap  -- No nodes in this range (shouldn't happen)
-        (masterId, masterAddr) : replicaInfos ->
-          -- Insert master node
-          let nodeMapWithMaster = insertNode nodeMap (masterId, masterAddr) Master
-              -- Insert replica nodes
-              nodeMapWithReplicas = foldl (\nm (replicaId, replicaAddr) ->
-                                            insertNode nm (replicaId, replicaAddr) Replica)
-                                          nodeMapWithMaster replicaInfos
-          in nodeMapWithReplicas
+    parseNodeInfo :: String -> RespData -> Either String (ByteString, NodeAddress)
+    parseNodeInfo context (RespArray (RespBulkString host : RespInteger port : RespBulkString nodeIdBS : _))
+      | BS.null host =
+          Left $ "CLUSTER SLOTS " ++ context ++ " has an empty host"
+      | host == "?" =
+          Left $ "CLUSTER SLOTS " ++ context ++ " has unusable host \"?\""
+      | BS.any isInvalidHostByte host =
+          Left $ "CLUSTER SLOTS " ++ context ++ " has a non-printable host"
+      | port < 1 || port > 65535 =
+          Left $
+            "CLUSTER SLOTS " ++ context ++ " has port outside 1-65535: "
+              ++ show port
+      | BS.null nodeIdBS =
+          Left $ "CLUSTER SLOTS " ++ context ++ " has an empty node ID"
+      | otherwise =
+          Right (nodeIdBS, NodeAddress (BS8.unpack host) (fromInteger port))
+    parseNodeInfo context other =
+      Left $
+        "CLUSTER SLOTS " ++ context
+          ++ " must be an array containing bulk-string host, integer port, and bulk-string node ID: "
+          ++ show other
+
+    isInvalidHostByte byte = byte < 0x21 || byte > 0x7e
+
+    emptySlotAssignments :: Vector (Either Int ByteString)
+    emptySlotAssignments = V.generate slotCount Left
+
+    assignSlots
+      :: Vector (Either Int ByteString)
+      -> (SlotRange, (ByteString, NodeAddress), [(ByteString, NodeAddress)])
+      -> Either String (Vector (Either Int ByteString))
+    assignSlots assignments (range, _, _) =
+      case find isAssigned rangeSlots of
+        Just overlappingSlot ->
+          Left $
+            "CLUSTER SLOTS response assigns slot " ++ show overlappingSlot
+              ++ " more than once"
+        Nothing ->
+          Right $
+            assignments V.//
+              [ (fromIntegral slot, Right (slotMaster range))
+              | slot <- rangeSlots
+              ]
       where
-        insertNode :: Map ByteString ClusterNode -> (ByteString, NodeAddress) -> NodeRole -> Map ByteString ClusterNode
-        insertNode nm (nodeId, addr) role =
-          if Map.member nodeId nm
-            then nm -- Node already exists, don't overwrite
-            else Map.insert nodeId (ClusterNode nodeId addr role [range] []) nm
+        rangeSlots = [slotStart range .. slotEnd range]
+        isAssigned slot =
+          maybe False isRight (assignments V.!? fromIntegral slot)
+
+    buildNodeMap
+      :: Map ByteString ClusterNode
+      -> (SlotRange, (ByteString, NodeAddress), [(ByteString, NodeAddress)])
+      -> Either String (Map ByteString ClusterNode)
+    buildNodeMap nodeMap (range, master, replicas) = do
+      withMaster <- insertNode range (map fst replicas) Master master nodeMap
+      foldM (\nodes replica -> insertNode range [] Replica replica nodes) withMaster replicas
+
+    insertNode
+      :: SlotRange
+      -> [ByteString]
+      -> NodeRole
+      -> (ByteString, NodeAddress)
+      -> Map ByteString ClusterNode
+      -> Either String (Map ByteString ClusterNode)
+    insertNode range replicaIds role (nodeIdBS, address) nodeMap =
+      case Map.lookup nodeIdBS nodeMap of
+        Nothing ->
+          Right $
+            Map.insert
+              nodeIdBS
+              (ClusterNode nodeIdBS address role [range] (unique replicaIds))
+              nodeMap
+        Just node
+          | nodeAddress node /= address ->
+              Left $
+                "CLUSTER SLOTS node " ++ show nodeIdBS
+                  ++ " has conflicting addresses "
+                  ++ show (nodeAddress node) ++ " and " ++ show address
+          | nodeRole node /= role ->
+              Left $
+                "CLUSTER SLOTS node " ++ show nodeIdBS
+                  ++ " appears as both master and replica"
+          | otherwise ->
+              Right $
+                Map.insert
+                  nodeIdBS
+                  node
+                    { nodeSlotsServed = nodeSlotsServed node ++ [range],
+                      nodeReplicas = unique (nodeReplicas node ++ replicaIds)
+                    }
+                  nodeMap
+
+    unique :: Eq a => [a] -> [a]
+    unique = foldr (\item items -> if item `elem` items then items else item : items) []
 parseClusterSlots other _ = Left $ "Expected array of slot ranges, got: " ++ show other
 
 -- | Build a slot-to-NodeAddress vector from the slot-to-nodeId vector and node map.
 -- Used for O(1) hot path lookups that skip the Map entirely.
-buildAddressVector :: Vector ByteString -> Map ByteString ClusterNode -> Vector NodeAddress
+buildAddressVector :: Vector ByteString -> Map ByteString ClusterNode -> Either String (Vector NodeAddress)
 buildAddressVector slotVec nodeMap =
-  V.map (\nid -> case Map.lookup nid nodeMap of
-    Just node -> nodeAddress node
-    Nothing   -> NodeAddress "" 0  -- placeholder for unassigned slots
-  ) slotVec
+  traverse
+    (\nodeIdBS ->
+      case Map.lookup nodeIdBS nodeMap of
+        Just node -> Right (nodeAddress node)
+        Nothing ->
+          Left $
+            "CLUSTER SLOTS internal validation error: missing node "
+              ++ show nodeIdBS)
+    slotVec
+
+slotCount :: Int
+slotCount = 16384
 
 -- | Look up the master node ID responsible for a given slot.
--- Returns 'Nothing' if the slot is out of range (≥ 16384).
+-- Returns 'Nothing' if the slot is out of range or the topology was manually
+-- constructed with missing ownership.
 findNodeForSlot :: ClusterTopology -> Word16 -> Maybe ByteString
 findNodeForSlot topology slot
-  | slot < 16384 = Just $ topologySlots topology V.! fromIntegral slot
-  | otherwise = Nothing
+  | slot >= fromIntegral slotCount = Nothing
+  | otherwise = do
+      nodeIdBS <- topologySlots topology V.!? fromIntegral slot
+      if BS.null nodeIdBS then Nothing else Just nodeIdBS
 
 -- | Look up the 'NodeAddress' responsible for a given slot directly (O(1), no Map lookup).
--- Returns 'Nothing' if the slot is out of range (≥ 16384).
+-- Returns 'Nothing' if the slot is out of range or the topology was manually
+-- constructed with an unusable placeholder address.
 findNodeAddressForSlot :: ClusterTopology -> Word16 -> Maybe NodeAddress
 findNodeAddressForSlot topology slot
-  | slot < 16384 = Just $! topologyAddresses topology V.! fromIntegral slot
-  | otherwise = Nothing
+  | slot >= fromIntegral slotCount = Nothing
+  | otherwise = do
+      address <- topologyAddresses topology V.!? fromIntegral slot
+      if null (nodeHost address) || nodePort address < 1 || nodePort address > 65535
+        then Nothing
+        else Just address
 {-# INLINE findNodeAddressForSlot #-}

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
@@ -70,7 +70,8 @@ import           Control.Concurrent.MVar               (MVar, newMVar, putMVar,
 import           Control.Concurrent.STM                (TVar, atomically,
                                                         newTVarIO, readTVarIO,
                                                         writeTVar)
-import           Control.Exception                     (SomeAsyncException,
+import           Control.Exception                     (Exception,
+                                                        SomeAsyncException,
                                                         SomeException, bracket,
                                                         finally, fromException,
                                                         onException, throwIO,
@@ -140,6 +141,11 @@ data ClusterError
   | ConnectionTimeoutError ConnectionSetupException -- ^ A bounded connection setup attempt timed out.
   | ClusterClientClosed -- ^ The client has been terminally closed.
   deriving (Show, Eq)
+
+newtype TopologyValidationException = TopologyValidationException String
+  deriving (Show)
+
+instance Exception TopologyValidationException
 
 -- | Redirection information parsed from errors
 data RedirectionInfo = RedirectionInfo
@@ -292,7 +298,7 @@ createClusterClientWithFactoriesUsing connectorIsBounded
 
       currentTime <- getCurrentTime
       case parseClusterSlots response currentTime of
-        Left err -> throwIO $ userError $ "Failed to parse cluster topology: " <> err
+        Left err -> throwIO $ TopologyValidationException err
         Right initialTopology -> do
           topology <- newTVarIO initialTopology
           refreshLock <- newMVar ()
@@ -365,7 +371,7 @@ refreshTopology client = do
 
       currentTime <- getCurrentTime
       case parseClusterSlots response currentTime of
-        Left err -> throwIO $ userError $ "Failed to parse cluster topology: " <> err
+        Left err -> throwIO $ TopologyValidationException err
         Right topology -> atomically $ writeTVar (clusterTopology client) topology
 
 -- | Check if topology is stale and refresh if needed
@@ -476,6 +482,7 @@ withRetryAndRefresh client maxRetries initialDelay action = go 0 initialDelay No
               refreshResult <- tryClusterAction $ refreshTopology client
               case refreshResult of
                 Left ClusterClientClosed -> return $ Left ClusterClientClosed
+                Left err@(TopologyError _) -> return $ Left err
                 _ -> do
                   threadDelay delay
                   go (attempt + 1) (delay * 2) Nothing
@@ -485,6 +492,7 @@ withRetryAndRefresh client maxRetries initialDelay action = go 0 initialDelay No
               refreshResult <- tryClusterAction $ refreshTopology client
               case refreshResult of
                 Left ClusterClientClosed -> return $ Left ClusterClientClosed
+                Left err@(TopologyError _) -> return $ Left err
                 _ -> do
                   threadDelay delay
                   go (attempt + 1) (delay * 2) Nothing
@@ -509,6 +517,8 @@ tryClusterAction action = do
               return $ Left ClusterClientClosed
           | Just timeoutError <- fromException e ->
               return $ Left $ ConnectionTimeoutError timeoutError
+          | Just (TopologyValidationException err) <- fromException e ->
+              return $ Left $ TopologyError err
           | otherwise ->
               return $ Left $ ConnectionError $ show e
 

--- a/hask-redis-mux/test/ClusterCommandSpec.hs
+++ b/hask-redis-mux/test/ClusterCommandSpec.hs
@@ -400,6 +400,86 @@ clusterLifecycleSpec = describe "Cluster client lifecycle" $ do
     readIORef connectionCount `shouldReturn` 1
     readIORef closeCount `shouldReturn` 1
 
+  it "returns a MOVED refresh validation failure as TopologyError without retrying" $ do
+    let incompleteTopology =
+          RespArray
+            [ RespArray
+                [ RespInteger 0
+                , RespInteger 100
+                , RespArray
+                    [ RespBulkString "127.0.0.1"
+                    , RespInteger 6379
+                    , RespBulkString "partial-node"
+                    ]
+                ]
+            ]
+    connectionCount <- newIORef (0 :: Int)
+    closeCount <- newIORef (0 :: Int)
+    let connector _ = do
+          connectionIndex <- atomicModifyIORef' connectionCount $ \count ->
+            (count + 1, count)
+          sendBuf <- newIORef BS.empty
+          recvQueue <- newIORef
+            [ encodeResp $
+                if connectionIndex == 0
+                  then RespError "MOVED 3999 127.0.0.2:6380"
+                  else incompleteTopology
+            ]
+          return $ MockConnected sendBuf recvQueue closeCount
+    topology <- mkTopology node1
+    client <- mkClusterClient connector topology
+
+    outcome <- timeout 1000000 $
+      executeKeyedClusterCommand client "key" ["GET", "key"]
+    case outcome of
+      Just (Left (TopologyError err)) ->
+        err `shouldContain` "does not cover slot 101"
+      other ->
+        expectationFailure $
+          "Expected immediate TopologyError after MOVED refresh, got: "
+            ++ show other
+    readIORef connectionCount `shouldReturn` 2
+    closeClusterClient client
+
+  it "returns a connection refresh validation failure as TopologyError without retrying" $ do
+    let incompleteTopology =
+          RespArray
+            [ RespArray
+                [ RespInteger 0
+                , RespInteger 100
+                , RespArray
+                    [ RespBulkString "127.0.0.1"
+                    , RespInteger 6379
+                    , RespBulkString "partial-node"
+                    ]
+                ]
+            ]
+    connectionCount <- newIORef (0 :: Int)
+    closeCount <- newIORef (0 :: Int)
+    let connector _ = do
+          connectionIndex <- atomicModifyIORef' connectionCount $ \count ->
+            (count + 1, count)
+          if connectionIndex == 0
+            then throwIO $ userError "injected command connection failure"
+            else do
+              sendBuf <- newIORef BS.empty
+              recvQueue <- newIORef [encodeResp incompleteTopology]
+              return $ MockConnected sendBuf recvQueue closeCount
+    topology <- mkTopology node1
+    client <- mkClusterClient connector topology
+
+    outcome <- timeout 1000000 $
+      executeKeyedClusterCommand client "key" ["GET", "key"]
+    case outcome of
+      Just (Left (TopologyError err)) ->
+        err `shouldContain` "does not cover slot 101"
+      other ->
+        expectationFailure $
+          "Expected immediate TopologyError after connection refresh, got: "
+            ++ show other
+    readIORef connectionCount `shouldReturn` 2
+    closeClusterClient client
+
   it "closes the discovery pool when later initialization fails" $ do
     (connector, connectionCount, closeCount) <-
       createLifecycleConnector validClusterSlots

--- a/hask-redis-mux/test/ClusterSpec.hs
+++ b/hask-redis-mux/test/ClusterSpec.hs
@@ -2,9 +2,15 @@
 
 module Main (main) where
 
+import           Control.Exception      (SomeException, evaluate, try)
 import qualified Data.ByteString        as BS
 import qualified Data.ByteString.Char8  as BS8
-import           Data.Time.Clock        (getCurrentTime)
+import           Data.Either            (isLeft)
+import qualified Data.Map.Strict        as Map
+import           Data.Maybe             (isJust)
+import qualified Data.Set               as Set
+import           Data.Time.Clock        (UTCTime, getCurrentTime)
+import qualified Data.Vector            as V
 import           Database.Redis.Cluster
 import           Database.Redis.Resp    (RespData (..))
 import           Test.Hspec
@@ -92,110 +98,357 @@ spec = do
       slot `shouldSatisfy` (< 16384)
 
   describe "Topology parsing" $ do
-    it "parses simple CLUSTER SLOTS response" $ do
+    it "builds a complete topology with O(1) lookups" $ do
       currentTime <- getCurrentTime
-      let response =
-            RespArray
-              [ RespArray
-                  [ RespInteger 0,
-                    RespInteger 5460,
-                    RespArray
-                      [ RespBulkString "127.0.0.1",
-                        RespInteger 7000,
-                        RespBulkString "node-id-1"
-                      ]
-                  ]
-              ]
+      let response = clusterSlots
+            [ slotRange 0 8191 (nodeRecord "127.0.0.1" 7000 "node-1") [],
+              slotRange 8192 16383 (nodeRecord "redis-2.example" 7001 "node-2") []
+            ]
       case parseClusterSlots response currentTime of
         Left err -> expectationFailure $ "Parsing failed: " ++ err
         Right topology -> do
-          -- Check that slots are assigned
-          case findNodeForSlot topology 0 of
-            Nothing     -> expectationFailure "Slot 0 should be assigned"
-            Just nodeId -> nodeId `shouldNotBe` ""
+          V.length (topologySlots topology) `shouldBe` 16384
+          V.length (topologyAddresses topology) `shouldBe` 16384
+          Map.size (topologyNodes topology) `shouldBe` 2
+          findNodeAddressForSlot topology 0 `shouldBe` Just (NodeAddress "127.0.0.1" 7000)
+          findNodeAddressForSlot topology 8191 `shouldBe` Just (NodeAddress "127.0.0.1" 7000)
+          findNodeAddressForSlot topology 8192 `shouldBe` Just (NodeAddress "redis-2.example" 7001)
+          findNodeAddressForSlot topology 16383 `shouldBe` Just (NodeAddress "redis-2.example" 7001)
+          mapM_
+            (\slot -> findNodeForSlot topology slot `shouldSatisfy` isJust)
+            [0 .. 16383]
 
-    it "handles invalid responses" $ do
+    it "allows one node to own multiple disjoint ranges" $ do
       currentTime <- getCurrentTime
-      let invalidResponse = RespBulkString "invalid"
-      case parseClusterSlots invalidResponse currentTime of
-        Left _  -> return () -- Expected
-        Right _ -> expectationFailure "Should fail on invalid response"
+      let response = clusterSlots
+            [ slotRange 0 100 (nodeRecord "127.0.0.1" 7000 "node-1") [],
+              slotRange 101 16383 (nodeRecord "127.0.0.1" 7000 "node-1") []
+            ]
+      case parseClusterSlots response currentTime of
+        Left err -> expectationFailure $ "Parsing failed: " ++ err
+        Right topology ->
+          case Map.lookup "node-1" (topologyNodes topology) of
+            Nothing -> expectationFailure "node-1 was not recorded"
+            Just node -> nodeSlotsServed node `shouldBe`
+              [ SlotRange 0 100 "node-1" [],
+                SlotRange 101 16383 "node-1" []
+              ]
 
     it "parses response with replicas" $ do
       currentTime <- getCurrentTime
-      let response =
-            RespArray
-              [ RespArray
-                  [ RespInteger 0,
-                    RespInteger 5460,
-                    RespArray
-                      [ RespBulkString "127.0.0.1",
-                        RespInteger 7000,
-                        RespBulkString "master-1"
-                      ],
-                    RespArray
-                      [ RespBulkString "127.0.0.1",
-                        RespInteger 7003,
-                        RespBulkString "replica-1"
-                      ]
-                  ]
-              ]
+      let response = clusterSlots
+            [ slotRange
+                0
+                16383
+                (nodeRecord "127.0.0.1" 7000 "master-1")
+                [nodeRecord "127.0.0.1" 7003 "replica-1"]
+            ]
       case parseClusterSlots response currentTime of
         Left err -> expectationFailure $ "Parsing failed: " ++ err
         Right topology -> do
-          -- Check that master is assigned
-          case findNodeForSlot topology 0 of
-            Nothing     -> expectationFailure "Slot 0 should be assigned"
-            Just nodeId -> nodeId `shouldNotBe` ""
+          nodeReplicas (topologyNodes topology Map.! "master-1")
+            `shouldBe` ["replica-1"]
+          nodeRole (topologyNodes topology Map.! "replica-1")
+            `shouldBe` Replica
+
+    it "rejects negative, reversed, out-of-range, and overflow-sized ranges" $ do
+      currentTime <- getCurrentTime
+      let invalidRanges =
+            [ slotRange (-1) 16383 validMaster [],
+              slotRange 0 (-1) validMaster [],
+              slotRange 10 9 validMaster [],
+              slotRange 0 16384 validMaster [],
+              slotRange 16384 16384 validMaster [],
+              slotRange 0 (10 ^ (100 :: Int)) validMaster []
+            ]
+      mapM_
+        (\entry ->
+          parseClusterSlots (clusterSlots [entry]) currentTime
+            `shouldSatisfy` isLeft)
+        invalidRanges
+
+    it "rejects ports outside the Redis TCP range before conversion" $ do
+      currentTime <- getCurrentTime
+      let invalidPorts = [-1, 0, 65536, 10 ^ (100 :: Int)]
+      mapM_
+        (\port ->
+          shouldFailWith
+            "port outside 1-65535"
+            (clusterSlots [slotRange 0 16383 (nodeRecord "127.0.0.1" port "node-1") []])
+            currentTime)
+        invalidPorts
+
+    it "accepts the minimum and maximum valid TCP ports" $ do
+      currentTime <- getCurrentTime
+      let response = clusterSlots
+            [ slotRange 0 8191 (nodeRecord "127.0.0.1" 1 "node-low") [],
+              slotRange 8192 16383 (nodeRecord "127.0.0.2" 65535 "node-high") []
+            ]
+      case parseClusterSlots response currentTime of
+        Left err -> expectationFailure $ "Parsing failed: " ++ err
+        Right topology -> do
+          findNodeAddressForSlot topology 0
+            `shouldBe` Just (NodeAddress "127.0.0.1" 1)
+          findNodeAddressForSlot topology 16383
+            `shouldBe` Just (NodeAddress "127.0.0.2" 65535)
+
+    it "rejects empty or unusable hosts and node IDs" $ do
+      currentTime <- getCurrentTime
+      mapM_
+        (\host ->
+          parseClusterSlots
+            (clusterSlots [slotRange 0 16383 (nodeRecord host 7000 "node-1") []])
+            currentTime
+            `shouldSatisfy` isLeft)
+        ["", "?", "bad host", BS.pack [0x7f], BS.pack [0xff]]
+      shouldFailWith
+        "empty node ID"
+        (clusterSlots [slotRange 0 16383 (nodeRecord "127.0.0.1" 7000 "") []])
+        currentTime
+
+    it "rejects invalid node record shapes" $ do
+      currentTime <- getCurrentTime
+      let invalidRecords =
+            [ RespBulkString "not-an-array",
+              RespArray [],
+              RespArray [RespBulkString "127.0.0.1"],
+              RespArray [RespInteger 1, RespInteger 7000, RespBulkString "node-1"],
+              RespArray [RespBulkString "127.0.0.1", RespBulkString "7000", RespBulkString "node-1"],
+              RespArray [RespBulkString "127.0.0.1", RespInteger 7000, RespInteger 1]
+            ]
+      mapM_
+        (\record ->
+          parseClusterSlots (clusterSlots [slotRange 0 16383 record []]) currentTime
+            `shouldSatisfy` isLeft)
+        invalidRecords
+
+    it "rejects missing slot coverage" $ do
+      currentTime <- getCurrentTime
+      shouldFailWith "does not cover slot 0" (clusterSlots []) currentTime
+      shouldFailWith
+        "does not cover slot 101"
+        (clusterSlots
+          [ slotRange 0 100 validMaster [],
+            slotRange 102 16383 (nodeRecord "127.0.0.2" 7001 "node-2") []
+          ])
+        currentTime
+
+    it "rejects exact, contained, partial, and out-of-order overlaps" $ do
+      currentTime <- getCurrentTime
+      let node2Record = nodeRecord "127.0.0.2" 7001 "node-2"
+          overlapCases :: [(String, Int, RespData)]
+          overlapCases =
+            [ ( "exact duplicate for the same node",
+                0,
+                clusterSlots
+                  [ slotRange 0 16383 validMaster [],
+                    slotRange 0 16383 validMaster []
+                  ]
+              ),
+              ( "contained range with conflicting ownership",
+                100,
+                clusterSlots
+                  [ slotRange 0 16383 validMaster [],
+                    slotRange 100 200 node2Record []
+                  ]
+              ),
+              ( "partial overlap for the same node",
+                100,
+                clusterSlots
+                  [ slotRange 0 100 validMaster [],
+                    slotRange 100 16383 validMaster []
+                  ]
+              ),
+              ( "out-of-order partial overlap with conflicting ownership",
+                100,
+                clusterSlots
+                  [ slotRange 100 16383 validMaster [],
+                    slotRange 0 100 node2Record []
+                  ]
+              )
+            ]
+      mapM_
+        (\(label, overlappingSlot, response) ->
+          case parseClusterSlots response currentTime of
+            Left err ->
+              err `shouldContain`
+                ("assigns slot " ++ show overlappingSlot ++ " more than once")
+            Right _ ->
+              expectationFailure $
+                "Expected overlap validation failure for " ++ label)
+        overlapCases
+
+    it "rejects conflicting addresses and roles for a repeated node ID" $ do
+      currentTime <- getCurrentTime
+      let conflictingAddress = clusterSlots
+            [ slotRange 0 100 validMaster [],
+              slotRange 101 16383 (nodeRecord "127.0.0.2" 7001 "node-1") []
+            ]
+          conflictingRole = clusterSlots
+            [ slotRange
+                0
+                100
+                validMaster
+                [nodeRecord "127.0.0.2" 7001 "node-2"],
+              slotRange 101 16383 (nodeRecord "127.0.0.2" 7001 "node-2") []
+            ]
+      shouldFailWith "conflicting addresses" conflictingAddress currentTime
+      shouldFailWith "both master and replica" conflictingRole currentTime
+
+    it "is total across a deterministic matrix of malformed nested RESP values" $ do
+      currentTime <- getCurrentTime
+      mapM_
+        (\(label, response) -> do
+          result <- try $ evaluate $
+            case parseClusterSlots response currentTime of
+              Left err       -> length err
+              Right topology -> forceTopology topology
+          case (result :: Either SomeException Int) of
+            Left err ->
+              expectationFailure $
+                "Synchronous exception for malformed case " ++ label
+                  ++ ": " ++ show err
+            Right _ -> return ()
+          case parseClusterSlots response currentTime of
+            Left err -> length err `shouldSatisfy` (> 0)
+            Right _ ->
+              expectationFailure $
+                "Expected Left for malformed case " ++ label)
+        malformedTopologyResponses
 
   describe "Node lookup" $ do
-    it "finds correct node for slot" $ do
+    it "returns Nothing for invalid slots or manually incomplete vectors" $ do
       currentTime <- getCurrentTime
-      let response =
-            RespArray
-              [ RespArray
-                  [ RespInteger 0,
-                    RespInteger 100,
-                    RespArray
-                      [ RespBulkString "127.0.0.1",
-                        RespInteger 7000,
-                        RespBulkString "node1"
-                      ]
-                  ],
-                RespArray
-                  [ RespInteger 101,
-                    RespInteger 200,
-                    RespArray
-                      [ RespBulkString "127.0.0.1",
-                        RespInteger 7001,
-                        RespBulkString "node2"
-                      ]
-                  ]
-              ]
-      case parseClusterSlots response currentTime of
-        Left err -> expectationFailure $ "Parsing failed: " ++ err
-        Right topology -> do
-          findNodeForSlot topology 50 `shouldSatisfy` (/= Nothing)
-          findNodeForSlot topology 150 `shouldSatisfy` (/= Nothing)
-          -- Out of range
-          findNodeForSlot topology 16384 `shouldBe` Nothing
+      let emptyTopology = ClusterTopology V.empty V.empty Map.empty currentTime
+          sentinelTopology =
+            ClusterTopology
+              (V.replicate 16384 "")
+              (V.replicate 16384 (NodeAddress "" 0))
+              Map.empty
+              currentTime
+      findNodeForSlot emptyTopology 0 `shouldBe` Nothing
+      findNodeAddressForSlot emptyTopology 0 `shouldBe` Nothing
+      findNodeForSlot sentinelTopology 0 `shouldBe` Nothing
+      findNodeAddressForSlot sentinelTopology 0 `shouldBe` Nothing
+      findNodeForSlot sentinelTopology 16384 `shouldBe` Nothing
+      findNodeAddressForSlot sentinelTopology 16384 `shouldBe` Nothing
 
-    it "returns empty string for slots not covered by any node" $ do
-      currentTime <- getCurrentTime
-      let response =
-            RespArray
-              [ RespArray
-                  [ RespInteger 0,
-                    RespInteger 100,
-                    RespArray
-                      [ RespBulkString "127.0.0.1",
-                        RespInteger 7000,
-                        RespBulkString "node1"
-                      ]
-                  ]
-              ]
-      case parseClusterSlots response currentTime of
-        Left err -> expectationFailure $ "Parsing failed: " ++ err
-        Right topology -> do
-          findNodeForSlot topology 50 `shouldSatisfy` (/= Nothing)
-          findNodeForSlot topology 200 `shouldBe` Just ""
+clusterSlots :: [RespData] -> RespData
+clusterSlots = RespArray
+
+slotRange :: Integer -> Integer -> RespData -> [RespData] -> RespData
+slotRange start end master replicas =
+  RespArray (RespInteger start : RespInteger end : master : replicas)
+
+nodeRecord :: BS.ByteString -> Integer -> BS.ByteString -> RespData
+nodeRecord host port nodeIdBS =
+  RespArray
+    [ RespBulkString host,
+      RespInteger port,
+      RespBulkString nodeIdBS
+    ]
+
+validMaster :: RespData
+validMaster = nodeRecord "127.0.0.1" 7000 "node-1"
+
+malformedTopologyResponses :: [(String, RespData)]
+malformedTopologyResponses =
+  labelCases "top-level value" malformedTopLevel
+    ++ labelCases "slot-range entry" (map (clusterSlots . pure) malformedRangeEntries)
+    ++ labelCases "range start" (map rangeWithStart malformedIntegerValues)
+    ++ labelCases "range end" (map rangeWithEnd malformedIntegerValues)
+    ++ labelCases "master node" (map rangeWithMaster malformedNodeValues)
+    ++ labelCases "replica node" (map rangeWithReplica malformedNodeValues)
+    ++ labelCases "node host" (map (rangeWithNodeField 0) malformedBulkStringValues)
+    ++ labelCases "node port" (map (rangeWithNodeField 1) malformedIntegerValues)
+    ++ labelCases "node ID" (map (rangeWithNodeField 2) malformedBulkStringValues)
+  where
+    malformedAtoms =
+      [ RespSimpleString "simple",
+        RespError "ERR malformed",
+        RespInteger 7,
+        RespBulkString "bulk",
+        RespNullBulkString,
+        RespSet (Set.fromList [RespInteger 1, RespNullBulkString]),
+        RespMap (Map.fromList [(RespBulkString "key", RespArray [RespNullBulkString])])
+      ]
+    nestedArrays =
+      [ RespArray [],
+        RespArray [RespNullBulkString],
+        RespArray [RespArray []],
+        RespArray [RespArray [RespArray [RespNullBulkString]]]
+      ]
+    malformedTopLevel = malformedAtoms ++ nestedArrays
+    malformedRangeEntries = malformedAtoms ++ nestedArrays
+    malformedNodeValues = malformedAtoms ++ nestedArrays
+    malformedIntegerValues =
+      [ RespSimpleString "0",
+        RespError "ERR integer",
+        RespBulkString "0",
+        RespNullBulkString,
+        RespSet (Set.singleton (RespInteger 0)),
+        RespMap (Map.singleton (RespBulkString "0") (RespInteger 0))
+      ] ++ nestedArrays
+    malformedBulkStringValues =
+      [ RespSimpleString "text",
+        RespError "ERR bulk",
+        RespInteger 1,
+        RespNullBulkString,
+        RespSet (Set.singleton (RespBulkString "text")),
+        RespMap (Map.singleton (RespBulkString "key") (RespBulkString "value"))
+      ] ++ nestedArrays
+    rangeWithStart value =
+      clusterSlots [RespArray [value, RespInteger 16383, validMaster]]
+    rangeWithEnd value =
+      clusterSlots [RespArray [RespInteger 0, value, validMaster]]
+    rangeWithMaster value =
+      clusterSlots [slotRange 0 16383 value []]
+    rangeWithReplica value =
+      clusterSlots [slotRange 0 16383 validMaster [value]]
+    rangeWithNodeField fieldIndex value =
+      clusterSlots
+        [ slotRange
+            0
+            16383
+            (RespArray (replaceAt fieldIndex value validNodeFields))
+            []
+        ]
+    validNodeFields =
+      [ RespBulkString "127.0.0.1",
+        RespInteger 7000,
+        RespBulkString "node-1"
+      ]
+
+labelCases :: String -> [RespData] -> [(String, RespData)]
+labelCases position =
+  zipWith
+    (\index response -> (position ++ " #" ++ show index, response))
+    [0 :: Int ..]
+
+replaceAt :: Int -> a -> [a] -> [a]
+replaceAt index replacement values =
+  take index values ++ [replacement] ++ drop (index + 1) values
+
+forceTopology :: ClusterTopology -> Int
+forceTopology topology =
+  V.foldl' (\total nodeIdBS -> total + BS.length nodeIdBS) 0 (topologySlots topology)
+    + V.foldl'
+        (\total address -> total + length (nodeHost address) + nodePort address)
+        0
+        (topologyAddresses topology)
+    + Map.foldl'
+        (\total node ->
+          total
+            + BS.length (nodeId node)
+            + length (nodeHost (nodeAddress node))
+            + nodePort (nodeAddress node)
+            + length (nodeSlotsServed node)
+            + length (nodeReplicas node))
+        0
+        (topologyNodes topology)
+
+shouldFailWith :: String -> RespData -> UTCTime -> Expectation
+shouldFailWith expected response currentTime =
+  case parseClusterSlots response currentTime of
+    Left err -> err `shouldContain` expected
+    Right _ -> expectationFailure $ "Expected topology validation failure containing: " ++ expected


### PR DESCRIPTION
## Summary
- validate all slot integers, node records, endpoints, ports, and node IDs before conversion or vector construction
- require a complete, non-overlapping 0-16383 ownership snapshot
- remove placeholder routing outcomes and keep bounds-safe O(1) slot/address lookup
- surface validation failures encountered during stale, MOVED, or connection-triggered refresh as existing `TopologyError`

## Validation and coverage policy
A successful topology must cover every slot exactly once. Any gap or overlap is rejected, including duplicate ownership by the same node, because incomplete or ambiguous snapshots are unsafe to publish. A node may own multiple disjoint ranges when its address and role remain consistent.

Node endpoints must be non-empty printable ASCII other than `?`; ports must be 1-65535; node IDs must be non-empty. Additional Redis node metadata fields remain accepted and ignored.

The public `ClusterTopology` field types and lookup APIs remain unchanged. Successful parsed topologies contain complete vectors; lookups also return `Nothing` safely for manually constructed short vectors or placeholder entries.

## Validation
- `nix-build --no-out-link`
- `ClusterSpec`: 26 examples, 0 failures, including a forced deterministic matrix of 94 malformed nested values
- `ClusterCommandSpec`: 53 examples, 0 failures
- Tester review: approved after revision
- Lead policy/API review: approved

## Profiling
No comparable `-p` profile is reported because the repository has no topology-construction or lookup benchmark. `ConnectionPoolBench` measures unrelated contention, while CLI throughput is dominated by network and Redis behavior and does not isolate topology parsing. No profiling artifacts remain.

## Scope and risk
This narrowly propagates topology validation failures instead of discarding them in the existing MOVED/connection refresh branches. Other retry and server-error classification behavior remains unchanged for #61.

Strict complete-snapshot validation may reject transient resharding responses rather than publishing ambiguous routing. Direct callers of exported `refreshTopology` still receive an exception on validation failure; command paths map it to `TopologyError`.

Closes #88