### PR TITLE
Retry MOVED commands at authoritative targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
     *   Added `ClusterPassword` and `ClusterACL` construction policies that authenticate seed, pooled, multiplexed, redirected, and replacement connections before use.
     *   Password authentication uses `AUTH password`; named ACL authentication uses `HELLO 2 AUTH username password` and never negotiates RESP3.
     *   Cluster runtime `auth` now rejects its misleading one-socket behavior; standalone `auth` remains connection-scoped.
+*   **Authoritative MOVED recovery**
+    *   MOVED commands retry directly at the advertised target without sending `ASKING`, and patch the affected slot before the retry.
+    *   Full topology refresh uses a bounded candidate list of the redirect target, known masters, and the original seed.
+    *   Concurrent MOVED patches survive stale in-flight refreshes, while connector and refresh failures remain in the typed retry result.
 
 ## 0.6.0.0 -- 2026-02-13
 

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
@@ -76,25 +76,27 @@ import           Control.Concurrent                    (threadDelay)
 import           Control.Concurrent.MVar               (MVar, newMVar, putMVar,
                                                         tryTakeMVar)
 import           Control.Concurrent.STM                (TVar, atomically,
-                                                        newTVarIO, readTVarIO,
-                                                        writeTVar)
+                                                        newTVarIO, readTVar,
+                                                        readTVarIO, writeTVar)
 import           Control.Exception                     (Exception,
                                                         SomeAsyncException,
                                                         SomeException, bracket,
                                                         finally, fromException,
                                                         onException, throwIO,
                                                         try)
-import           Control.Monad                         (when)
+import           Control.Monad                         (void, when)
 import           Control.Monad.IO.Class                (MonadIO (..))
 import qualified Control.Monad.State                   as State
 import           Data.ByteString                       (ByteString)
 import qualified Data.ByteString                       as BS
 import qualified Data.ByteString.Builder               as Builder
 import qualified Data.ByteString.Char8                 as BS8
+import           Data.List                             (foldl')
 import qualified Data.Map.Strict                       as Map
 import           Data.Time.Clock                       (NominalDiffTime,
                                                         diffUTCTime,
                                                         getCurrentTime)
+import qualified Data.Vector                           as V
 import           Data.Word                             (Word16)
 import           Database.Redis.Client                 (Client (..),
                                                         ConnectionStatus (..))
@@ -102,6 +104,7 @@ import           Database.Redis.Cluster                (ClusterNode (..),
                                                         ClusterTopology (..),
                                                         NodeAddress (..),
                                                         NodeRole (..),
+                                                        SlotRange (..),
                                                         calculateSlot,
                                                         findNodeAddressForSlot,
                                                         parseClusterSlots)
@@ -166,6 +169,11 @@ data RedirectionInfo = RedirectionInfo
     redirPort :: Int
   }
   deriving (Show, Eq)
+
+data RetryRoute
+  = RouteBySlot
+  | RouteMoved !Word16 !NodeAddress
+  | RouteAsk !NodeAddress
 
 -- | Configuration for a cluster client.
 data ClusterConfig = ClusterConfig
@@ -455,7 +463,7 @@ withClusterClientAuthentication config authentication connector =
     (createClusterClientWithAuthentication config authentication connector)
     closeClusterClient
 
--- | Refresh cluster topology by querying CLUSTER SLOTS.
+-- | Refresh cluster topology by querying known masters and then the seed.
 -- Uses a lock to prevent thundering herd: if another thread is already
 -- refreshing, this call returns immediately (the other thread's refresh
 -- will update the shared topology).
@@ -464,23 +472,185 @@ refreshTopology ::
   ClusterClient client ->
   IO ()
 refreshTopology client = do
+  result <- refreshTopologyFromCandidates client [] []
+  case result of
+    Right () -> return ()
+    Left err -> throwRefreshError err
+  where
+    throwRefreshError (TopologyError err) =
+      throwIO $ TopologyValidationException err
+    throwRefreshError (ConnectionTimeoutError err) = throwIO err
+    throwRefreshError (ClusterAuthenticationError err) = throwIO err
+    throwRefreshError ClusterClientClosed = throwIO ConnectionPoolClosed
+    throwRefreshError err = throwIO $ userError $ show err
+
+refreshTopologyFromCandidates
+  :: (Client client)
+  => ClusterClient client
+  -> [NodeAddress]
+  -> [(Word16, NodeAddress)]
+  -> IO (Either ClusterError ())
+refreshTopologyFromCandidates client preferred protectedPatches = do
   acquired <- tryTakeMVar (clusterRefreshLock client)
   case acquired of
