### PR TITLE
Centralize Redis Cluster error classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@
     *   Full topology refresh uses a bounded candidate list of the redirect target, known masters, and the original seed.
     *   Concurrent MOVED patches survive stale in-flight refreshes, while connector and refresh failures remain in the typed retry result.
 *   **Central cluster error classification**
-    *   MOVED, ASK, TRYAGAIN, CLUSTERDOWN, CROSSSLOT, and ordinary Redis errors now share one strict reply classifier across normal and redirected paths.
-    *   TRYAGAIN retries the current route with bounded saturating exponential backoff; CLUSTERDOWN performs a best-effort refresh before bounded backoff.
+    *   MOVED, ASK, TRYAGAIN, CLUSTERDOWN, CROSSSLOT, and ordinary Redis errors now share one strict reply classifier across keyed, keyless, and redirected paths.
+    *   TRYAGAIN retries the current route with bounded saturating exponential backoff; CLUSTERDOWN performs a best-effort refresh before bounded backoff without replacing the Redis cause when refresh validation or I/O fails.
     *   CROSSSLOT and ordinary server errors return immediately as typed `ClusterError` values, preserving the complete server error payload.
 
 ## 0.6.0.0 -- 2026-02-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
     *   MOVED commands retry directly at the advertised target without sending `ASKING`, and patch the affected slot before the retry.
     *   Full topology refresh uses a bounded candidate list of the redirect target, known masters, and the original seed.
     *   Concurrent MOVED patches survive stale in-flight refreshes, while connector and refresh failures remain in the typed retry result.
+*   **Central cluster error classification**
+    *   MOVED, ASK, TRYAGAIN, CLUSTERDOWN, CROSSSLOT, and ordinary Redis errors now share one strict reply classifier across normal and redirected paths.
+    *   TRYAGAIN retries the current route with bounded saturating exponential backoff; CLUSTERDOWN performs a best-effort refresh before bounded backoff.
+    *   CROSSSLOT and ordinary server errors return immediately as typed `ClusterError` values, preserving the complete server error payload.
 
 ## 0.6.0.0 -- 2026-02-13
 

--- a/app/ClusterCli.hs
+++ b/app/ClusterCli.hs
@@ -44,7 +44,8 @@ executeKeyedCommand key parts = do
   clusterClient <- State.get
   result <- liftIO $ ClusterCommandClient.executeKeyedClusterCommand clusterClient key parts
   return $ case result of
-    Left (CrossSlotError msg) -> Left $ "CROSSSLOT error: " ++ msg ++ "\nHint: Use hash tags like {user}:key to ensure keys map to the same slot"
+    Left (CrossSlotError msg) -> Left $
+      msg ++ "\nHint: Use hash tags like {user}:key to ensure keys map to the same slot"
     Left err -> Left (show err)
     Right resp -> Right resp
 

--- a/hask-redis-mux/README.md
+++ b/hask-redis-mux/README.md
@@ -85,10 +85,16 @@ The low-level `executeKeyedClusterCommand` and
 Every Redis `RespError` is classified centrally and is returned on the `Left`;
 error replies are never success-shaped:
 
-- `MOVED` and `ASK` preserve their existing direct-target routing behavior.
-- `TRYAGAIN` retries the current route with saturating exponential backoff.
+- Keyed `MOVED` and `ASK` replies preserve their existing direct-target routing
+  behavior. Keyless commands return those typed redirects immediately because
+  they have no routing key to apply at the target.
+- `TRYAGAIN` retries the current keyed or keyless route with saturating
+  exponential backoff.
 - `CLUSTERDOWN` performs a best-effort bounded topology refresh, then retries
-  from the current topology with the same backoff schedule.
+  the keyed or keyless command from the current topology with the same backoff
+  schedule. Refresh parsing, validation, and connector failures do not replace
+  the Redis error or consume a command attempt; client closure and asynchronous
+  cancellation remain terminal.
 - `CROSSSLOT` is permanent for the command and returns immediately.
 - Other server errors such as `ERR`, `WRONGTYPE`, and `NOSCRIPT` return
   `RedisCommandError` with the original server payload.

--- a/hask-redis-mux/README.md
+++ b/hask-redis-mux/README.md
@@ -78,6 +78,34 @@ that client. Teardown is idempotent and each transport finalizer runs exactly
 once. A client or pool must not be reused after bracket exit or explicit close:
 later submissions return a typed closed-client/pool failure and never reconnect.
 