-    Nothing -> return ()  -- Another thread is already refreshing
-    Just _  -> finally doRefresh (putMVar (clusterRefreshLock client) ())
+    Nothing -> return $ Right ()
+    Just _  ->
+      finally doRefresh (putMVar (clusterRefreshLock client) ())
   where
-    connector = clusterConnector client
     doRefresh = do
-      let seedNode = clusterSeedNode (clusterConfig client)
-      response <- withConnectionBounded
-        (clusterConnectionPool client) seedNode connector $ \conn -> do
-        let clientState = ClientState conn BS8.empty
-        State.evalStateT (runRedisCommandClient clusterSlots) clientState
+      baseline <- readTVarIO $ clusterTopology client
+      tryCandidates baseline $ refreshCandidates baseline
 
-      currentTime <- getCurrentTime
-      case parseClusterSlots response currentTime of
-        Left err -> throwIO $ TopologyValidationException err
-        Right topology -> atomically $ writeTVar (clusterTopology client) topology
+    refreshCandidates topology =
+      take candidateLimit $ uniqueAddresses $
+        preferred
+          ++ knownMasters topology
+          ++ [clusterSeedNode $ clusterConfig client]
+
+    candidateLimit = max 1 $ clusterMaxRetries $ clusterConfig client
+
+    knownMasters topology =
+      [ nodeAddress node
+      | node <- Map.elems $ topologyNodes topology
+      , nodeRole node == Master
+      , not $ null $ nodeSlotsServed node
+      ]
+
+    uniqueAddresses = foldl'
+      (\addresses address ->
+        if address `elem` addresses
+          then addresses
+          else addresses ++ [address])
+      []
+
+    tryCandidates _ [] =
+      return $ Left $ ConnectionError "No topology refresh candidates available"
+    tryCandidates baseline (candidate : candidates) = do
+      result <- fetchTopology candidate
+      case result of
+        Right topology -> do
+          commitRefreshedTopology protectedPatches topology
+          return $ Right ()
+        Left err ->
+          case candidates of
+            [] -> return $ Left err
+            _  -> tryCandidates baseline candidates
+
+    fetchTopology candidate = do
+      response <- executeOnNode client candidate clusterSlots $
+        clusterConnector client
+      case response of
+        Left err -> return $ Left err
+        Right payload -> do
+          currentTime <- getCurrentTime
+          return $
+            case parseClusterSlots payload currentTime of
+              Left err       -> Left $ TopologyError err
+              Right topology -> Right topology
+
+    commitRefreshedTopology explicitPatches refreshed =
+      atomically $ do
+        current <- readTVar $ clusterTopology client
+        let currentPatches = movedTopologyPatches current
+            merged =
+              foldl'
+                (\topology (slot, address) ->
+                  if findNodeAddressForSlot topology slot == Just address
+                    then topology
+                    else patchTopologySlot slot address topology)
+                refreshed
+                (explicitPatches ++ currentPatches)
+        writeTVar (clusterTopology client) merged
+
+movedTopologyPatches
+  :: ClusterTopology
+  -> [(Word16, NodeAddress)]
+movedTopologyPatches topology =
+  [ (fromIntegral index, topologyAddresses topology V.! index)
+  | index <- [0 .. upperBound]
+  , movedNodePrefix `BS.isPrefixOf` (topologySlots topology V.! index)
+  ]
+  where
+    upperBound = min
+      (V.length $ topologySlots topology)
+      (V.length $ topologyAddresses topology)
+      - 1
+
+patchMovedSlot
+  :: ClusterClient client
+  -> Word16
+  -> NodeAddress
+  -> IO ()
+patchMovedSlot client slot address =
+  atomically $ do
+    topology <- readTVar $ clusterTopology client
+    writeTVar
+      (clusterTopology client)
+      (patchTopologySlot slot address topology)
+
+patchTopologySlot
+  :: Word16
+  -> NodeAddress
+  -> ClusterTopology
+  -> ClusterTopology
+patchTopologySlot slot _ topology
+  | fromIntegral slot >= V.length (topologySlots topology)
+      || fromIntegral slot >= V.length (topologyAddresses topology) =
+      topology
+patchTopologySlot slot address topology =
+  topology
+    { topologySlots =
+        topologySlots topology V.// [(slotIndex, targetNodeId)]
+    , topologyAddresses =
+        topologyAddresses topology V.// [(slotIndex, address)]
+    , topologyNodes =
+        Map.insert targetNodeId targetNode nodesWithoutSlot
+    }
+  where
+    slotIndex = fromIntegral slot
+    targetNodeId = movedNodeId address
+    nodesWithoutSlot =
+      Map.map removeSlotFromNode $ topologyNodes topology
+    existingTarget =
+      Map.lookup targetNodeId nodesWithoutSlot
+    targetNode =
+      case existingTarget of
+        Just node ->
+          node
+            { nodeAddress = address
+            , nodeRole = Master
+            , nodeSlotsServed =
+                movedRange : nodeSlotsServed node
+            }
+        Nothing ->
+          ClusterNode targetNodeId address Master [movedRange] []
+    movedRange = SlotRange slot slot targetNodeId []
+
+    removeSlotFromNode node =
+      node
+        { nodeSlotsServed =
+            concatMap removeSlotFromRange $ nodeSlotsServed node
+        }
+
+    removeSlotFromRange range
+      | slot < slotStart range || slot > slotEnd range = [range]
+      | slotStart range == slotEnd range = []
+      | slot == slotStart range =
+          [range { slotStart = slot + 1 }]
+      | slot == slotEnd range =
+          [range { slotEnd = slot - 1 }]
+      | otherwise =
+          [ range { slotEnd = slot - 1 }
+          , range { slotStart = slot + 1 }
+          ]
+
+movedNodePrefix :: ByteString
+movedNodePrefix = "__redis_client_moved__:"
+
+movedNodeId :: NodeAddress -> ByteString
+movedNodeId address =
+  movedNodePrefix <> BS8.pack
+    (nodeHost address ++ ":" ++ show (nodePort address))
 
 -- | Check if topology is stale and refresh if needed
 -- Called before every keyed command execution.
@@ -556,16 +726,17 @@ executeKeylessClusterCommand client action = do
     []       -> return $ Left $ TopologyError "No master nodes available"
     (node:_) -> executeOnNode client (nodeAddress node) action connector
 
--- | Retry logic with exponential backoff and topology refresh on MOVED errors
+-- | Retry logic for transient failures and Redis redirections.
 --
--- MOVED errors trigger immediate topology refresh and retry. This ensures the client
--- quickly adapts to cluster topology changes (e.g., slot migrations, node failures).
+-- MOVED retries go directly to the authoritative target without ASKING. The
+-- affected slot is patched before retrying, and a bounded full refresh follows
+-- a successful direct retry. Refresh candidates include the redirect target,
+-- known masters, and the original seed.
 --
 -- Performance considerations:
--- - During cluster reconfiguration, multiple MOVED errors may trigger concurrent refreshes
+-- - Concurrent MOVED patches are retained across an in-flight stale refresh
 -- - Each refresh costs ~1-5ms (network + parsing)
--- - For clusters with high concurrency and frequent rebalancing, consider implementing
---   refresh rate limiting or deduplication to prevent refresh storms
+-- - A single refresh lock prevents a thundering herd
 --
 -- ASK errors follow the Redis protocol: retry at the target node with an ASKING prefix.
 -- No topology refresh is needed since ASK indicates a temporary, in-progress migration.
@@ -574,41 +745,55 @@ withRetryAndRefresh ::
   ClusterClient client ->
   Int -> -- Max retries
   Int -> -- Initial delay (microseconds)
-  (Maybe NodeAddress -> IO (Either ClusterError a)) ->
+  (RetryRoute -> IO (Either ClusterError a)) ->
   IO (Either ClusterError a)
-withRetryAndRefresh client maxRetries initialDelay action = go 0 initialDelay Nothing
+withRetryAndRefresh client maxRetries initialDelay action =
+  go 0 initialDelay RouteBySlot
   where
-    go attempt delay askTarget
+    go attempt delay route
       | attempt >= maxRetries = return $ Left $ MaxRetriesExceeded $ "Max retries (" ++ show maxRetries ++ ") exceeded"
       | otherwise = do
-          result <- action askTarget
+          result <- action route
           case result of
+            Right value -> do
+              case route of
+                RouteMoved slot address ->
+                  void $ refreshTopologyFromCandidates
+                    client [address] [(slot, address)]
+                _ -> return ()
+              return $ Right value
             Left (TryAgainError _) -> do
               threadDelay delay
-              go (attempt + 1) (delay * 2) Nothing
-            Left (MovedError _ _) -> do
-              refreshResult <- tryClusterAction $ refreshTopology client
-              case refreshResult of
-                Left ClusterClientClosed -> return $ Left ClusterClientClosed
-                Left err@(TopologyError _) -> return $ Left err
-                _ -> do
-                  threadDelay delay
-                  go (attempt + 1) (delay * 2) Nothing
-            Left (AskError _ addr) -> do
-              go (attempt + 1) delay (Just addr)
+              go (attempt + 1) (delay * 2) RouteBySlot
+            Left (MovedError slot address) -> do
+              patchMovedSlot client slot address
+              go (attempt + 1) delay $ RouteMoved slot address
+            Left (AskError _ address) ->
+              go (attempt + 1) delay $ RouteAsk address
             Left (ConnectionError _) -> do