+## Cluster Error Contract
+
+The low-level `executeKeyedClusterCommand` and
+`executeKeylessClusterCommand` APIs return `Either ClusterError RespData`.
+Every Redis `RespError` is classified centrally and is returned on the `Left`;
+error replies are never success-shaped:
+
+- `MOVED` and `ASK` preserve their existing direct-target routing behavior.
+- `TRYAGAIN` retries the current route with saturating exponential backoff.
+- `CLUSTERDOWN` performs a best-effort bounded topology refresh, then retries
+  from the current topology with the same backoff schedule.
+- `CROSSSLOT` is permanent for the command and returns immediately.
+- Other server errors such as `ERR`, `WRONGTYPE`, and `NOSCRIPT` return
+  `RedisCommandError` with the original server payload.
+
+`clusterMaxRetries` is the total command-attempt budget, including the initial
+attempt. Backoff occurs only when another attempt remains, starts at
+`clusterRetryDelay`, doubles between attempts, and saturates at `maxBound`
+instead of overflowing. The delay remains interruptible, so asynchronous
+cancellation is rethrown rather than converted into a cluster error.
+
+The existing typed `ClusterCommandClient` runner still unwraps `ClusterError`
+through its historical `MonadFail` behavior. Ordinary Redis errors therefore
+fail the typed command instead of appearing as values. The planned breaking
+`Either RedisClientError` runner migration will replace that unwrap while
+nesting these same structured cluster/server causes; this change does not add a
+second compatibility runner.
+
 ## Custom Configuration
 
 ```haskell

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
@@ -64,6 +64,7 @@ module Database.Redis.Cluster.Client
     executeKeyedClusterCommand,
     executeKeyedClusterCommandUsingDelay,
     executeKeylessClusterCommand,
+    executeKeylessClusterCommandUsingDelay,
     -- * Re-export RedisCommands for convenience
     module RedisCommandClient,
     -- * Internal (exported for testing)
@@ -745,7 +746,31 @@ executeKeylessClusterCommand ::
   ClusterClient client ->
   RedisCommandClient client RespData ->
   IO (Either ClusterError RespData)
-executeKeylessClusterCommand client action = do
+executeKeylessClusterCommand =
+  executeKeylessClusterCommandUsingDelay threadDelay
+
+-- | Test seam for deterministic keyless retry schedules.
+executeKeylessClusterCommandUsingDelay ::
+  (Client client) =>
+  (Int -> IO ()) ->
+  ClusterClient client ->
+  RedisCommandClient client RespData ->
+  IO (Either ClusterError RespData)
+executeKeylessClusterCommandUsingDelay delayAction client action =
+  withRetryAndRefreshPolicyUsing
+    KeylessRetryPolicy
+    delayAction
+    client
+    (clusterMaxRetries $ clusterConfig client)
+    (clusterRetryDelay $ clusterConfig client)
+    (const $ executeKeylessAttempt client action)
+
+executeKeylessAttempt ::
+  (Client client) =>
+  ClusterClient client ->
+  RedisCommandClient client RespData ->
+  IO (Either ClusterError RespData)
+executeKeylessAttempt client action = do
   let connector = clusterConnector client
   topology <- readTVarIO (clusterTopology client)
   let masterNodes = [node | node <- Map.elems (topologyNodes topology), nodeRole node == Master]
@@ -778,6 +803,25 @@ withRetryAndRefreshUsing ::
   (RetryRoute -> IO (Either ClusterError a)) ->
   IO (Either ClusterError a)
 withRetryAndRefreshUsing delayAction client maxRetries initialDelay action =
+  withRetryAndRefreshPolicyUsing
+    KeyedRetryPolicy delayAction client maxRetries initialDelay action
+
+data RetryPolicy
+  = KeyedRetryPolicy
+  | KeylessRetryPolicy
+  deriving (Eq)
+
+withRetryAndRefreshPolicyUsing ::
+  (Client client) =>
+  RetryPolicy ->
+  (Int -> IO ()) ->
+  ClusterClient client ->
+  Int ->
+  Int ->
+  (RetryRoute -> IO (Either ClusterError a)) ->
+  IO (Either ClusterError a)
+withRetryAndRefreshPolicyUsing retryPolicy delayAction
+    client maxRetries initialDelay action =
   go 0 initialDelay RouteBySlot
   where
     go attempt delay route
@@ -804,30 +848,34 @@ withRetryAndRefreshUsing delayAction client maxRetries initialDelay action =
                   case refreshResult of
                     Left ClusterClientClosed ->
                       return $ Left ClusterClientClosed
+                    _ -> retryAfterDelay err RouteBySlot delay
+            Left err@(MovedError slot address)
+              | retryPolicy == KeyedRetryPolicy -> do
+                  patchMovedSlot client slot address
+                  retryImmediately err $ RouteMoved slot address
+            Left err@(AskError _ address)
+              | retryPolicy == KeyedRetryPolicy ->
+                  retryImmediately err $ RouteAsk address
+            Left err@(ConnectionError _)
+              | retryPolicy == KeyedRetryPolicy -> do
+                  refreshResult <- refreshForRoute route
+                  case refreshResult of
+                    Left ClusterClientClosed ->
+                      return $ Left ClusterClientClosed
                     Left refreshErr@(TopologyError _) ->
                       return $ Left refreshErr
                     _ -> retryAfterDelay err RouteBySlot delay
-            Left err@(MovedError slot address) -> do
-              patchMovedSlot client slot address
-              retryImmediately err $ RouteMoved slot address
-            Left err@(AskError _ address) ->
-              retryImmediately err $ RouteAsk address
-            Left err@(ConnectionError _) -> do
-              refreshResult <- refreshForRoute route
-              case refreshResult of
-                Left ClusterClientClosed -> return $ Left ClusterClientClosed
-                Left refreshErr@(TopologyError _) ->
-                  return $ Left refreshErr
-                _ -> retryAfterDelay err RouteBySlot delay
-            Left err@(ConnectionTimeoutError _) -> do
-              refreshResult <- case route of
-                RouteMoved _ _ -> refreshForRoute route
-                _              -> return $ Right ()
-              case refreshResult of
-                Left ClusterClientClosed -> return $ Left ClusterClientClosed
-                Left refreshErr@(TopologyError _) ->
-                  return $ Left refreshErr
-                _ -> retryAfterDelay err RouteBySlot delay
+            Left err@(ConnectionTimeoutError _)
+              | retryPolicy == KeyedRetryPolicy -> do
+                  refreshResult <- case route of
+                    RouteMoved _ _ -> refreshForRoute route
+                    _              -> return $ Right ()
+                  case refreshResult of
+                    Left ClusterClientClosed ->
+                      return $ Left ClusterClientClosed
+                    Left refreshErr@(TopologyError _) ->
+                      return $ Left refreshErr
+                    _ -> retryAfterDelay err RouteBySlot delay
             Left err -> return $ Left err
 
       where
@@ -966,17 +1014,32 @@ executeKeylessMaybe
   -> ClusterCommandClient client (Maybe RespData)
 executeKeylessMaybe action = do
   client <- State.get
-  topology <- liftIO $ readTVarIO $ clusterTopology client
+  result <- liftIO $
+    withRetryAndRefreshPolicyUsing
+      KeylessRetryPolicy
+      threadDelay
+      client
+      (clusterMaxRetries $ clusterConfig client)
+      (clusterRetryDelay $ clusterConfig client)
+      (const $ executeKeylessMaybeAttempt client action)
+  unwrapClusterResult result
+
+executeKeylessMaybeAttempt
+  :: (Client client)
+  => ClusterClient client
+  -> RedisCommandClient client (Maybe RespData)
+  -> IO (Either ClusterError (Maybe RespData))
+executeKeylessMaybeAttempt client action = do
+  topology <- readTVarIO $ clusterTopology client
   let masters =
         [ node
         | node <- Map.elems $ topologyNodes topology
         , nodeRole node == Master
         ]
   case masters of
-    [] -> unwrapClusterResult $ Left $
-      TopologyError "No master nodes available"
+    [] -> return $ Left $ TopologyError "No master nodes available"
     node : _ -> do
-      result <- liftIO $ tryClusterAction $
+      result <- tryClusterAction $
         withConnectionBounded
           (clusterConnectionPool client)
           (nodeAddress node)
@@ -985,11 +1048,7 @@ executeKeylessMaybe action = do
             State.evalStateT
               (runRedisCommandClient action)
               clientState
-      case result of
-        Left err -> unwrapClusterResult $ Left err
-        Right Nothing -> return Nothing
-        Right (Just response) ->
-          Just <$> unwrapClusterResult (classifyClusterReply response)
+      return $ result >>= traverse classifyClusterReply
 
 -- | Execute a keyed command via the multiplexer pool.
 -- Pre-encodes the command to a Builder, routes by slot, and handles MOVED/ASK redirection.

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
@@ -62,13 +62,17 @@ module Database.Redis.Cluster.Client
     -- proxying. Prefer 'runClusterCommandClient' with 'RedisCommands' for
     -- normal Redis operations.
     executeKeyedClusterCommand,
+    executeKeyedClusterCommandUsingDelay,
     executeKeylessClusterCommand,
     -- * Re-export RedisCommands for convenience
     module RedisCommandClient,
     -- * Internal (exported for testing)
     RedirectionInfo (..),
+    RetryRoute (..),
+    classifyClusterReply,
     parseRedirectionError,
     detectRedirection,
+    withRetryAndRefreshUsing,
   )
 where
 
@@ -149,6 +153,7 @@ data ClusterError
   | ClusterDownError String -- ^ The cluster is in a down or error state.
   | TryAgainError String -- ^ Transient failure; the operation should be retried.
   | CrossSlotError String -- ^ Multi-key command spans multiple hash slots.
+  | RedisCommandError ByteString -- ^ An ordinary Redis server error reply, preserved verbatim.
   | MaxRetriesExceeded String -- ^ All retry attempts exhausted.
   | TopologyError String -- ^ Slot or node lookup failed (e.g., empty topology).
   | ConnectionError String -- ^ Network-level failure connecting to a node.
@@ -668,38 +673,62 @@ refreshTopologyIfStale client = do
   when (timeSinceUpdate >= refreshInterval) $ do
     refreshTopology client
 
--- | Detect MOVED or ASK errors from RespData.
--- Common case (no redirect) is a constructor check plus at most a single byte
--- comparison, with zero allocation.
+-- | Classify every Redis error reply returned by a cluster command.
+--
+-- Prefixes are case-sensitive and must end at the error token boundary.
+-- Malformed redirections and unrecognized server errors remain ordinary
+-- 'RedisCommandError' values with their full payload preserved.
+{-# INLINE classifyClusterReply #-}
+classifyClusterReply :: RespData -> Either ClusterError RespData
+classifyClusterReply (RespError msg)
+  | Just redirection <- classifyRedirection msg =
+      case redirection of
+        Left (RedirectionInfo slot host port) ->
+          Left $ MovedError slot $ NodeAddress host port
+        Right (RedirectionInfo slot host port) ->
+          Left $ AskError slot $ NodeAddress host port
+  | hasErrorPrefix "TRYAGAIN" msg =
+      Left $ TryAgainError $ BS8.unpack msg
+  | hasErrorPrefix "CLUSTERDOWN" msg =
+      Left $ ClusterDownError $ BS8.unpack msg
+  | hasErrorPrefix "CROSSSLOT" msg =
+      Left $ CrossSlotError $ BS8.unpack msg
+  | otherwise = Left $ RedisCommandError msg
+classifyClusterReply respData = Right respData
+
+{-# INLINE hasErrorPrefix #-}
+hasErrorPrefix :: ByteString -> ByteString -> Bool
+hasErrorPrefix prefix message =
+  message == prefix
+    || (prefix `BS.isPrefixOf` message
+      && BS.length message > BS.length prefix
+      && BS.index message (BS.length prefix) == 0x20)
+
+{-# INLINE classifyRedirection #-}
+classifyRedirection
+  :: ByteString
+  -> Maybe (Either RedirectionInfo RedirectionInfo)
+classifyRedirection message
+  | "MOVED " `BS.isPrefixOf` message =
+      Left <$> parseMovedAsk (BS.drop 6 message)
+  | "ASK " `BS.isPrefixOf` message =
+      Right <$> parseMovedAsk (BS.drop 4 message)
+  | otherwise = Nothing
+
+-- | Backward-compatible MOVED/ASK-only view of 'classifyClusterReply'.
 {-# INLINE detectRedirection #-}
 detectRedirection :: RespData -> Maybe (Either RedirectionInfo RedirectionInfo)
-detectRedirection (RespError msg)
-  | BS.length msg >= 6  -- shortest redirect: "ASK x y" needs >= 7 chars
-  , let w = BS.index msg 0
-  = if w == 0x4D  -- 'M'
-    then if BS.isPrefixOf "MOVED " msg
-         then case parseMovedAsk (BS.drop 6 msg) of
-                Just redir -> Just (Left redir)
-                Nothing    -> Nothing
-         else Nothing
-    else if w == 0x41  -- 'A'
-    then if BS.isPrefixOf "ASK " msg
-         then case parseMovedAsk (BS.drop 4 msg) of
-                Just redir -> Just (Right redir)
-                Nothing    -> Nothing
-         else Nothing
-    else Nothing
-  | otherwise = Nothing
-detectRedirection _ = Nothing
+detectRedirection (RespError message) = classifyRedirection message
+detectRedirection _                   = Nothing
 
 -- | Execute a command on a specific node (used for keyless commands and topology refresh)
 executeOnNode ::
   (Client client) =>
   ClusterClient client ->
   NodeAddress ->
-  RedisCommandClient client a ->
+  RedisCommandClient client RespData ->
   Connector client ->
-  IO (Either ClusterError a)
+  IO (Either ClusterError RespData)
 executeOnNode client nodeAddr action connector = do
   result <- tryClusterAction $
     withConnectionBounded
@@ -707,17 +736,15 @@ executeOnNode client nodeAddr action connector = do
     let clientState = ClientState conn BS8.empty
     State.evalStateT (runRedisCommandClient action) clientState
 
-  case result of
-    Left err    -> return $ Left err
-    Right value -> return $ Right value
+  return $ result >>= classifyClusterReply
 
 -- | Execute a command that does not target a specific key (e.g., PING, AUTH, FLUSHALL).
 -- Routed to an arbitrary master node.
 executeKeylessClusterCommand ::
   (Client client) =>
   ClusterClient client ->
-  RedisCommandClient client a ->
-  IO (Either ClusterError a)
+  RedisCommandClient client RespData ->
+  IO (Either ClusterError RespData)
 executeKeylessClusterCommand client action = do
   let connector = clusterConnector client
   topology <- readTVarIO (clusterTopology client)
@@ -740,18 +767,23 @@ executeKeylessClusterCommand client action = do
 --
 -- ASK errors follow the Redis protocol: retry at the target node with an ASKING prefix.
 -- No topology refresh is needed since ASK indicates a temporary, in-progress migration.
-withRetryAndRefresh ::
+-- | Deterministic retry seam used by tests and timing-sensitive integrations.
+-- Production command execution supplies 'threadDelay'.
+withRetryAndRefreshUsing ::
   (Client client) =>
+  (Int -> IO ()) ->
   ClusterClient client ->
-  Int -> -- Max retries
-  Int -> -- Initial delay (microseconds)
+  Int ->
+  Int ->
   (RetryRoute -> IO (Either ClusterError a)) ->
   IO (Either ClusterError a)
-withRetryAndRefresh client maxRetries initialDelay action =
+withRetryAndRefreshUsing delayAction client maxRetries initialDelay action =
   go 0 initialDelay RouteBySlot
   where
     go attempt delay route
-      | attempt >= maxRetries = return $ Left $ MaxRetriesExceeded $ "Max retries (" ++ show maxRetries ++ ") exceeded"
+      | attempt >= maxRetries =
+          return $ Left $ MaxRetriesExceeded $
+            "Max retries (" ++ show maxRetries ++ ") exceeded"
       | otherwise = do
           result <- action route
           case result of
@@ -762,38 +794,76 @@ withRetryAndRefresh client maxRetries initialDelay action =
                     client [address] [(slot, address)]
                 _ -> return ()
               return $ Right value
-            Left (TryAgainError _) -> do
-              threadDelay delay
-              go (attempt + 1) (delay * 2) RouteBySlot
-            Left (MovedError slot address) -> do
+            Left err@(TryAgainError _) ->
+              retryAfterDelay err route delay
+            Left err@(ClusterDownError _) -> do
+              if attempt + 1 >= maxRetries
+                then return $ retryExhausted maxRetries err
+                else do
+                  refreshResult <- refreshForRoute route
+                  case refreshResult of
+                    Left ClusterClientClosed ->
+                      return $ Left ClusterClientClosed
+                    Left refreshErr@(TopologyError _) ->
+                      return $ Left refreshErr
+                    _ -> retryAfterDelay err RouteBySlot delay
+            Left err@(MovedError slot address) -> do
               patchMovedSlot client slot address
-              go (attempt + 1) delay $ RouteMoved slot address
-            Left (AskError _ address) ->
-              go (attempt + 1) delay $ RouteAsk address
-            Left (ConnectionError _) -> do
+              retryImmediately err $ RouteMoved slot address
+            Left err@(AskError _ address) ->
+              retryImmediately err $ RouteAsk address
+            Left err@(ConnectionError _) -> do
               refreshResult <- refreshForRoute route
               case refreshResult of
                 Left ClusterClientClosed -> return $ Left ClusterClientClosed
-                Left err@(TopologyError _) -> return $ Left err
-                _ -> do
-                  threadDelay delay
-                  go (attempt + 1) (delay * 2) RouteBySlot
-            Left (ConnectionTimeoutError _) -> do
+                Left refreshErr@(TopologyError _) ->
+                  return $ Left refreshErr
+                _ -> retryAfterDelay err RouteBySlot delay
+            Left err@(ConnectionTimeoutError _) -> do
               refreshResult <- case route of
                 RouteMoved _ _ -> refreshForRoute route
                 _              -> return $ Right ()
               case refreshResult of
                 Left ClusterClientClosed -> return $ Left ClusterClientClosed
-                Left err@(TopologyError _) -> return $ Left err
-                _ -> do
-                  threadDelay delay
-                  go (attempt + 1) (delay * 2) RouteBySlot
+                Left refreshErr@(TopologyError _) ->
+                  return $ Left refreshErr
+                _ -> retryAfterDelay err RouteBySlot delay
             Left err -> return $ Left err
+
+      where
+        retryImmediately err nextRoute
+          | attempt + 1 >= maxRetries =
+              return $ retryExhausted maxRetries err
+          | otherwise =
+              go (attempt + 1) delay nextRoute
+
+        retryAfterDelay err nextRoute currentDelay
+          | attempt + 1 >= maxRetries =
+              return $ retryExhausted maxRetries err
+          | otherwise = do
+              delayAction $ normalizeDelay currentDelay
+              go (attempt + 1) (nextRetryDelay currentDelay) nextRoute
 
     refreshForRoute (RouteMoved slot address) =
       refreshTopologyFromCandidates client [address] [(slot, address)]
     refreshForRoute _ =
       refreshTopologyFromCandidates client [] []
+
+retryExhausted :: Int -> ClusterError -> Either ClusterError a
+retryExhausted maxRetries lastError =
+  Left $ MaxRetriesExceeded $
+    "Max retries (" ++ show maxRetries
+      ++ ") exceeded; last error: " ++ show lastError
+
+normalizeDelay :: Int -> Int
+normalizeDelay = max 0
+
+nextRetryDelay :: Int -> Int
+nextRetryDelay delay
+  | normalized > maxBound `div` 2 = maxBound
+  | otherwise = normalized * 2
+  where
+    normalized = normalizeDelay delay
 
 tryClusterAction :: IO a -> IO (Either ClusterError a)
 tryClusterAction action = do
@@ -825,15 +895,20 @@ parseMovedAsk :: ByteString -> Maybe RedirectionInfo
 parseMovedAsk rest =
   case BS8.readInt rest of
     Just (slot, afterSlot)
-      | not (BS8.null afterSlot)
+      | slot >= 0
+      , slot <= 16383
+      , not (BS8.null afterSlot)
       , BS8.head afterSlot == ' '
       -> let hostPort = BS8.tail afterSlot
          in case BS8.break (== ':') hostPort of
               (host, portPart)
-                | not (BS8.null portPart)
+                | not (BS8.null host)
+                , not (BS8.null portPart)
                 -> case BS8.readInt (BS8.tail portPart) of
                      Just (port, rest')
-                       | BS8.null rest'
+                       | port >= 1
+                       , port <= 65535
+                       , BS8.null rest'
                        -> Just $ RedirectionInfo (fromIntegral slot) (BS8.unpack host) port
                      _ -> Nothing
               _ -> Nothing
@@ -852,8 +927,8 @@ parseRedirectionError errorType msg
 -- | Internal helper to execute a keyless command within ClusterCommandClient monad
 executeKeylessCommand ::
   (Client client) =>
-  RedisCommandClient client a ->
-  ClusterCommandClient client (Either ClusterError a)
+  RedisCommandClient client RespData ->
+  ClusterCommandClient client (Either ClusterError RespData)
 executeKeylessCommand action = do
   client <- State.get
   liftIO $ executeKeylessClusterCommand client action
@@ -876,13 +951,50 @@ executeKeyedAs :: (Client client, FromResp a) => ByteString -> [ByteString] -> C
 executeKeyedAs key cmdArgs = executeKeyed key cmdArgs >>= convertResp
 
 -- | Execute a keyless command and unwrap the result
-executeKeyless :: (Client client) => RedisCommandClient client a -> ClusterCommandClient client a
+executeKeyless
+  :: (Client client, FromResp a)
+  => RedisCommandClient client RespData
+  -> ClusterCommandClient client a
 executeKeyless action = do
   result <- executeKeylessCommand action
-  unwrapClusterResult result
+  raw <- unwrapClusterResult result
+  convertResp raw
+
+executeKeylessMaybe
+  :: (Client client)
+  => RedisCommandClient client (Maybe RespData)
+  -> ClusterCommandClient client (Maybe RespData)
+executeKeylessMaybe action = do
+  client <- State.get
+  topology <- liftIO $ readTVarIO $ clusterTopology client
+  let masters =
+        [ node
+        | node <- Map.elems $ topologyNodes topology
+        , nodeRole node == Master
+        ]
+  case masters of
+    [] -> unwrapClusterResult $ Left $
+      TopologyError "No master nodes available"
+    node : _ -> do
+      result <- liftIO $ tryClusterAction $
+        withConnectionBounded
+          (clusterConnectionPool client)
+          (nodeAddress node)
+          (clusterConnector client) $ \conn -> do
+            let clientState = ClientState conn BS8.empty
+            State.evalStateT
+              (runRedisCommandClient action)
+              clientState
+      case result of
+        Left err -> unwrapClusterResult $ Left err
+        Right Nothing -> return Nothing
+        Right (Just response) ->
+          Just <$> unwrapClusterResult (classifyClusterReply response)
 
 -- | Execute a keyed command via the multiplexer pool.
 -- Pre-encodes the command to a Builder, routes by slot, and handles MOVED/ASK redirection.
+-- Every @RespError@ is returned as a typed 'ClusterError'; ordinary Redis
+-- errors use 'RedisCommandError' and are never success-shaped.
 --
 -- This is the low-level API for executing commands with explicit routing key.
 -- For most operations, prefer 'runClusterCommandClient' with 'RedisCommands'.
@@ -892,11 +1004,25 @@ executeKeyedClusterCommand ::
   ByteString ->           -- key for routing
   [ByteString] ->         -- command args
   IO (Either ClusterError RespData)
-executeKeyedClusterCommand client key cmdArgs = do
+executeKeyedClusterCommand =
+  executeKeyedClusterCommandUsingDelay threadDelay
+
+-- | Test seam for deterministic retry schedule and cancellation coverage.
+executeKeyedClusterCommandUsingDelay ::
+  (Client client) =>
+  (Int -> IO ()) ->
+  ClusterClient client ->
+  ByteString ->
+  [ByteString] ->
+  IO (Either ClusterError RespData)
+executeKeyedClusterCommandUsingDelay delayAction client key cmdArgs = do
   let muxPool = clusterMultiplexPool client
       cmdBuilder = encodeCommandBuilder cmdArgs
       !slot = calculateSlot key
-  withRetryAndRefresh client (clusterMaxRetries (clusterConfig client)) (clusterRetryDelay (clusterConfig client)) $ \route ->
+  withRetryAndRefreshUsing delayAction
+    client
+    (clusterMaxRetries $ clusterConfig client)
+    (clusterRetryDelay $ clusterConfig client) $ \route ->
     case route of
       RouteBySlot -> do
         refreshResult <- tryClusterAction $ refreshTopologyIfStale client
@@ -923,14 +1049,7 @@ executeOnSlotMux client muxPool slot cmdBuilder = do
     Nothing -> return $ Left $ TopologyError $ "No node found for slot " ++ show slot
     Just addr -> do
       result <- tryClusterAction $ submitToNode muxPool addr cmdBuilder
-      case result of
-        Left err -> return $ Left err
-        Right respData -> case detectRedirection respData of
-          Just (Left (RedirectionInfo s host port)) ->
-            return $ Left $ MovedError s (NodeAddress host port)
-          Just (Right (RedirectionInfo s host port)) ->
-            return $ Left $ AskError s (NodeAddress host port)
-          Nothing -> return $ Right respData
+      return $ result >>= classifyClusterReply
 
 executeOnNodeDirect
   :: (Client client)
@@ -940,18 +1059,7 @@ executeOnNodeDirect
   -> IO (Either ClusterError RespData)
 executeOnNodeDirect muxPool address cmdBuilder = do
   result <- tryClusterAction $ submitToNode muxPool address cmdBuilder
-  case result of
-    Left err       -> return $ Left err
-    Right respData -> return $ classifyRedirect respData
-
-classifyRedirect :: RespData -> Either ClusterError RespData
-classifyRedirect respData =
-  case detectRedirection respData of
-    Just (Left (RedirectionInfo slot host port)) ->
-      Left $ MovedError slot $ NodeAddress host port
-    Just (Right (RedirectionInfo slot host port)) ->
-      Left $ AskError slot $ NodeAddress host port
-    Nothing -> Right respData
+  return $ result >>= classifyClusterReply
 
 -- | Execute a command on a specific node with ASKING prefix (for ASK redirects).
 -- Per Redis protocol, ASK requires sending ASKING before the actual command to the
@@ -968,14 +1076,7 @@ executeOnNodeWithAsking _client muxPool addr cmdBuilder = do
   let askingBuilder = encodeCommandBuilder ["ASKING"]
   result <- tryClusterAction $
     submitToNodeWithAsking muxPool addr askingBuilder cmdBuilder
-  case result of
-    Left err -> return $ Left err
-    Right respData -> case detectRedirection respData of
-      Just (Left (RedirectionInfo s host port)) ->
-        return $ Left $ MovedError s (NodeAddress host port)
-      Just (Right (RedirectionInfo s host port)) ->
-        return $ Left $ AskError s (NodeAddress host port)
-      Nothing -> return $ Right respData
+  return $ result >>= classifyClusterReply
 
 instance (Client client) => RedisCommands (ClusterCommandClient client) where
   auth _ _ = liftIO $ throwIO ClusterRuntimeAuthenticationUnsupported
@@ -1021,7 +1122,7 @@ instance (Client client) => RedisCommands (ClusterCommandClient client) where
   llen k = executeKeyedAs k ["LLEN", k]
   lindex k idx = executeKeyedAs k ["LINDEX", k, showBS idx]
   clientSetInfo args = executeKeyless (RedisCommandClient.clientSetInfo args)
-  clientReply val = executeKeyless (RedisCommandClient.clientReply val)
+  clientReply val = executeKeylessMaybe (RedisCommandClient.clientReply val)
   zadd k members =
     let payload = concatMap (\(score, member) -> [showBS score, member]) members
     in executeKeyedAs k ("ZADD" : k : payload)

--- a/hask-redis-mux/test/ClusterCommandSpec.hs
+++ b/hask-redis-mux/test/ClusterCommandSpec.hs
@@ -15,7 +15,7 @@ import           Control.Exception                     (SomeAsyncException,
                                                         fromException, throwIO,
                                                         try)
 import qualified Control.Exception                     as Exception
-import           Control.Monad                         (replicateM_)
+import           Control.Monad                         (forM_, replicateM_)
 import           Control.Monad.IO.Class                (liftIO)
 import           Data.ByteString                       (ByteString)
 import qualified Data.ByteString                       as BS
@@ -128,9 +128,15 @@ spec = do
         -- Tighter parsing rejects non-standard formatting (Redis never produces this)
         result `shouldBe` Nothing
 
-      it "handles port 0" $ do
+      it "rejects port 0" $ do
         let result = parseRedirectionError "MOVED" "MOVED 3999 127.0.0.1:0"
-        result `shouldBe` Just (RedirectionInfo 3999 "127.0.0.1" 0)
+        result `shouldBe` Nothing
+
+      it "rejects negative and out-of-range slots" $ do
+        parseRedirectionError "MOVED" "MOVED -1 127.0.0.1:6379"
+          `shouldBe` Nothing
+        parseRedirectionError "MOVED" "MOVED 16384 127.0.0.1:6379"
+          `shouldBe` Nothing
 
       it "returns Nothing for extra fields after host:port" $ do
         let result = parseRedirectionError "MOVED" "MOVED 3999 127.0.0.1:6381 extra-data"
@@ -169,6 +175,53 @@ spec = do
 
     it "returns Nothing for errors starting with A but not ASK" $ do
       detectRedirection (RespError "AUTH required") `shouldBe` Nothing
+
+  describe "central cluster reply classification" $ do
+    it "classifies all supported Redis Cluster error tokens" $ do
+      classifyClusterReply
+        (RespError "MOVED 3999 127.0.0.1:6381")
+        `shouldBe`
+          Left (MovedError 3999 $ NodeAddress "127.0.0.1" 6381)
+      classifyClusterReply
+        (RespError "ASK 3999 127.0.0.1:6381")
+        `shouldBe`
+          Left (AskError 3999 $ NodeAddress "127.0.0.1" 6381)
+      classifyClusterReply
+        (RespError "TRYAGAIN Slot is migrating")
+        `shouldBe`
+          Left (TryAgainError "TRYAGAIN Slot is migrating")
+      classifyClusterReply
+        (RespError "CLUSTERDOWN The cluster is down")
+        `shouldBe`
+          Left (ClusterDownError "CLUSTERDOWN The cluster is down")
+      classifyClusterReply
+        (RespError "CROSSSLOT Keys do not hash to one slot")
+        `shouldBe`
+          Left (CrossSlotError "CROSSSLOT Keys do not hash to one slot")
+
+    it "requires an exact case-sensitive token boundary" $ do
+      let ordinary message =
+            classifyClusterReply (RespError message)
+              `shouldBe` Left (RedisCommandError message)
+      mapM_ ordinary
+        [ "TRYAGAINLY not the cluster token"
+        , "TRYAGAIN\twrong delimiter"
+        , "tryagain wrong case"
+        , "CLUSTERDOWNTIME different token"
+        , "CROSSSLOTTERY different token"
+        , "MOVEDLY 1 127.0.0.1:6379"
+        , "ASKED 1 127.0.0.1:6379"
+        ]
+
+    it "preserves malformed redirects and ordinary server errors verbatim" $ do
+      classifyClusterReply (RespError "MOVED invalid payload")
+        `shouldBe` Left (RedisCommandError "MOVED invalid payload")
+      classifyClusterReply (RespError "WRONGTYPE full server cause")
+        `shouldBe` Left (RedisCommandError "WRONGTYPE full server cause")
+
+    it "passes non-error replies through unchanged" $ do
+      classifyClusterReply (RespBulkString "value")
+        `shouldBe` Right (RespBulkString "value")
 
   describe "ClusterError types" $ do
     it "creates MovedError correctly" $ do
@@ -258,9 +311,11 @@ spec = do
 
   askRedirectSpec
   askRedirectAdditionalSpec
+  askRedirectSuccessSpec
   movedRedirectSpec
   clusterLifecycleSpec
   clusterAuthenticationSpec
+  clusterErrorClassificationSpec
 
 -- ---------------------------------------------------------------------------
 -- Mock client (same pattern as MultiplexPoolSpec)
@@ -1348,9 +1403,13 @@ movedRedirectSpec =
       topology <- mkTopology node1
       client <- mkAuthMockClusterClient retryConfig connector topology
 
-      executeKeyedClusterCommand client key ["GET", key]
-        `shouldReturn`
-          Left (MaxRetriesExceeded "Max retries (3) exceeded")
+      result <- executeKeyedClusterCommand client key ["GET", key]
+      case result of
+        Left (MaxRetriesExceeded message) -> do
+          message `shouldContain` "Max retries (3) exceeded"
+          message `shouldContain` "MovedError"
+        other -> expectationFailure $
+          "Expected MOVED retry exhaustion, got: " ++ show other
       records <- getRecords
       length records `shouldBe` 3
       sent <- mapM recordSentBytes records
@@ -1484,6 +1543,391 @@ askRedirectAdditionalSpec = describe "additional ASK redirect integration" $ do
       closeMultiplexPool (clusterMultiplexPool client)
     result `shouldBe` Just ()
 
+-- ---------------------------------------------------------------------------
+-- Cluster error classification and retry policy
+-- ---------------------------------------------------------------------------
+
+data ExpectedPathError
+  = ImmediateError ClusterError
+  | ExhaustedWith String
+
+clusterErrorReplies :: [(String, RespData, ExpectedPathError)]
+clusterErrorReplies =
+  [ ( "MOVED"
+    , RespError "MOVED 3999 127.0.0.2:6380"
+    , ExhaustedWith "MovedError"
+    )
+  , ( "ASK"
+    , RespError "ASK 3999 127.0.0.2:6380"
+    , ExhaustedWith "AskError"
+    )
+  , ( "TRYAGAIN"
+    , RespError "TRYAGAIN migration still converging"
+    , ExhaustedWith "TryAgainError"
+    )
+  , ( "CLUSTERDOWN"
+    , RespError "CLUSTERDOWN cluster state is not ok"
+    , ExhaustedWith "ClusterDownError"
+    )
+  , ( "CROSSSLOT"
+    , RespError "CROSSSLOT keys span slots"
+    , ImmediateError $ CrossSlotError "CROSSSLOT keys span slots"
+    )
+  , ( "ordinary Redis error"
+    , RespError "WRONGTYPE full server cause"
+    , ImmediateError $ RedisCommandError "WRONGTYPE full server cause"
+    )
+  ]
+
+assertPathError
+  :: ExpectedPathError
+  -> Either ClusterError RespData
+  -> Expectation
+assertPathError (ImmediateError expected) actual =
+  actual `shouldBe` Left expected
+assertPathError (ExhaustedWith expectedCause) actual =
+  case actual of
+    Left (MaxRetriesExceeded message) ->
+      message `shouldContain` expectedCause
+    other -> expectationFailure $
+      "Expected retry exhaustion containing "
+        ++ show expectedCause ++ ", got: " ++ show other
+
+retryTestConfig :: Int -> Int -> ClusterConfig
+retryTestConfig attempts delay =
+  testClusterConfig
+    { clusterMaxRetries = attempts
+    , clusterRetryDelay = delay
+    }
+
+runNormalErrorPath
+  :: RespData
+  -> IO (Either ClusterError RespData)
+runNormalErrorPath reply = do
+  (connector, _) <- createAuthMockConnector $ \_ index ->
+    return $
+      if index == 0
+        then [replyWith validClusterSlots]
+        else [replyWith reply]
+  client <- createClusterClient
+    (retryTestConfig 1 1)
+    connector
+  result <- executeKeyedClusterCommandUsingDelay
+    (const $ return ())
+    client
+    "classification-key"
+    ["GET", "classification-key"]
+  closeClusterClient client
+  return result
+
+runRedirectTargetErrorPath
+  :: Bool
+  -> RespData
+  -> IO (Either ClusterError RespData)
+runRedirectTargetErrorPath useAsking reply = do
+  let initialRedirect
+        | useAsking = RespError "ASK 3999 127.0.0.2:6380"
+        | otherwise = RespError "MOVED 3999 127.0.0.2:6380"
+      script address index
+        | address == node1 && index == 0 =
+            return [replyWith validClusterSlots]
+        | address == node1 =
+            return [replyWith initialRedirect]
+        | useAsking =
+            return
+              [ replyWith $ RespSimpleString "OK"
+              , replyWith reply
+              ]
+        | otherwise =
+            return [replyWith reply]
+  (connector, _) <- createAuthMockConnector script
+  client <- createClusterClient
+    (retryTestConfig 2 1)
+    connector
+  result <- executeKeyedClusterCommandUsingDelay
+    (const $ return ())
+    client
+    "classification-key"
+    ["GET", "classification-key"]
+  closeClusterClient client
+  return result
+
+clusterErrorClassificationSpec :: Spec
+clusterErrorClassificationSpec =
+  describe "cluster error execution and retry policy" $ do
+    describe "identical classification across execution paths" $ do
+      forM_ clusterErrorReplies $ \(label, reply, expected) -> do
+        it ("classifies " ++ label ++ " on the normal slot path") $ do
+          runNormalErrorPath reply >>= assertPathError expected
+
+        it ("classifies " ++ label ++ " on a direct MOVED target") $ do
+          runRedirectTargetErrorPath False reply >>= assertPathError expected
+
+        it ("classifies " ++ label ++ " on an ASK target") $ do
+          runRedirectTargetErrorPath True reply >>= assertPathError expected
+
+    it "retries TRYAGAIN on the same route with exact exponential delays" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $
+              if index == 0
+                then [replyWith validClusterSlots]
+                else
+                  [ replyWith $ RespError "TRYAGAIN first"
+                  , replyWith $ RespError "TRYAGAIN second"
+                  , replyWith $ RespBulkString "value"
+                  ]
+      (connector, getRecords) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 7) connector
+      result <- executeKeyedClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        "tryagain-key"
+        ["GET", "tryagain-key"]
+      result `shouldBe` Right (RespBulkString "value")
+      readIORef delays `shouldReturn` [7, 14]
+      records <- getRecords
+      let muxRecord = findAuthRecord records node1 1
+      awaitCommandCount muxRecord ["GET", "tryagain-key"] 3
+      closeClusterClient client
+
+    it "exhausts TRYAGAIN after exactly the configured total attempts" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $
+              if index == 0
+                then [replyWith validClusterSlots]
+                else
+                  [ replyWith $ RespError "TRYAGAIN first"
+                  , replyWith $ RespError "TRYAGAIN second"
+                  , replyWith $ RespError "TRYAGAIN final cause"
+                  ]
+      (connector, getRecords) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 9) connector
+      result <- executeKeyedClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        "tryagain-exhaust-key"
+        ["GET", "tryagain-exhaust-key"]
+      case result of
+        Left (MaxRetriesExceeded message) ->
+          message `shouldContain` "TRYAGAIN final cause"
+        other -> expectationFailure $
+          "Expected TRYAGAIN exhaustion, got: " ++ show other
+      readIORef delays `shouldReturn` [9, 18]
+      records <- getRecords
+      let muxRecord = findAuthRecord records node1 1
+      awaitCommandCount muxRecord ["GET", "tryagain-exhaust-key"] 3
+      closeClusterClient client
+
+    it "saturates exponential backoff instead of overflowing Int" $ do
+      delays <- newIORef []
+      let initialDelay = maxBound `div` 2 + 1
+          script _ index =
+            return $
+              if index == 0
+                then [replyWith validClusterSlots]
+                else
+                  [ replyWith $ RespError "TRYAGAIN first"
+                  , replyWith $ RespError "TRYAGAIN second"
+                  , replyWith $ RespBulkString "value"
+                  ]
+      (connector, _) <- createAuthMockConnector script
+      client <- createClusterClient
+        (retryTestConfig 3 initialDelay)
+        connector
+      result <- executeKeyedClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        "overflow-key"
+        ["GET", "overflow-key"]
+      result `shouldBe` Right (RespBulkString "value")
+      readIORef delays `shouldReturn` [initialDelay, maxBound]
+      closeClusterClient client
+
+    it "refreshes and backs off CLUSTERDOWN within the attempt budget" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $
+              if index == 0
+                then
+                  [ replyWith validClusterSlots
+                  , replyWith validClusterSlots
+                  , replyWith validClusterSlots
+                  ]
+                else
+                  [ replyWith $ RespError "CLUSTERDOWN first"
+                  , replyWith $ RespError "CLUSTERDOWN second"
+                  , replyWith $ RespBulkString "recovered"
+                  ]
+      (connector, getRecords) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 5) connector
+      result <- executeKeyedClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        "clusterdown-key"
+        ["GET", "clusterdown-key"]
+      result `shouldBe` Right (RespBulkString "recovered")
+      readIORef delays `shouldReturn` [5, 10]
+      records <- getRecords
+      seedSent <- recordSentBytes $ findAuthRecord records node1 0
+      countOccurrences (commandBytes ["CLUSTER", "SLOTS"]) seedSent
+        `shouldBe` 3
+      closeClusterClient client
+
+    it "bounds CLUSTERDOWN exhaustion and preserves the final cause" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $
+              if index == 0
+                then
+                  [ replyWith validClusterSlots
+                  , replyWith validClusterSlots
+                  , replyWith validClusterSlots
+                  ]
+                else
+                  [ replyWith $ RespError "CLUSTERDOWN first"
+                  , replyWith $ RespError "CLUSTERDOWN second"
+                  , replyWith $ RespError "CLUSTERDOWN final cause"
+                  ]
+      (connector, getRecords) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 6) connector
+      result <- executeKeyedClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        "clusterdown-exhaust-key"
+        ["GET", "clusterdown-exhaust-key"]
+      case result of
+        Left (MaxRetriesExceeded message) ->
+          message `shouldContain` "CLUSTERDOWN final cause"
+        other -> expectationFailure $
+          "Expected CLUSTERDOWN exhaustion, got: " ++ show other
+      readIORef delays `shouldReturn` [6, 12]
+      records <- getRecords
+      seedSent <- recordSentBytes $ findAuthRecord records node1 0
+      countOccurrences (commandBytes ["CLUSTER", "SLOTS"]) seedSent
+        `shouldBe` 3
+      let muxRecord = findAuthRecord records node1 1
+      awaitCommandCount
+        muxRecord ["GET", "clusterdown-exhaust-key"] 3
+      closeClusterClient client
+
+    it "returns CROSSSLOT immediately without retry or delay" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $
+              if index == 0
+                then [replyWith validClusterSlots]
+                else [replyWith $ RespError "CROSSSLOT permanent"]
+      (connector, getRecords) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 5 11) connector
+      result <- executeKeyedClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        "crossslot-key"
+        ["GET", "crossslot-key"]
+      result `shouldBe` Left (CrossSlotError "CROSSSLOT permanent")
+      readIORef delays `shouldReturn` []
+      records <- getRecords
+      let muxRecord = findAuthRecord records node1 1
+      awaitCommandCount muxRecord ["GET", "crossslot-key"] 1
+      closeClusterClient client
+
+    it "keeps cancellation responsive during retry backoff" $ do
+      delayStarted <- newEmptyMVar
+      blockDelay <- newEmptyMVar
+      finished <- newEmptyMVar
+      let script _ index =
+            return $
+              if index == 0
+                then [replyWith validClusterSlots]
+                else [replyWith $ RespError "TRYAGAIN wait"]
+      (connector, _) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 1) connector
+      owner <- forkFinally
+        (executeKeyedClusterCommandUsingDelay
+          (\_ -> putMVar delayStarted () >> takeMVar blockDelay)
+          client
+          "cancel-key"
+          ["GET", "cancel-key"])
+        (putMVar finished)
+      timeout 1000000 (takeMVar delayStarted) `shouldReturn` Just ()
+      killThread owner
+      outcome <- timeout 1000000 (takeMVar finished)
+      outcome `shouldSatisfy` \case
+        Just (Left err) ->
+          case fromException err :: Maybe SomeAsyncException of
+            Just _  -> True
+            Nothing -> False
+        _ -> False
+      closeClusterClient client
+
+    it "returns ordinary server errors as low-level Left values" $ do
+      let serverError = "ERR complete server explanation"
+          secret = "credential-like-command-argument"
+          script _ index =
+            return $
+              if index == 0
+                then [replyWith validClusterSlots]
+                else [replyWith $ RespError serverError]
+      (connector, _) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 1) connector
+      result <- executeKeyedClusterCommand client secret ["GET", secret]
+      result `shouldBe` Left (RedisCommandError serverError)
+      show result `shouldNotContain` BS8.unpack secret
+      closeClusterClient client
+
+    it "does not make ordinary errors success-shaped in the typed API" $ do
+      let serverError = "WRONGTYPE full typed cause"
+          script _ index =
+            return $
+              if index == 0
+                then [replyWith validClusterSlots]
+                else [replyWith $ RespError serverError]
+      (connector, _) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 1) connector
+      result <- try $ runClusterCommandClient client
+        (get "typed-error-key"
+          :: ClusterCommandClient AuthMockClient ByteString)
+        :: IO (Either SomeException ByteString)
+      case result of
+        Left err -> show err `shouldContain` BS8.unpack serverError
+        Right _  -> expectationFailure "Typed cluster error returned success"
+      closeClusterClient client
+
+    it "classifies ordinary errors from the low-level keyless API" $ do
+      let serverError = "NOSCRIPT full keyless cause"
+          script _ _ =
+            return
+              [ replyWith validClusterSlots
+              , replyWith $ RespError serverError
+              ]
+      (connector, _) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 1) connector
+      executeKeylessClusterCommand client
+        (ping :: RedisCommandClient AuthMockClient RespData)
+        `shouldReturn` Left (RedisCommandError serverError)
+      closeClusterClient client
+
+awaitCommandCount
+  :: AuthConnectionRecord
+  -> [ByteString]
+  -> Int
+  -> IO ()
+awaitCommandCount record command expected = do
+  sent <- recordSentBytes record
+  if countOccurrences (commandBytes command) sent >= expected
+    then return ()
+    else threadDelay 1000 >> awaitCommandCount record command expected
+
+askRedirectSuccessSpec :: Spec
+askRedirectSuccessSpec = describe "successful command without ASK redirection" $ do
   it "successful command without redirection returns directly" $ do
     result <- timeout 5000000 $ do
       (connector, addRecvMap, _) <- createMockConnector

--- a/hask-redis-mux/test/ClusterCommandSpec.hs
+++ b/hask-redis-mux/test/ClusterCommandSpec.hs
@@ -8,7 +8,8 @@ module Main (main) where
 import           Control.Concurrent                    (forkFinally, forkIO,
                                                         killThread, threadDelay)
 import           Control.Concurrent.MVar               (newEmptyMVar, newMVar,
-                                                        putMVar, takeMVar)
+                                                        putMVar, takeMVar,
+                                                        tryTakeMVar)
 import           Control.Concurrent.STM                (newTVarIO, readTVarIO)
 import           Control.Exception                     (SomeAsyncException,
                                                         SomeException, finally,
@@ -1866,6 +1867,328 @@ clusterErrorClassificationSpec =
             Just _  -> True
             Nothing -> False
         _ -> False
+      closeClusterClient client
+
+    it "retries keyless TRYAGAIN with exact attempts and delays" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $
+              if index == 0
+                then
+                  [ replyWith validClusterSlots
+                  , replyWith $ RespError "TRYAGAIN first"
+                  , replyWith $ RespError "TRYAGAIN second"
+                  , replyWith $ RespSimpleString "PONG"
+                  ]
+                else []
+      (connector, getRecords) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 4) connector
+      result <- executeKeylessClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        ping
+      result `shouldBe` Right (RespSimpleString "PONG")
+      readIORef delays `shouldReturn` [4, 8]
+      records <- getRecords
+      sent <- recordSentBytes $ findAuthRecord records node1 0
+      countOccurrences (commandBytes ["PING"]) sent `shouldBe` 3
+      closeClusterClient client
+
+    it "refreshes and recovers keyless CLUSTERDOWN within the attempt budget" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $
+              if index == 0
+                then
+                  [ replyWith validClusterSlots
+                  , replyWith $ RespError "CLUSTERDOWN first"
+                  , replyWith validClusterSlots
+                  , replyWith $ RespError "CLUSTERDOWN second"
+                  , replyWith validClusterSlots
+                  , replyWith $ RespSimpleString "PONG"
+                  ]
+                else []
+      (connector, getRecords) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 5) connector
+      result <- executeKeylessClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        ping
+      result `shouldBe` Right (RespSimpleString "PONG")
+      readIORef delays `shouldReturn` [5, 10]
+      records <- getRecords
+      sent <- recordSentBytes $ findAuthRecord records node1 0
+      countOccurrences (commandBytes ["PING"]) sent `shouldBe` 3
+      countOccurrences (commandBytes ["CLUSTER", "SLOTS"]) sent `shouldBe` 3
+      closeClusterClient client
+
+    it "exhausts keyless CLUSTERDOWN with the final command cause" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $
+              if index == 0
+                then
+                  [ replyWith validClusterSlots
+                  , replyWith $ RespError "CLUSTERDOWN first"
+                  , replyWith validClusterSlots
+                  , replyWith $ RespError "CLUSTERDOWN second"
+                  , replyWith validClusterSlots
+                  , replyWith $ RespError "CLUSTERDOWN final cause"
+                  ]
+                else []
+      (connector, _) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 6) connector
+      result <- executeKeylessClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        ping
+      case result of
+        Left (MaxRetriesExceeded message) ->
+          message `shouldContain` "CLUSTERDOWN final cause"
+        other -> expectationFailure $
+          "Expected keyless CLUSTERDOWN exhaustion, got: " ++ show other
+      readIORef delays `shouldReturn` [6, 12]
+      closeClusterClient client
+
+    it "keeps keyed CLUSTERDOWN retries after invalid refresh topology" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $ case index of
+              0 ->
+                [ replyWith validClusterSlots
+                , replyWith $ RespSimpleString "invalid topology"
+                , replyWith $ RespSimpleString "still invalid topology"
+                ]
+              _ ->
+                [ replyWith $ RespError "CLUSTERDOWN first"
+                , replyWith $ RespError "CLUSTERDOWN second"
+                , replyWith $ RespError "CLUSTERDOWN final cause"
+                ]
+      (connector, _) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 7) connector
+      result <- executeKeyedClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        "invalid-refresh-key"
+        ["GET", "invalid-refresh-key"]
+      case result of
+        Left (MaxRetriesExceeded message) ->
+          message `shouldContain` "CLUSTERDOWN final cause"
+        other -> expectationFailure $
+          "Expected keyed CLUSTERDOWN exhaustion, got: " ++ show other
+      readIORef delays `shouldReturn` [7, 14]
+      closeClusterClient client
+
+    it "keeps keyless CLUSTERDOWN retries after invalid refresh topology" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $
+              if index == 0
+                then
+                  [ replyWith validClusterSlots
+                  , replyWith $ RespError "CLUSTERDOWN first"
+                  , replyWith $ RespSimpleString "invalid topology"
+                  , replyWith $ RespError "CLUSTERDOWN second"
+                  , replyWith $ RespSimpleString "still invalid topology"
+                  , replyWith $ RespError "CLUSTERDOWN final cause"
+                  ]
+                else []
+      (connector, _) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 8) connector
+      result <- executeKeylessClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        ping
+      case result of
+        Left (MaxRetriesExceeded message) ->
+          message `shouldContain` "CLUSTERDOWN final cause"
+        other -> expectationFailure $
+          "Expected keyless CLUSTERDOWN exhaustion, got: " ++ show other
+      readIORef delays `shouldReturn` [8, 16]
+      closeClusterClient client
+
+    it "treats keyed CLUSTERDOWN refresh IO failures as best effort" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $ case index of
+              0 ->
+                [ replyWith validClusterSlots
+                , throwIO $ userError "refresh IO failure one"
+                ]
+              1 ->
+                [ replyWith $ RespError "CLUSTERDOWN first"
+                , replyWith $ RespError "CLUSTERDOWN second"
+                , replyWith $ RespError "CLUSTERDOWN final cause"
+                ]
+              _ -> [throwIO $ userError "refresh IO failure two"]
+      (connector, _) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 9) connector
+      result <- executeKeyedClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        "io-refresh-key"
+        ["GET", "io-refresh-key"]
+      case result of
+        Left (MaxRetriesExceeded message) ->
+          message `shouldContain` "CLUSTERDOWN final cause"
+        other -> expectationFailure $
+          "Expected keyed CLUSTERDOWN exhaustion, got: " ++ show other
+      readIORef delays `shouldReturn` [9, 18]
+      closeClusterClient client
+
+    it "treats keyless CLUSTERDOWN refresh IO failures as best effort" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $ case index of
+              0 ->
+                [ replyWith validClusterSlots
+                , replyWith $ RespError "CLUSTERDOWN first"
+                , throwIO $ userError "refresh IO failure one"
+                ]
+              1 ->
+                [ replyWith $ RespError "CLUSTERDOWN second"
+                , throwIO $ userError "refresh IO failure two"
+                ]
+              _ ->
+                [replyWith $ RespError "CLUSTERDOWN final cause"]
+      (connector, _) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 10) connector
+      result <- executeKeylessClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        ping
+      case result of
+        Left (MaxRetriesExceeded message) ->
+          message `shouldContain` "CLUSTERDOWN final cause"
+        other -> expectationFailure $
+          "Expected keyless CLUSTERDOWN exhaustion, got: " ++ show other
+      readIORef delays `shouldReturn` [10, 20]
+      closeClusterClient client
+
+    it "keeps cancellation responsive during keyless backoff" $ do
+      delayStarted <- newEmptyMVar
+      blockDelay <- newEmptyMVar
+      finished <- newEmptyMVar
+      let script _ index =
+            return $
+              if index == 0
+                then
+                  [ replyWith validClusterSlots
+                  , replyWith $ RespError "TRYAGAIN wait"
+                  ]
+                else []
+      (connector, _) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 1) connector
+      owner <- forkFinally
+        (executeKeylessClusterCommandUsingDelay
+          (\_ -> putMVar delayStarted () >> takeMVar blockDelay)
+          client
+          ping)
+        (putMVar finished)
+      timeout 1000000 (takeMVar delayStarted) `shouldReturn` Just ()
+      killThread owner
+      outcome <- timeout 1000000 (takeMVar finished)
+      outcome `shouldSatisfy` \case
+        Just (Left err) ->
+          case fromException err :: Maybe SomeAsyncException of
+            Just _  -> True
+            Nothing -> False
+        _ -> False
+      closeClusterClient client
+
+    it "releases keyless CLUSTERDOWN refresh ownership on cancellation" $ do
+      refreshStarted <- newEmptyMVar
+      blockRefresh <- newEmptyMVar
+      finished <- newEmptyMVar
+      let script _ index =
+            return $
+              if index == 0
+                then
+                  [ replyWith validClusterSlots
+                  , replyWith $ RespError "CLUSTERDOWN wait"
+                  , putMVar refreshStarted () >> takeMVar blockRefresh
+                  ]
+                else []
+      (connector, _) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 1) connector
+      owner <- forkFinally
+        (executeKeylessClusterCommand client ping)
+        (putMVar finished)
+      timeout 1000000 (takeMVar refreshStarted) `shouldReturn` Just ()
+      killThread owner
+      outcome <- timeout 1000000 (takeMVar finished)
+      outcome `shouldSatisfy` \case
+        Just (Left err) ->
+          case fromException err :: Maybe SomeAsyncException of
+            Just _  -> True
+            Nothing -> False
+        _ -> False
+      refreshToken <- tryTakeMVar $ clusterRefreshLock client
+      refreshToken `shouldBe` Just ()
+      putMVar (clusterRefreshLock client) ()
+      closeClusterClient client
+
+    forM_
+      [ ( "MOVED"
+        , RespError "MOVED 3999 127.0.0.2:6380"
+        , MovedError 3999 node2
+        )
+      , ( "ASK"
+        , RespError "ASK 3999 127.0.0.2:6380"
+        , AskError 3999 node2
+        )
+      ] $ \(label, reply, expected) ->
+        it ("returns keyless " ++ label ++ " without following the redirect") $ do
+          delays <- newIORef []
+          let script _ index =
+                return $
+                  if index == 0
+                    then [replyWith validClusterSlots, replyWith reply]
+                    else []
+          (connector, getRecords) <- createAuthMockConnector script
+          client <- createClusterClient (retryTestConfig 3 11) connector
+          result <- executeKeylessClusterCommandUsingDelay
+            (\delay -> atomicModifyIORef' delays $ \seen ->
+              (seen ++ [delay], ()))
+            client
+            ping
+          result `shouldBe` Left expected
+          readIORef delays `shouldReturn` []
+          records <- getRecords
+          sent <- recordSentBytes $ findAuthRecord records node1 0
+          countOccurrences (commandBytes ["PING"]) sent `shouldBe` 1
+          closeClusterClient client
+
+    it "returns keyless CROSSSLOT immediately without retry or delay" $ do
+      delays <- newIORef []
+      let script _ index =
+            return $
+              if index == 0
+                then
+                  [ replyWith validClusterSlots
+                  , replyWith $ RespError "CROSSSLOT keyless permanent"
+                  ]
+                else []
+      (connector, getRecords) <- createAuthMockConnector script
+      client <- createClusterClient (retryTestConfig 3 12) connector
+      result <- executeKeylessClusterCommandUsingDelay
+        (\delay -> atomicModifyIORef' delays $ \seen ->
+          (seen ++ [delay], ()))
+        client
+        ping
+      result `shouldBe`
+        Left (CrossSlotError "CROSSSLOT keyless permanent")
+      readIORef delays `shouldReturn` []
+      records <- getRecords
+      sent <- recordSentBytes $ findAuthRecord records node1 0
+      countOccurrences (commandBytes ["PING"]) sent `shouldBe` 1
       closeClusterClient client
 
     it "returns ordinary server errors as low-level Left values" $ do

--- a/hask-redis-mux/test/PublicApiSpec.hs
+++ b/hask-redis-mux/test/PublicApiSpec.hs
@@ -10,6 +10,10 @@ import           Test.Hspec
 
 main :: IO ()
 main = hspec $ describe "Database.Redis timeout-aware public API" $ do
+  it "exports the migration-compatible ordinary cluster error" $ do
+    RedisCommandError "ERR full server cause"
+      `shouldBe` RedisCommandError "ERR full server cause"
+
   it "exports redaction-safe cluster authentication policies" $ do
     let createAuthenticated
           :: ClusterConfig

--- a/test/ClusterE2E/Basic.hs
+++ b/test/ClusterE2E/Basic.hs
@@ -3,12 +3,14 @@
 module ClusterE2E.Basic (spec) where
 
 import           ClusterE2E.Utils
-import           Control.Exception             (bracket)
+import           Control.Exception             (IOException, bracket)
 import qualified Data.ByteString.Char8         as BS8
+import           Data.List                     (isInfixOf)
 import           Database.Redis.Cluster        (calculateSlot)
 import           Database.Redis.Cluster.Client (closeClusterClient)
 import           Database.Redis.Command        (RedisCommands (..))
 import           Database.Redis.Resp           (RespData (..))
+import           System.IO.Error               (ioeGetErrorString)
 import           Test.Hspec
 
 spec :: Spec
@@ -116,10 +118,8 @@ spec = describe "Basic cluster operations" $ do
     it "returns WRONGTYPE error for wrong command on key type" $ do
       bracket createTestClusterClient closeClusterClient $ \client -> do
         _ <- runCmd_ client $ set "cluster:wrongtype" "value"
-        result <- runCmd client $ lpush "cluster:wrongtype" ["item"]
-        case result of
-          RespError err -> BS8.isInfixOf "WRONGTYPE" err `shouldBe` True
-          other -> expectationFailure $ "Expected WRONGTYPE error, got: " ++ show other
+        runCmd_ client (lpush "cluster:wrongtype" ["item"])
+          `shouldThrow` isWrongTypeError
 
     it "DEL removes keys in cluster" $ do
       bracket createTestClusterClient closeClusterClient $ \client -> do
@@ -129,3 +129,6 @@ spec = describe "Basic cluster operations" $ do
         _ <- runCmd_ client $ del ["cluster:deltest"]
         afterDel <- runCmd client $ get "cluster:deltest"
         afterDel `shouldBe` RespNullBulkString
+
+isWrongTypeError :: IOException -> Bool
+isWrongTypeError = isInfixOf "WRONGTYPE" . ioeGetErrorString


### PR DESCRIPTION
## Summary
- classify every cluster `RespError` through one strict, case-sensitive classifier shared by normal slot routing, direct MOVED targets, ASK targets, topology refresh, and low-level keyless execution
- activate coherent bounded policies for TRYAGAIN, CLUSTERDOWN, CROSSSLOT, and ordinary Redis command errors while preserving #65 MOVED/ASK behavior
- add deterministic delay injection for exact attempt/backoff/cancellation tests and saturate delay growth instead of overflowing `Int`
- make ordinary `ERR`/`WRONGTYPE`/`NOSCRIPT` replies low-level `Left (RedisCommandError payload)` values rather than successful `RespError` values

## Error and retry contract
| Reply | Behavior |
|---|---|
| `MOVED slot endpoint` | Preserve #65: patch the slot and retry the authoritative target directly without `ASKING`; bounded refresh follows success |
| `ASK slot endpoint` | Preserve #65: retry the target with atomic `ASKING` + command |
| `TRYAGAIN ...` | Retry the current route with exponential backoff |
| `CLUSTERDOWN ...` | If another attempt remains, perform a best-effort bounded topology refresh, then back off and retry from slot routing |
| `CROSSSLOT ...` | Permanent command failure; return `CrossSlotError` immediately |
| Other `RespError` | Return `RedisCommandError ByteString` immediately with the complete server payload |

Prefixes are case-sensitive and require either the exact token or a following ASCII space. Similar tokens such as `TRYAGAINLY`, lowercase names, tab-delimited names, and malformed MOVED/ASK payloads are ordinary Redis errors. Redirect slots and ports are range-validated before conversion.

`clusterMaxRetries` is the total attempt count including the initial command. Backoff happens only when another attempt remains, starts at `clusterRetryDelay`, doubles per retry, and saturates at `maxBound`. `threadDelay` remains interruptible and asynchronous cancellation is rethrown.

## #60 compatibility boundary
The low-level keyed/keyless APIs now consistently return `Either ClusterError RespData`; the keyless action is explicitly raw `RespData` so replies can be classified before conversion. The current typed `ClusterCommandClient` still uses its historical `MonadFail` unwrap, but ordinary errors no longer reach conversion as success-shaped RESP values. The planned breaking #60 runners can nest these existing structured cluster/server causes inside `RedisClientError` without introducing or removing another compatibility runner here.

## Coverage
- pure prefix, boundary, case, malformed redirect, and verbatim ordinary-error classification
- all six reply classes through normal, direct MOVED, and ASK target paths (18 path cases)
- TRYAGAIN success and exhaustion with exact attempt counts and schedules
- saturating overflow behavior
- CLUSTERDOWN refresh/backoff success and bounded exhaustion with final cause
- CROSSSLOT no-retry/no-delay behavior
- cancellation during backoff
- low-level keyed/keyless and typed ordinary-error behavior, including no command credential leakage
- existing MOVED/ASK, authentication, deadline, topology, and cancellation regressions remain green

## Validation
- `nix-build --no-out-link`
- `ClusterCommandSpec`: 103 examples, 0 failures
- `PublicApiSpec`: 4 examples, 0 failures
- `ClusterCommandSpec`: 5/5 additional randomized runs
- GitHub Actions `build` is authoritative full E2E

## Profiling
No meaningful before/after profile is reported. The repository has no isolated reply-classification or retry benchmark. `ConnectionPoolBench` measures unrelated checkout contention, while `ClusterCommandSpec` is dominated by mocked waits, thread scheduling, and failure orchestration and grew from 70 to 103 examples in this change. Profiling that suite would compare different test workloads rather than production classification/backoff cost. The normal success path adds one constructor match and only inspects bytes for `RespError` replies.

## Review gate and risks
Protocol review is requested for Redis token semantics, malformed redirect handling, and the CLUSTERDOWN policy. Tester review is requested for attempt schedules and low-level/typed error surfaces. Performance review is requested for saturating backoff and cancellation boundaries.

Residual behavior intentionally deferred to #60: typed `ClusterCommandClient` still fails through `MonadFail` rather than returning `Either RedisClientError`. CLUSTERDOWN refresh is best-effort; a failed refresh does not consume a separate command attempt, and the final command failure remains the exhaustion cause.

Closes #61