-              refreshResult <- tryClusterAction $ refreshTopology client
+              refreshResult <- refreshForRoute route
               case refreshResult of
                 Left ClusterClientClosed -> return $ Left ClusterClientClosed
                 Left err@(TopologyError _) -> return $ Left err
                 _ -> do
                   threadDelay delay
-                  go (attempt + 1) (delay * 2) Nothing
+                  go (attempt + 1) (delay * 2) RouteBySlot
             Left (ConnectionTimeoutError _) -> do
-              threadDelay delay
-              go (attempt + 1) (delay * 2) Nothing
+              refreshResult <- case route of
+                RouteMoved _ _ -> refreshForRoute route
+                _              -> return $ Right ()
+              case refreshResult of
+                Left ClusterClientClosed -> return $ Left ClusterClientClosed
+                Left err@(TopologyError _) -> return $ Left err
+                _ -> do
+                  threadDelay delay
+                  go (attempt + 1) (delay * 2) RouteBySlot
             Left err -> return $ Left err
-            Right value -> return $ Right value
+
+    refreshForRoute (RouteMoved slot address) =
+      refreshTopologyFromCandidates client [address] [(slot, address)]
+    refreshForRoute _ =
+      refreshTopologyFromCandidates client [] []
 
 tryClusterAction :: IO a -> IO (Either ClusterError a)
 tryClusterAction action = do
@@ -711,14 +896,17 @@ executeKeyedClusterCommand client key cmdArgs = do
   let muxPool = clusterMultiplexPool client
       cmdBuilder = encodeCommandBuilder cmdArgs
       !slot = calculateSlot key
-  withRetryAndRefresh client (clusterMaxRetries (clusterConfig client)) (clusterRetryDelay (clusterConfig client)) $ \askTarget ->
-    case askTarget of
-      Nothing -> do
+  withRetryAndRefresh client (clusterMaxRetries (clusterConfig client)) (clusterRetryDelay (clusterConfig client)) $ \route ->
+    case route of
+      RouteBySlot -> do
         refreshResult <- tryClusterAction $ refreshTopologyIfStale client
         case refreshResult of
           Left err -> return $ Left err
           Right () -> executeOnSlotMux client muxPool slot cmdBuilder
-      Just addr -> executeOnNodeWithAsking client muxPool addr cmdBuilder
+      RouteMoved _ address ->
+        executeOnNodeDirect muxPool address cmdBuilder
+      RouteAsk address ->
+        executeOnNodeWithAsking client muxPool address cmdBuilder
 
 -- | Execute a pre-encoded command via multiplexer on the node for a given slot.
 -- Uses findNodeAddressForSlot for O(1) direct address lookup (no Map needed).
@@ -743,6 +931,27 @@ executeOnSlotMux client muxPool slot cmdBuilder = do
           Just (Right (RedirectionInfo s host port)) ->
             return $ Left $ AskError s (NodeAddress host port)
           Nothing -> return $ Right respData
+
+executeOnNodeDirect
+  :: (Client client)
+  => MultiplexPool client
+  -> NodeAddress
+  -> Builder.Builder
+  -> IO (Either ClusterError RespData)
+executeOnNodeDirect muxPool address cmdBuilder = do
+  result <- tryClusterAction $ submitToNode muxPool address cmdBuilder
+  case result of
+    Left err       -> return $ Left err
+    Right respData -> return $ classifyRedirect respData
+
+classifyRedirect :: RespData -> Either ClusterError RespData
+classifyRedirect respData =
+  case detectRedirection respData of
+    Just (Left (RedirectionInfo slot host port)) ->
+      Left $ MovedError slot $ NodeAddress host port
+    Just (Right (RedirectionInfo slot host port)) ->
+      Left $ AskError slot $ NodeAddress host port
+    Nothing -> Right respData
 
 -- | Execute a command on a specific node with ASKING prefix (for ASK redirects).
 -- Per Redis protocol, ASK requires sending ASKING before the actual command to the

--- a/hask-redis-mux/test/ClusterCommandSpec.hs
+++ b/hask-redis-mux/test/ClusterCommandSpec.hs
@@ -9,7 +9,7 @@ import           Control.Concurrent                    (forkFinally, forkIO,
                                                         killThread, threadDelay)
 import           Control.Concurrent.MVar               (newEmptyMVar, newMVar,
                                                         putMVar, takeMVar)
-import           Control.Concurrent.STM                (newTVarIO)
+import           Control.Concurrent.STM                (newTVarIO, readTVarIO)
 import           Control.Exception                     (SomeAsyncException,
                                                         SomeException, finally,
                                                         fromException, throwIO,
@@ -36,7 +36,8 @@ import           Database.Redis.Cluster                (ClusterNode (..),
                                                         NodeAddress (..),
                                                         NodeRole (..),
                                                         SlotRange (..),
-                                                        calculateSlot)
+                                                        calculateSlot,
+                                                        findNodeAddressForSlot)
 import           Database.Redis.Cluster.Client
 import           Database.Redis.Cluster.ConnectionPool (PoolConfig (..),
                                                         createPool)
@@ -257,6 +258,7 @@ spec = do
 
   askRedirectSpec
   askRedirectAdditionalSpec
+  movedRedirectSpec
   clusterLifecycleSpec
   clusterAuthenticationSpec
 
@@ -349,6 +351,29 @@ mkTopology addr = do
       nodeMap = Map.singleton nodeIdBS node
   return $ ClusterTopology slotVec addrVec nodeMap now
 
+mkTwoMasterTopology
+  :: NodeAddress
+  -> NodeAddress
+  -> IO ClusterTopology
+mkTwoMasterTopology firstAddress secondAddress = do
+  now <- getCurrentTime
+  let firstId = "test-node-id-1"
+      secondId = "test-node-id-2"
+      firstRange = SlotRange 0 8191 firstId []
+      secondRange = SlotRange 8192 16383 secondId []
+      firstNode =
+        ClusterNode firstId firstAddress Master [firstRange] []
+      secondNode =
+        ClusterNode secondId secondAddress Master [secondRange] []
+      slotVec =
+        V.replicate 8192 firstId <> V.replicate 8192 secondId
+      addrVec =
+        V.replicate 8192 firstAddress
+          <> V.replicate 8192 secondAddress
+      nodeMap = Map.fromList
+        [(firstId, firstNode), (secondId, secondNode)]
+  return $ ClusterTopology slotVec addrVec nodeMap now
+
 validClusterSlots :: RespData
 validClusterSlots =
   RespArray
@@ -406,7 +431,7 @@ clusterLifecycleSpec = describe "Cluster client lifecycle" $ do
     readIORef connectionCount `shouldReturn` 1
     readIORef closeCount `shouldReturn` 1
 
-  it "returns a MOVED refresh validation failure as TopologyError without retrying" $ do
+  it "does not make a successful direct MOVED retry depend on refresh validation" $ do
     let incompleteTopology =
           RespArray
             [ RespArray
@@ -429,6 +454,8 @@ clusterLifecycleSpec = describe "Cluster client lifecycle" $ do
             [ encodeResp $
                 if connectionIndex == 0
                   then RespError "MOVED 3999 127.0.0.2:6380"
+                  else if connectionIndex == 1
+                    then RespBulkString "redirected-value"
                   else incompleteTopology
             ]
           return $ MockConnected sendBuf recvQueue closeCount
@@ -437,14 +464,8 @@ clusterLifecycleSpec = describe "Cluster client lifecycle" $ do
 
     outcome <- timeout 1000000 $
       executeKeyedClusterCommand client "key" ["GET", "key"]
-    case outcome of
-      Just (Left (TopologyError err)) ->
-        err `shouldContain` "does not cover slot 101"
-      other ->
-        expectationFailure $
-          "Expected immediate TopologyError after MOVED refresh, got: "
-            ++ show other
-    readIORef connectionCount `shouldReturn` 2
+    outcome `shouldBe` Just (Right $ RespBulkString "redirected-value")
+    readIORef connectionCount `shouldReturn` 4
     closeClusterClient client
 
   it "returns a connection refresh validation failure as TopologyError without retrying" $ do
@@ -664,9 +685,10 @@ awaitIORefValue ref expected = do
 -- ASK redirect integration tests
 -- ---------------------------------------------------------------------------
 
-node1, node2 :: NodeAddress
+node1, node2, node3 :: NodeAddress
 node1 = NodeAddress "127.0.0.1" 6379
 node2 = NodeAddress "127.0.0.2" 6380
+node3 = NodeAddress "127.0.0.3" 6381
 
 askRedirectSpec :: Spec
 askRedirectSpec = describe "ASK redirect integration (executeKeyedClusterCommand)" $ do
@@ -964,7 +986,7 @@ clusterAuthenticationSpec =
           <> commandBytes ["GET", key]
       closeClusterClient client
 
-    it "authenticates MOVED targets after the topology refresh" $ do
+    it "authenticates a direct MOVED target and its refresh connection" $ do
       let credentials = ClusterPassword "moved-secret"
           key = "moved-key"
           script addr index
@@ -972,17 +994,21 @@ clusterAuthenticationSpec =
                 return
                   [ replyWith $ RespSimpleString "OK"
                   , replyWith $ singleMasterClusterSlots node1 "node-1"
-                  , replyWith $ singleMasterClusterSlots node2 "node-2"
                   ]
             | addr == node1 =
                 return
                   [ replyWith $ RespSimpleString "OK"
                   , replyWith $ RespError "MOVED 3999 127.0.0.2:6380"
                   ]
-            | otherwise =
+            | index == 0 =
                 return
                   [ replyWith $ RespSimpleString "OK"
                   , replyWith $ RespBulkString "moved-value"
+                  ]
+            | otherwise =
+                return
+                  [ replyWith $ RespSimpleString "OK"
+                  , replyWith $ singleMasterClusterSlots node2 "node-2"
                   ]
       (connector, getRecords) <- createAuthMockConnector script
       client <- createClusterClientWithAuthentication
@@ -990,9 +1016,12 @@ clusterAuthenticationSpec =
       executeKeyedClusterCommand client key ["GET", key]
         `shouldReturn` Right (RespBulkString "moved-value")
       records <- getRecords
-      sent <- recordSentBytes $ findAuthRecord records node2 0
-      sent `shouldBe`
+      targetSent <- recordSentBytes $ findAuthRecord records node2 0
+      targetSent `shouldBe`
         authCommandFor credentials <> commandBytes ["GET", key]
+      refreshSent <- recordSentBytes $ findAuthRecord records node2 1
+      refreshSent `shouldBe`
+        authCommandFor credentials <> commandBytes ["CLUSTER", "SLOTS"]
       closeClusterClient client
 
     it "reapplies authentication after a failed multiplexer is replaced" $ do
@@ -1185,6 +1214,241 @@ clusterAuthenticationSpec =
       sentAfter <- recordSentBytes $ findAuthRecord recordsAfter node1 0
       sentAfter `shouldBe` sentBefore
       closeClusterClient client
+
+movedRedirectSpec :: Spec
+movedRedirectSpec =
+  describe "MOVED redirect recovery" $ do
+    it "retries the authoritative target and patches the next route" $ do
+      let key = "moved-direct-key"
+          slot = calculateSlot key
+          moved = movedResponse slot node2
+          script address index
+            | address == node1 && index == 0 =
+                return [replyWith moved]
+            | address == node1 =
+                throwIO $ userError "seed unavailable"
+            | address == node2 && index == 0 =
+                return
+                  [ replyWith $ RespBulkString "first-value"
+                  , replyWith $ RespBulkString "second-value"
+                  ]
+            | otherwise =
+                return
+                  [replyWith $ singleMasterClusterSlots node2 "node-2"]
+      (connector, getRecords) <- createAuthMockConnector script
+      topology <- mkTopology node1
+      client <- mkAuthMockClusterClient testClusterConfig connector topology
+
+      executeKeyedClusterCommand client key ["GET", key]
+        `shouldReturn` Right (RespBulkString "first-value")
+      updated <- readTVarIO $ clusterTopology client
+      findNodeAddressForSlot updated slot `shouldBe` Just node2
+      let patchedNodeId = topologySlots updated V.! fromIntegral slot
+      nodeAddress <$> Map.lookup patchedNodeId (topologyNodes updated)
+        `shouldBe` Just node2
+      Map.size (topologyNodes updated) `shouldBe` 1
+      length
+        [ ()
+        | node <- Map.elems $ topologyNodes updated
+        , range <- nodeSlotsServed node
+        , slot >= slotStart range
+        , slot <= slotEnd range
+        ]
+        `shouldBe` 1
+
+      executeKeyedClusterCommand client key ["GET", key]
+        `shouldReturn` Right (RespBulkString "second-value")
+      records <- getRecords
+      staleSent <- recordSentBytes $ findAuthRecord records node1 0
+      staleSent `shouldBe` commandBytes ["GET", key]
+      targetSent <- recordSentBytes $ findAuthRecord records node2 0
+      targetSent `shouldBe`
+        commandBytes ["GET", key] <> commandBytes ["GET", key]
+      BS.isInfixOf (commandBytes ["ASKING"]) targetSent `shouldBe` False
+      closeClusterClient client
+
+    it "refreshes from an alternate known master when target and seed refresh fail" $ do
+      let key = keyForSlotRange (< 8192)
+          slot = calculateSlot key
+          moved = movedResponse slot node2
+      attempts <- newIORef Map.empty
+      (rawConnector, getRecords) <- createAuthMockConnector $ \address index ->
+        if address == node1 && index == 0
+          then return [replyWith moved]
+          else if address == node2 && index == 0
+            then return [replyWith $ RespBulkString "redirected-value"]
+            else if address == node3
+              then return
+                [replyWith $ singleMasterClusterSlots node2 "node-2"]
+              else throwIO $ userError "refresh candidate unavailable"
+      let connector address = do
+            atomicModifyIORef' attempts $ \current ->
+              (Map.insertWith (+) address (1 :: Int) current, ())
+            rawConnector address
+      topology <- mkTwoMasterTopology node1 node3
+      client <- mkAuthMockClusterClient testClusterConfig connector topology
+
+      executeKeyedClusterCommand client key ["GET", key]
+        `shouldReturn` Right (RespBulkString "redirected-value")
+      updated <- readTVarIO $ clusterTopology client
+      findNodeAddressForSlot updated slot `shouldBe` Just node2
+      counts <- readIORef attempts
+      Map.findWithDefault 0 node2 counts `shouldBe` 2
+      Map.findWithDefault 0 node1 counts `shouldBe` 2
+      Map.findWithDefault 0 node3 counts `shouldBe` 1
+      records <- getRecords
+      alternateSent <- recordSentBytes $ findAuthRecord records node3 0
+      alternateSent `shouldBe` commandBytes ["CLUSTER", "SLOTS"]
+      closeClusterClient client
+
+    it "returns a bounded typed failure when target and refresh candidates fail" $ do
+      let key = "bounded-moved-key"
+          slot = calculateSlot key
+          moved = movedResponse slot node2
+          retryConfig = testClusterConfig
+            { clusterMaxRetries = 3
+            , clusterRetryDelay = 1000
+            }
+      attempts <- newIORef Map.empty
+      (rawConnector, _) <- createAuthMockConnector $ \address index ->
+        if address == node1 && index == 0
+          then return [replyWith moved]
+          else throwIO $ userError "all redirected paths unavailable"
+      let connector address = do
+            atomicModifyIORef' attempts $ \current ->
+              (Map.insertWith (+) address (1 :: Int) current, ())
+            rawConnector address
+      topology <- mkTopology node1
+      client <- mkAuthMockClusterClient retryConfig connector topology
+
+      outcome <- timeout 1000000 $
+        executeKeyedClusterCommand client key ["GET", key]
+      outcome `shouldSatisfy` \case
+        Just (Left (MaxRetriesExceeded _)) -> True
+        _                                  -> False
+      counts <- readIORef attempts
+      sum (Map.elems counts) `shouldBe` 7
+      closeClusterClient client
+
+    it "bounds repeated MOVED replies without refreshing through ASKING" $ do
+      let key = "repeated-moved-key"
+          slot = calculateSlot key
+          retryConfig = testClusterConfig
+            { clusterMaxRetries = 3
+            , clusterRetryDelay = 1000
+            }
+          script address _
+            | address == node1 =
+                return [replyWith $ movedResponse slot node2]
+            | address == node2 =
+                return [replyWith $ movedResponse slot node3]
+            | otherwise =
+                return [replyWith $ movedResponse slot node2]
+      (connector, getRecords) <- createAuthMockConnector script
+      topology <- mkTopology node1
+      client <- mkAuthMockClusterClient retryConfig connector topology
+
+      executeKeyedClusterCommand client key ["GET", key]
+        `shouldReturn`
+          Left (MaxRetriesExceeded "Max retries (3) exceeded")
+      records <- getRecords
+      length records `shouldBe` 3
+      sent <- mapM recordSentBytes records
+      mapM_ (\bytes ->
+          BS.isInfixOf (commandBytes ["ASKING"]) bytes `shouldBe` False
+        ) sent
+      finalTopology <- readTVarIO $ clusterTopology client
+      findNodeAddressForSlot finalTopology slot `shouldBe` Just node2
+      closeClusterClient client
+
+    it "preserves concurrent MOVED patches across a stale full refresh" $ do
+      let firstKey = "concurrent-moved-one"
+          firstSlot = calculateSlot firstKey
+          secondKey = nextDifferentSlotKey firstSlot 0
+          secondSlot = calculateSlot secondKey
+          staleTopology = singleMasterClusterSlots node1 "node-1"
+      refreshRelease <- newEmptyMVar
+      (connector, _) <- createAuthMockConnector $ \address index ->
+        if address == node1 && index == 0
+          then return
+            [ replyWith $ movedResponse firstSlot node2
+            , replyWith $ movedResponse secondSlot node3
+            ]
+          else if index == 0
+            then return [replyWith $ RespBulkString "redirected"]
+            else return
+              [takeMVar refreshRelease >> replyWith staleTopology]
+      topology <- mkTopology node1
+      client <- mkAuthMockClusterClient testClusterConfig connector topology
+      firstResult <- newEmptyMVar
+      secondResult <- newEmptyMVar
+      _ <- forkIO $ executeKeyedClusterCommand
+        client firstKey ["GET", firstKey] >>= putMVar firstResult
+      _ <- forkIO $ executeKeyedClusterCommand
+        client secondKey ["GET", secondKey] >>= putMVar secondResult
+
+      timeout 1000000
+        (awaitSlotAddresses client
+          [(firstSlot, node2), (secondSlot, node3)])
+        `shouldReturn` Just ()
+      patchedTopology <- readTVarIO $ clusterTopology client
+      let firstNodeId =
+            topologySlots patchedTopology V.! fromIntegral firstSlot
+          secondNodeId =
+            topologySlots patchedTopology V.! fromIntegral secondSlot
+      nodeAddress <$> Map.lookup firstNodeId (topologyNodes patchedTopology)
+        `shouldBe` Just node2
+      nodeAddress <$> Map.lookup secondNodeId (topologyNodes patchedTopology)
+        `shouldBe` Just node3
+      putMVar refreshRelease ()
+
+      timeout 1000000 (takeMVar firstResult)
+        `shouldReturn` Just (Right $ RespBulkString "redirected")
+      timeout 1000000 (takeMVar secondResult)
+        `shouldReturn` Just (Right $ RespBulkString "redirected")
+      finalTopology <- readTVarIO $ clusterTopology client
+      findNodeAddressForSlot finalTopology firstSlot `shouldBe` Just node2
+      findNodeAddressForSlot finalTopology secondSlot `shouldBe` Just node3
+      closeClusterClient client
+
+mkAuthMockClusterClient
+  :: ClusterConfig
+  -> (NodeAddress -> IO (AuthMockClient 'Connected))
+  -> ClusterTopology
+  -> IO (ClusterClient AuthMockClient)
+mkAuthMockClusterClient config connector topology = do
+  topologyVar <- newTVarIO topology
+  pool <- createPool $ clusterPoolConfig config
+  muxPool <- createMultiplexPool connector 1
+  refreshLock <- newMVar ()
+  return $
+    ClusterClient topologyVar pool config connector refreshLock muxPool
+
+movedResponse :: Word16 -> NodeAddress -> RespData
+movedResponse slot address =
+  RespError $ BS8.pack $
+    "MOVED " ++ show slot ++ " "
+      ++ nodeHost address ++ ":" ++ show (nodePort address)
+
+nextDifferentSlotKey :: Word16 -> Int -> ByteString
+nextDifferentSlotKey slot index
+  | calculateSlot candidate /= slot = candidate
+  | otherwise = nextDifferentSlotKey slot $ index + 1
+  where
+    candidate = BS8.pack $ "concurrent-moved-key-" ++ show index
+
+awaitSlotAddresses
+  :: ClusterClient client
+  -> [(Word16, NodeAddress)]
+  -> IO ()
+awaitSlotAddresses client expected = do
+  topology <- readTVarIO $ clusterTopology client
+  if all
+      (\(slot, address) ->
+        findNodeAddressForSlot topology slot == Just address)
+      expected
+    then return ()
+    else threadDelay 1000 >> awaitSlotAddresses client expected
 
 askRedirectAdditionalSpec :: Spec
 askRedirectAdditionalSpec = describe "additional ASK redirect integration" $ do


### PR DESCRIPTION
## Summary
- retry MOVED commands directly at the advertised target without `ASKING`
- atomically patch the affected slot before retry and preserve concurrent patches across stale refreshes
- refresh through a bounded candidate list of redirect target, known masters, and seed
- retain typed retry failures, existing attempt budgets, connection deadlines, and per-connection authentication

## Validation
- `nix-build`
- `nix-shell --run 'cabal test hask-redis-mux:ClusterCommandSpec hask-redis-mux:ClusterSpec --test-show-details=direct'`
  - ClusterCommandSpec: 70 examples, 0 failures
  - ClusterSpec: 26 examples, 0 failures

No dedicated redirect/retry benchmark exists. `ConnectionPoolBench` measures pool contention rather than MOVED recovery, while `ClusterCommandSpec` contains mock I/O delays and failure orchestration, so profiling either would be an unrelated or non-comparable proxy.

Closes #65
