### PR TITLE
Restore stopped Redis nodes after E2E failures

### DIFF
--- a/redis-client.cabal
+++ b/redis-client.cabal
@@ -83,6 +83,13 @@ test-suite ClusterTunnelSpec
                     , network
                     , stm
 
+test-suite NodeLifecycleSpec
+    import:           test-defaults
+    type:             exitcode-stdio-1.0
+    main-is:          NodeLifecycleSpec.hs
+    other-modules:    LibraryE2E.NodeLifecycle
+    hs-source-dirs:   test
+
 -- ---------------------------------------------------------------------------
 -- Flags
 -- ---------------------------------------------------------------------------
@@ -163,6 +170,7 @@ executable LibraryE2E
     main-is:          LibraryE2E.hs
     hs-source-dirs:   test
     other-modules:    LibraryE2E.Utils
+                    , LibraryE2E.NodeLifecycle
                     , LibraryE2E.ConnectionPoolTests
                     , LibraryE2E.TopologyTests
                     , LibraryE2E.ResilienceTests

--- a/test/LibraryE2E/ConcurrencyTests.hs
+++ b/test/LibraryE2E/ConcurrencyTests.hs
@@ -126,9 +126,8 @@ spec = describe "Concurrent Cluster Operations" $ do
 
           killerAction = do
             threadDelay 500000  -- 500ms into the test, kill node 3
-            stopNode 3
-            threadDelay 3000000  -- Let it stay dead for 3s
-            startNode 3
+            withStoppedNode 3 $
+              threadDelay 3000000  -- Let it stay dead for 3s
 
       _ <- concurrently workerAction killerAction
 
@@ -138,9 +137,6 @@ spec = describe "Concurrent Cluster Operations" $ do
 
       -- We should have both successes and failures
       successes `shouldSatisfy` (> 0)
-      -- After node restart, wait for stabilization
-      waitForClusterReady 30
-      threadDelay 5000000
 
       -- Final verification: cluster is healthy again
       _ <- try (refreshTopology client) :: IO (Either SomeException ())

--- a/test/LibraryE2E/NodeLifecycle.hs
+++ b/test/LibraryE2E/NodeLifecycle.hs
@@ -1,0 +1,296 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module LibraryE2E.NodeLifecycle
+  ( NodeTarget (..)
+  , NodeCommand (..)
+  , NodeCommandFailure (..)
+  , NodeReadinessFailure (..)
+  , NodeLifecycleException (..)
+  , NodeLifecycleOps (..)
+  , ProcessRunner
+  , runNodeCommandUsing
+  , sanitizeDiagnostic
+  , waitForReadinessUsing
+  , withStoppedNodeUsing
+  , withStoppedNodesUsing
+  ) where
+
+import           Control.Concurrent (threadDelay)
+import           Control.Exception  (Exception, IOException, SomeAsyncException,
+                                     SomeException, displayException,
+                                     fromException, mask, throwIO, try)
+import           Control.Monad      (forM)
+import           Data.Char          (isPrint, toLower)
+import           Data.IORef         (newIORef, readIORef, writeIORef)
+import           Data.List          (find, isInfixOf)
+import           System.Exit        (ExitCode (..))
+import           System.IO          (hPutStrLn, stderr)
+import           System.Timeout     (timeout)
+
+data NodeTarget = NodeTarget
+  { nodeNumber    :: Int
+  , nodeContainer :: String
+  , targetHost    :: String
+  , targetPort    :: Int
+  } deriving (Eq, Show)
+
+data NodeCommand = StopNode | StartNode
+  deriving (Eq, Show)
+
+data NodeCommandFailure = NodeCommandFailure
+  { failedNodeCommand :: NodeCommand
+  , failedNodeTarget  :: NodeTarget
+  , failedExitCode    :: Maybe ExitCode
+  , failedStdout      :: String
+  , failedStderr      :: String
+  }
+
+instance Show NodeCommandFailure where
+  show failure = unlines
+    [ show (failedNodeCommand failure) ++ " failed for "
+        ++ renderTarget (failedNodeTarget failure)
+    , "exit: " ++ maybe "process launch failure" show
+        (failedExitCode failure)
+    , "stdout: " ++ failedStdout failure
+    , "stderr: " ++ failedStderr failure
+    ]
+
+instance Exception NodeCommandFailure
+
+data NodeReadinessFailure = NodeReadinessFailure
+  { readinessNode        :: NodeTarget
+  , readinessWaitSeconds :: Int
+  , readinessDiagnostic  :: String
+  }
+
+instance Show NodeReadinessFailure where
+  show failure = unlines
+    [ "Redis node did not rejoin the healthy cluster: "
+        ++ renderTarget (readinessNode failure)
+    , "waited seconds: " ++ show (readinessWaitSeconds failure)
+    , "last diagnostic: " ++ readinessDiagnostic failure
+    ]
+
+instance Exception NodeReadinessFailure
+
+data NodeLifecycleException
+  = NodeCleanupFailed [SomeException]
+  | NodeBodyAndCleanupFailed SomeException [SomeException]
+
+instance Show NodeLifecycleException where
+  show (NodeCleanupFailed cleanupFailures) =
+    "Redis node cleanup failed:\n"
+      ++ renderExceptions cleanupFailures
+  show (NodeBodyAndCleanupFailed primary cleanupFailures) =
+    "Redis node test body failed: "
+      ++ safeExceptionText primary
+      ++ "\nRedis node cleanup also failed:\n"
+      ++ renderExceptions cleanupFailures
+
+instance Exception NodeLifecycleException
+
+data NodeLifecycleOps = NodeLifecycleOps
+  { stopNodeOperation  :: NodeTarget -> IO ()
+  , startNodeOperation :: NodeTarget -> IO ()
+  , waitNodeReady      :: NodeTarget -> IO ()
+  }
+
+type ProcessRunner =
+  FilePath -> [String] -> String -> IO (ExitCode, String, String)
+
+runNodeCommandUsing
+  :: ProcessRunner
+  -> NodeCommand
+  -> NodeTarget
+  -> IO ()
+runNodeCommandUsing runner command target = do
+  result <- try $ runner "docker" [commandName command, nodeContainer target] ""
+  case result of
+    Left (err :: IOException) ->
+      throwIO $ NodeCommandFailure
+        command
+        target
+        Nothing
+        ""
+        (sanitizeDiagnostic $ displayException err)
+    Right (ExitSuccess, _, _) -> return ()
+    Right (exitCode, stdoutOutput, stderrOutput) ->
+      throwIO $ NodeCommandFailure
+        command
+        target
+        (Just exitCode)
+        (sanitizeDiagnostic stdoutOutput)
+        (sanitizeDiagnostic stderrOutput)
+
+waitForReadinessUsing
+  :: Int
+  -> (NodeTarget -> IO ())
+  -> NodeTarget
+  -> IO ()
+waitForReadinessUsing maxWaitSeconds probe target = do
+  lastDiagnostic <- newIORef "readiness probe did not complete"
+  result <- timeout (waitSeconds * 1000000) $ poll lastDiagnostic
+  case result of
+    Just () -> return ()
+    Nothing -> do
+      diagnostic <- readIORef lastDiagnostic
+      throwIO $ NodeReadinessFailure target waitSeconds diagnostic
+  where
+    waitSeconds = max 1 maxWaitSeconds
+
+    poll lastDiagnostic = do
+      result <- tryAny $ probe target
+      case result of
+        Right () -> return ()
+        Left err ->
+          case fromException err :: Maybe SomeAsyncException of
+            Just async -> throwIO async
+            Nothing -> do
+              writeIORef lastDiagnostic $
+                sanitizeDiagnostic $ displayException err
+              threadDelay 500000
+              poll lastDiagnostic
+
+withStoppedNodeUsing
+  :: NodeLifecycleOps
+  -> NodeTarget
+  -> IO a
+  -> IO a
+withStoppedNodeUsing operations target =
+  withStoppedNodesUsing operations [target]
+
+withStoppedNodesUsing
+  :: NodeLifecycleOps
+  -> [NodeTarget]
+  -> IO a
+  -> IO a
+withStoppedNodesUsing operations targets action =
+  mask $ \restore -> do
+    stopped <- stopTargets [] targets
+    case stopped of
+      Left (primary, attemptedTargets) -> do
+        cleanupFailures <- restoreTargets attemptedTargets
+        resolveResult (Left primary) cleanupFailures
+      Right stoppedTargets -> do
+        bodyResult <- tryAny $ restore action
+        cleanupFailures <- restoreTargets stoppedTargets
+        resolveResult bodyResult cleanupFailures
+  where
+    stopTargets attempted [] = return $ Right attempted
+    stopTargets attempted (target : remaining) = do
+      result <- tryAny $ stopNodeOperation operations target
+      let attemptedTargets = attempted ++ [target]
+      case result of
+        Left err -> return $ Left (err, attemptedTargets)
+        Right () -> stopTargets attemptedTargets remaining
+
+    restoreTargets attemptedTargets = do
+      startResults <- forM attemptedTargets $ \target ->
+        tryAny $ startNodeOperation operations target
+      readinessResults <- forM attemptedTargets $ \target ->
+        tryAny $ waitNodeReady operations target
+      return $ failures startResults ++ failures readinessResults
+
+resolveResult
+  :: Either SomeException a
+  -> [SomeException]
+  -> IO a
+resolveResult (Right value) [] = return value
+resolveResult (Right _) cleanupFailures =
+  case firstAsyncException cleanupFailures of
+    Just async -> do
+      reportCleanupFailures cleanupFailures
+      throwIO async
+    Nothing ->
+      throwIO $ NodeCleanupFailed cleanupFailures
+resolveResult (Left primary) [] = throwIO primary
+resolveResult (Left primary) cleanupFailures =
+  case fromException primary :: Maybe SomeAsyncException of
+    Just async -> do
+      reportCleanupFailures cleanupFailures
+      throwIO async
+    Nothing ->
+      case firstAsyncException cleanupFailures of
+        Just async -> do
+          reportPrimaryAndCleanupFailures primary cleanupFailures
+          throwIO async
+        Nothing ->
+          throwIO $ NodeBodyAndCleanupFailed primary cleanupFailures
+
+tryAny :: IO a -> IO (Either SomeException a)
+tryAny = try
+
+failures :: [Either SomeException ()] -> [SomeException]
+failures = foldr collect []
+  where
+    collect (Left err) rest = err : rest
+    collect (Right ()) rest = rest
+
+firstAsyncException :: [SomeException] -> Maybe SomeAsyncException
+firstAsyncException cleanupFailures =
+  findAsync =<< find hasAsync cleanupFailures
+  where
+    hasAsync err =
+      case fromException err :: Maybe SomeAsyncException of
+        Just _  -> True
+        Nothing -> False
+    findAsync err = fromException err
+
+reportCleanupFailures :: [SomeException] -> IO ()
+reportCleanupFailures cleanupFailures = do
+  _ <- tryAny $ hPutStrLn stderr $
+    "Redis node cleanup failed while preserving asynchronous cancellation:\n"
+      ++ renderExceptions cleanupFailures
+  return ()
+
+reportPrimaryAndCleanupFailures
+  :: SomeException
+  -> [SomeException]
+  -> IO ()
+reportPrimaryAndCleanupFailures primary cleanupFailures = do
+  _ <- tryAny $ hPutStrLn stderr $
+    "Redis node test body failed before asynchronous cancellation: "
+      ++ safeExceptionText primary
+      ++ "\nRedis node cleanup also failed:\n"
+      ++ renderExceptions cleanupFailures
+  return ()
+
+renderExceptions :: [SomeException] -> String
+renderExceptions =
+  unlines . map (("  - " ++) . safeExceptionText)
+
+safeExceptionText :: SomeException -> String
+safeExceptionText = sanitizeDiagnostic . displayException
+
+sanitizeDiagnostic :: String -> String
+sanitizeDiagnostic raw
+  | any (`isInfixOf` lowered) sensitiveMarkers =
+      "<redacted sensitive diagnostic>"
+  | otherwise =
+      take 2000 $ map sanitizeCharacter raw
+  where
+    lowered = map toLower raw
+    sensitiveMarkers =
+      [ "password"
+      , "passwd"
+      , "secret"
+      , "credential"
+      , "rediscli_auth"
+      , "authorization"
+      , "token="
+      ]
+    sanitizeCharacter character
+      | character == '\n' || character == '\t' = character
+      | isPrint character = character
+      | otherwise = '?'
+
+commandName :: NodeCommand -> String
+commandName StopNode  = "stop"
+commandName StartNode = "start"
+
+renderTarget :: NodeTarget -> String
+renderTarget target =
+  nodeContainer target
+    ++ " (node " ++ show (nodeNumber target)
+    ++ ", " ++ targetHost target
+    ++ ":" ++ show (targetPort target) ++ ")"

--- a/test/LibraryE2E/ResilienceTests.hs
+++ b/test/LibraryE2E/ResilienceTests.hs
@@ -4,7 +4,8 @@
 module LibraryE2E.ResilienceTests (spec) where
 
 import           Control.Concurrent            (threadDelay)
-import           Control.Exception             (SomeException, try)
+import           Control.Exception             (SomeException, displayException,
+                                                throwIO, try)
 import           Database.Redis.Cluster.Client (ClusterConfig (..),
                                                 ClusterError (..),
                                                 closeClusterClient,
@@ -19,6 +20,28 @@ import           Test.Hspec
 
 spec :: Spec
 spec = describe "Error Handling & Resilience" $ do
+  describe "Exception-safe node restoration" $ do
+    it "restores a stopped node after an intentional body failure" $ do
+      result <- try $ withStoppedNode 3 $
+        throwIO $ userError "intentional node fixture failure"
+        :: IO (Either SomeException ())
+      case result of
+        Left err ->
+          displayException err `shouldContain`
+            "intentional node fixture failure"
+        Right () ->
+          expectationFailure "intentional failure unexpectedly succeeded"
+
+    it "starts the following example with a healthy cluster" $ do
+      waitForClusterReady 5
+      client <- createTestClient
+      result <- executeKeyedClusterCommand
+        client
+        "restoration-followup"
+        ["SET", "restoration-followup", "healthy"]
+      result `shouldSatisfy` isRight'
+      flushAllNodes client
+      closeClusterClient client
 
   describe "MOVED error retry" $ do
     it "transparently handles slot routing across nodes" $ do
@@ -57,33 +80,25 @@ spec = describe "Error Handling & Resilience" $ do
         clusterRetryDelay = 10000  -- 10ms to speed up test
       })
 
-      -- Stop multiple nodes to guarantee some slots are unavailable
-      stopNode 4
-      stopNode 5
-      threadDelay 3000000  -- 3s for detection
+      withStoppedNodes [4, 5] $ do
+        threadDelay 3000000  -- 3s for detection
 
-      -- Try operations — some should fail with MaxRetriesExceeded or ConnectionError
-      -- We try several keys to increase odds of hitting a down node's slots
-      let tryKeys = ["maxretry-" <> showBS i | i <- [1..20 :: Int]]
-      results <- mapM (\k ->
-        executeKeyedClusterCommand client k ["SET", k, "v"]
-        ) tryKeys
+        -- Try operations — some should fail with MaxRetriesExceeded or ConnectionError
+        -- We try several keys to increase odds of hitting a down node's slots
+        let tryKeys = ["maxretry-" <> showBS i | i <- [1..20 :: Int]]
+        results <- mapM (\k ->
+          executeKeyedClusterCommand client k ["SET", k, "v"]
+          ) tryKeys
 
-      -- At least some should fail (nodes 4 & 5 own some slots)
-      let failures = [e | Left e <- results]
-      length failures `shouldSatisfy` (> 0)
+        -- At least some should fail (nodes 4 & 5 own some slots)
+        let failures = [e | Left e <- results]
+        length failures `shouldSatisfy` (> 0)
 
-      -- Verify failures are the right error types
-      let isExpectedError (MaxRetriesExceeded _) = True
-          isExpectedError (ConnectionError _)    = True
-          isExpectedError _                      = False
-      mapM_ (\e -> e `shouldSatisfy` isExpectedError) failures
-
-      -- Restart nodes
-      startNode 4
-      startNode 5
-      waitForClusterReady 30
-      threadDelay 5000000  -- 5s stabilization
+        -- Verify failures are the right error types
+        let isExpectedError (MaxRetriesExceeded _) = True
+            isExpectedError (ConnectionError _)    = True
+            isExpectedError _                      = False
+        mapM_ (\e -> e `shouldSatisfy` isExpectedError) failures
 
       flushAllNodes client
       closeClusterClient client
@@ -96,31 +111,25 @@ spec = describe "Error Handling & Resilience" $ do
       -- Use hash tag to target specific node's slots
       _ <- executeKeyedClusterCommand client "conn-close-test" ["SET", "conn-close-test", "v"]
 
-      -- Kill node 3 abruptly
-      stopNode 3
-      threadDelay 2000000  -- 2s
+      withStoppedNode 3 $ do
+        threadDelay 2000000  -- 2s
 
-      -- Try operations — some may fail with ConnectionError
-      results <- mapM (\i -> do
-        let k = "connclose-" <> showBS i
-        try (executeKeyedClusterCommand client k ["SET", k, "v"])
-          :: IO (Either SomeException (Either ClusterError RespData))
-        ) [1..10 :: Int]
+        -- Try operations — some may fail with ConnectionError
+        results <- mapM (\i -> do
+          let k = "connclose-" <> showBS i
+          try (executeKeyedClusterCommand client k ["SET", k, "v"])
+            :: IO (Either SomeException (Either ClusterError RespData))
+          ) [1..10 :: Int]
 
-      -- Should not hang (test completing is the assertion)
-      -- Any failures should be connection-related, not parse errors
-      let checkResult r = case r of
-            Left _                              -> True  -- Exception is fine
-            Right (Left (ConnectionError _))    -> True
-            Right (Left (MaxRetriesExceeded _)) -> True
-            Right (Right _)                     -> True  -- Success is fine (different node)
-            Right (Left _)                      -> True  -- Other cluster errors ok
-      mapM_ (\r -> r `shouldSatisfy` checkResult) results
-
-      -- Restart
-      startNode 3
-      waitForClusterReady 30
-      threadDelay 5000000
+        -- Should not hang (test completing is the assertion)
+        -- Any failures should be connection-related, not parse errors
+        let checkResult r = case r of
+              Left _                              -> True  -- Exception is fine
+              Right (Left (ConnectionError _))    -> True
+              Right (Left (MaxRetriesExceeded _)) -> True
+              Right (Right _)                     -> True  -- Success is fine (different node)
+              Right (Left _)                      -> True  -- Other cluster errors ok
+        mapM_ (\r -> r `shouldSatisfy` checkResult) results
 
       flushAllNodes client
       closeClusterClient client
@@ -133,14 +142,8 @@ spec = describe "Error Handling & Resilience" $ do
       r1 <- executeKeyedClusterCommand client "recovery-key" ["SET", "recovery-key", "before"]
       r1 `shouldSatisfy` isRight'
 
-      -- Stop node
-      stopNode 3
-      threadDelay 3000000
-
-      -- Restart node
-      startNode 3
-      waitForClusterReady 30
-      threadDelay 5000000  -- stabilization
+      withStoppedNode 3 $
+        threadDelay 3000000
 
       -- Force topology refresh
       _ <- try (refreshTopology client) :: IO (Either SomeException ())

--- a/test/LibraryE2E/TopologyTests.hs
+++ b/test/LibraryE2E/TopologyTests.hs
@@ -81,25 +81,19 @@ spec = describe "Topology Refresh" $ do
       r1 <- executeKeyedClusterCommand client "topo-recover-key" ["SET", "topo-recover-key", "alive"]
       r1 `shouldSatisfy` isRight'
 
-      -- Stop a non-seed node to avoid breaking topology discovery
-      -- Node 3 (port 6381) is a good candidate
-      stopNode 3
-      threadDelay 3000000  -- 3s for cluster to detect failure
+      withStoppedNode 3 $ do
+        threadDelay 3000000  -- 3s for cluster to detect failure
 
-      -- Force a topology refresh so the client knows about the change
-      _ <- try (refreshTopology client) :: IO (Either SomeException ())
+        -- Force a topology refresh so the client knows about the change
+        _ <- try (refreshTopology client) :: IO (Either SomeException ())
 
-      -- Operations to other nodes should still work
-      _ <- executeKeyedClusterCommand client "topo-other-node" ["SET", "topo-other-node", "works"]
-      -- This might succeed or fail depending on which node owns the key slot
-      -- The important thing is it doesn't hang
-
-      -- Restart the node
-      startNode 3
-      waitForClusterReady 30
+        -- Operations to other nodes should still work
+        _ <- executeKeyedClusterCommand client "topo-other-node" ["SET", "topo-other-node", "works"]
+        -- This might succeed or fail depending on which node owns the key slot
+        -- The important thing is it doesn't hang
+        return ()
 
       -- After recovery, all operations should work
-      threadDelay 5000000  -- 5s for cluster to stabilize
       _ <- try (refreshTopology client) :: IO (Either SomeException ())
       r3 <- executeKeyedClusterCommand client "topo-recover-key" ["GET", "topo-recover-key"]
       -- After cluster recovery, the key should still be readable

--- a/test/LibraryE2E/Utils.hs
+++ b/test/LibraryE2E/Utils.hs
@@ -13,21 +13,24 @@ module LibraryE2E.Utils
   , runCmd
   , flushAllNodes
     -- * Docker node management
-  , stopNode
-  , startNode
+  , withStoppedNode
+  , withStoppedNodes
   , waitForClusterReady
     -- * Constants
   , seedNode
   ) where
 
-import           Control.Concurrent                    (threadDelay)
 import           Control.Concurrent.STM                (readTVarIO)
-import           Control.Exception                     (SomeException, try)
-import           Control.Monad                         (forM_)
+import           Control.Exception                     (SomeException, bracket,
+                                                        throwIO, try)
+import           Control.Monad                         (forM_, unless)
+import           Control.Monad.IO.Class                (liftIO)
 import qualified Control.Monad.State                   as State
 import qualified Data.ByteString                       as BS
+import qualified Data.ByteString.Lazy                  as LBS
 import qualified Data.Map.Strict                       as Map
 import           Database.Redis.Client                 (Client (..),
+                                                        ConnectionStatus (Connected),
                                                         PlainTextClient (NotConnectedPlainTextClient))
 import           Database.Redis.Cluster                (ClusterNode (..),
                                                         ClusterTopology (..),
@@ -41,10 +44,14 @@ import           Database.Redis.Cluster.Client         (ClusterClient (..),
 import           Database.Redis.Cluster.ConnectionPool (PoolConfig (..))
 import           Database.Redis.Command                (ClientState (..),
                                                         RedisCommandClient (..),
-                                                        RedisCommands (..))
+                                                        RedisCommands (..),
+                                                        encodeCommand,
+                                                        parseWith,
+                                                        runRedisCommandClient)
 import           Database.Redis.Connector              (Connector,
                                                         clusterPlaintextConnector)
 import           Database.Redis.Resp                   (RespData (..))
+import           LibraryE2E.NodeLifecycle
 import           System.Process                        (readProcessWithExitCode)
 
 -- | Seed node for cluster discovery
@@ -101,39 +108,82 @@ flushAllNodes client = do
       Left (_ :: SomeException) -> return ()
       Right _                   -> return ()
 
--- | Docker container names for each node
-nodeContainerName :: Int -> String
-nodeContainerName n = "redis-cluster-node" ++ show n
+withStoppedNode :: Int -> IO a -> IO a
+withStoppedNode node =
+  withStoppedNodeUsing nodeLifecycleOperations (nodeTarget node)
 
--- | Stop a Redis cluster node by number (1-5)
-stopNode :: Int -> IO ()
-stopNode n = do
-  (_, _, _) <- readProcessWithExitCode "docker" ["stop", nodeContainerName n] ""
-  return ()
+withStoppedNodes :: [Int] -> IO a -> IO a
+withStoppedNodes nodes =
+  withStoppedNodesUsing nodeLifecycleOperations $ map nodeTarget nodes
 
--- | Start a Redis cluster node by number (1-5)
-startNode :: Int -> IO ()
-startNode n = do
-  (_, _, _) <- readProcessWithExitCode "docker" ["start", nodeContainerName n] ""
-  return ()
+nodeLifecycleOperations :: NodeLifecycleOps
+nodeLifecycleOperations = NodeLifecycleOps
+  { stopNodeOperation =
+      runNodeCommandUsing readProcessWithExitCode StopNode
+  , startNodeOperation =
+      runNodeCommandUsing readProcessWithExitCode StartNode
+  , waitNodeReady = waitForNodeReady 30
+  }
+
+nodeTarget :: Int -> NodeTarget
+nodeTarget node
+  | node >= 1 && node <= 5 = NodeTarget
+      { nodeNumber = node
+      , nodeContainer = "redis-cluster-node" ++ show node
+      , targetHost = "redis" ++ show node ++ ".local"
+      , targetPort = 6378 + node
+      }
+  | otherwise =
+      error $ "Redis cluster node must be between 1 and 5, got "
+        ++ show node
 
 -- | Wait for the cluster to become ready after a node restart.
--- Polls node 1 (or fallback) for cluster_state:ok.
+-- Polls node 1 for PONG and a complete healthy cluster view.
 waitForClusterReady :: Int -> IO ()
-waitForClusterReady maxWaitSeconds = go maxWaitSeconds
-  where
-    go 0 = error "Cluster did not become ready in time"
-    go remaining = do
-      result <- try $ do
-        conn <- connect (NotConnectedPlainTextClient (nodeHost seedNode) (Just (nodePort seedNode)))
-        resp <- State.evalStateT (runRedisCommandClient ping) (ClientState conn BS.empty)
-        close conn
-        return resp
-        :: IO (Either SomeException RespData)
-      case result of
-        Right (RespSimpleString "PONG") -> do
-          -- Cluster bus needs a moment to stabilize after node restart
-          threadDelay 1000000  -- 1s extra stabilization
-        _ -> do
-          threadDelay 1000000  -- 1s
-          go (remaining - 1)
+waitForClusterReady maxWaitSeconds =
+  waitForNodeReady maxWaitSeconds $ nodeTarget 1
+
+waitForNodeReady :: Int -> NodeTarget -> IO ()
+waitForNodeReady maxWaitSeconds =
+  waitForReadinessUsing maxWaitSeconds probeNode
+
+probeNode :: NodeTarget -> IO ()
+probeNode target =
+  bracket
+    (connect $ NotConnectedPlainTextClient
+      (targetHost target) (Just $ targetPort target))
+    close $ \connection -> do
+      pingResponse <- runDirect connection ping
+      unless (pingResponse == RespSimpleString "PONG") $
+        throwIO $ userError $ "Unexpected PING response: "
+          ++ show pingResponse
+      clusterInfo <- runRaw connection ["CLUSTER", "INFO"]
+      case clusterInfo of
+        RespBulkString payload -> do
+          unless ("cluster_state:ok" `BS.isInfixOf` payload) $
+            throwIO $ userError "Cluster state is not ok"
+          unless ("cluster_slots_assigned:16384" `BS.isInfixOf` payload) $
+            throwIO $ userError "Cluster slot coverage is incomplete"
+          unless ("cluster_known_nodes:5" `BS.isInfixOf` payload) $
+            throwIO $ userError "Restarted node has not rejoined all peers"
+        other ->
+          throwIO $ userError $ "Unexpected CLUSTER INFO response: "
+            ++ show other
+
+runDirect
+  :: PlainTextClient 'Connected
+  -> RedisCommandClient PlainTextClient a
+  -> IO a
+runDirect connection command =
+  State.evalStateT
+    (runRedisCommandClient command)
+    (ClientState connection BS.empty)
+
+runRaw
+  :: PlainTextClient 'Connected
+  -> [BS.ByteString]
+  -> IO RespData
+runRaw connection arguments = runDirect connection $ RedisCommandClient $ do
+  ClientState connected _ <- State.get
+  liftIO $ send connected $ LBS.fromStrict $ encodeCommand arguments
+  parseWith $ liftIO $ receive connected

--- a/test/NodeLifecycleSpec.hs
+++ b/test/NodeLifecycleSpec.hs
@@ -1,0 +1,272 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Main (main) where
+
+import           Control.Concurrent       (forkFinally, killThread, threadDelay)
+import           Control.Concurrent.MVar  (newEmptyMVar, putMVar, takeMVar)
+import           Control.Exception        (SomeAsyncException, SomeException,
+                                           displayException, fromException,
+                                           throwIO, try)
+import           Data.IORef               (IORef, atomicModifyIORef', newIORef,
+                                           readIORef)
+import           LibraryE2E.NodeLifecycle
+import           System.Exit              (ExitCode (..))
+import           System.Timeout           (timeout)
+import           Test.Hspec
+
+main :: IO ()
+main = hspec $ describe "LibraryE2E node lifecycle" $ do
+  it "stops, runs the body, restarts, and waits for readiness" $ do
+    events <- newIORef []
+    let operations = successfulOperations events
+    withStoppedNodeUsing operations target $
+      record events "body"
+    readIORef events `shouldReturn`
+      ["stop", "body", "start", "ready"]
+
+  it "starts every stopped node before checking cluster readiness" $ do
+    events <- newIORef []
+    let operations = NodeLifecycleOps
+          { stopNodeOperation = \node ->
+              record events $ "stop-" ++ show (nodeNumber node)
+          , startNodeOperation = \node ->
+              record events $ "start-" ++ show (nodeNumber node)
+          , waitNodeReady = \node ->
+              record events $ "ready-" ++ show (nodeNumber node)
+          }
+        secondTarget = target
+          { nodeNumber = 4
+          , nodeContainer = "redis-cluster-node4"
+          , targetHost = "redis4.local"
+          , targetPort = 6382
+          }
+    withStoppedNodesUsing operations [target, secondTarget] $ return ()
+    readIORef events `shouldReturn`
+      [ "stop-3"
+      , "stop-4"
+      , "start-3"
+      , "start-4"
+      , "ready-3"
+      , "ready-4"
+      ]
+
+  it "does not run the body when stop fails and still attempts recovery" $ do
+    events <- newIORef []
+    bodyRan <- newIORef False
+    let operations = (successfulOperations events)
+          { stopNodeOperation = \_ -> do
+              record events "stop"
+              throwIO $ userError "stop failed"
+          }
+    result <- try $ withStoppedNodeUsing operations target $
+      atomicModifyIORef' bodyRan $ const (True, ())
+      :: IO (Either SomeException ())
+    case result of
+      Left err -> displayException err `shouldContain` "stop failed"
+      Right () -> expectationFailure "body ran after failed stop"
+    readIORef bodyRan `shouldReturn` False
+    readIORef events `shouldReturn` ["stop", "start", "ready"]
+
+  it "preserves a body failure after successful recovery" $ do
+    events <- newIORef []
+    let operations = successfulOperations events
+    result <- try $ withStoppedNodeUsing operations target $ do
+      record events "body"
+      throwIO $ userError "body failed"
+      :: IO (Either SomeException ())
+    case result of
+      Left err -> displayException err `shouldContain` "body failed"
+      Right () -> expectationFailure "body failure unexpectedly succeeded"
+    readIORef events `shouldReturn`
+      ["stop", "body", "start", "ready"]
+
+  it "restores the node before an enclosing timeout returns" $ do
+    events <- newIORef []
+    let operations = successfulOperations events
+    result <- timeout 50000 $ withStoppedNodeUsing operations target $
+      threadDelay 1000000
+    result `shouldBe` Nothing
+    readIORef events `shouldReturn` ["stop", "start", "ready"]
+
+  it "restores the node and rethrows asynchronous cancellation" $ do
+    events <- newIORef []
+    bodyStarted <- newEmptyMVar
+    bodyBlock <- newEmptyMVar
+    finished <- newEmptyMVar
+    let operations = successfulOperations events
+    owner <- forkFinally
+      (withStoppedNodeUsing operations target $ do
+        putMVar bodyStarted ()
+        takeMVar bodyBlock :: IO ())
+      (putMVar finished)
+    timeout 1000000 (takeMVar bodyStarted) `shouldReturn` Just ()
+    killThread owner
+    outcome <- timeout 1000000 $ takeMVar finished
+    outcome `shouldSatisfy` \case
+      Just (Left err) ->
+        case fromException err :: Maybe SomeAsyncException of
+          Just _  -> True
+          Nothing -> False
+      _ -> False
+    readIORef events `shouldReturn` ["stop", "start", "ready"]
+
+  it "preserves cancellation received during readiness cleanup" $ do
+    events <- newIORef []
+    readinessStarted <- newEmptyMVar
+    readinessBlock <- newEmptyMVar
+    finished <- newEmptyMVar
+    let operations = (successfulOperations events)
+          { waitNodeReady = \_ -> do
+              record events "ready"
+              putMVar readinessStarted ()
+              takeMVar readinessBlock
+          }
+    owner <- forkFinally
+      (withStoppedNodeUsing operations target $ return ())
+      (putMVar finished)
+    timeout 1000000 (takeMVar readinessStarted) `shouldReturn` Just ()
+    killThread owner
+    outcome <- timeout 1000000 $ takeMVar finished
+    outcome `shouldSatisfy` \case
+      Just (Left err) ->
+        case fromException err :: Maybe SomeAsyncException of
+          Just _  -> True
+          Nothing -> False
+      _ -> False
+    readIORef events `shouldReturn` ["stop", "start", "ready"]
+
+  it "preserves cleanup cancellation after a synchronous body failure" $ do
+    events <- newIORef []
+    readinessStarted <- newEmptyMVar
+    readinessBlock <- newEmptyMVar
+    finished <- newEmptyMVar
+    let operations = (successfulOperations events)
+          { waitNodeReady = \_ -> do
+              record events "ready"
+              putMVar readinessStarted ()
+              takeMVar readinessBlock
+          }
+    owner <- forkFinally
+      (withStoppedNodeUsing operations target $
+        throwIO (userError "primary body failure") :: IO ())
+      (putMVar finished)
+    timeout 1000000 (takeMVar readinessStarted) `shouldReturn` Just ()
+    killThread owner
+    outcome <- timeout 1000000 $ takeMVar finished
+    outcome `shouldSatisfy` \case
+      Just (Left err) ->
+        case fromException err :: Maybe SomeAsyncException of
+          Just _  -> True
+          Nothing -> False
+      _ -> False
+    readIORef events `shouldReturn` ["stop", "start", "ready"]
+
+  it "attempts readiness and returns a restart cleanup failure" $ do
+    events <- newIORef []
+    let operations = (successfulOperations events)
+          { startNodeOperation = \_ -> do
+              record events "start"
+              throwIO $ userError "restart failed"
+          }
+    result <- try $ withStoppedNodeUsing operations target $ return ()
+      :: IO (Either NodeLifecycleException ())
+    case result of
+      Left err -> displayException err `shouldContain` "restart failed"
+      Right () -> expectationFailure "restart failure unexpectedly succeeded"
+    readIORef events `shouldReturn` ["stop", "start", "ready"]
+
+  it "returns a readiness cleanup failure after restart succeeds" $ do
+    events <- newIORef []
+    let operations = (successfulOperations events)
+          { waitNodeReady = \_ -> do
+              record events "ready"
+              throwIO $ userError "readiness failed"
+          }
+    result <- try $ withStoppedNodeUsing operations target $ return ()
+      :: IO (Either NodeLifecycleException ())
+    case result of
+      Left err -> displayException err `shouldContain` "readiness failed"
+      Right () -> expectationFailure "readiness failure unexpectedly succeeded"
+    readIORef events `shouldReturn` ["stop", "start", "ready"]
+
+  it "bounds a readiness probe that never returns" $ do
+    blocked <- newEmptyMVar
+    result <- timeout 2000000
+      (try (waitForReadinessUsing 1
+        (\_ -> takeMVar blocked)
+        target) :: IO (Either NodeReadinessFailure ()))
+    result `shouldSatisfy` \case
+      Just (Left failure) ->
+        readinessWaitSeconds failure == 1
+      _ -> False
+
+  it "preserves both synchronous body and cleanup failures" $ do
+    events <- newIORef []
+    let operations = (successfulOperations events)
+          { startNodeOperation = \_ -> do
+              record events "start"
+              throwIO $ userError "cleanup failed"
+          }
+    result <- try $ withStoppedNodeUsing operations target $
+      throwIO $ userError "primary failed"
+      :: IO (Either NodeLifecycleException ())
+    case result of
+      Left err -> do
+        displayException err `shouldContain` "primary failed"
+        displayException err `shouldContain` "cleanup failed"
+      Right () -> expectationFailure "combined failure unexpectedly succeeded"
+    readIORef events `shouldReturn` ["stop", "start", "ready"]
+
+  it "checks Docker exit status and redacts sensitive diagnostics" $ do
+    let runner _ _ _ =
+          return
+            ( ExitFailure 17
+            , "password=not-for-logs"
+            , "credential token=also-secret"
+            )
+    result <- try $ runNodeCommandUsing runner StopNode target
+      :: IO (Either NodeCommandFailure ())
+    case result of
+      Left err -> do
+        displayException err `shouldContain` "redis-cluster-node3"
+        displayException err `shouldContain` "ExitFailure 17"
+        displayException err `shouldContain` "<redacted"
+        displayException err `shouldNotContain` "not-for-logs"
+        displayException err `shouldNotContain` "also-secret"
+      Right () -> expectationFailure "failed Docker stop unexpectedly succeeded"
+
+  it "includes safe Docker stdout and stderr in command failures" $ do
+    let runner _ _ _ =
+          return
+            ( ExitFailure 19
+            , "container was not running"
+            , "daemon unavailable"
+            )
+    result <- try $ runNodeCommandUsing runner StartNode target
+      :: IO (Either NodeCommandFailure ())
+    case result of
+      Left err -> do
+        displayException err `shouldContain` "container was not running"
+        displayException err `shouldContain` "daemon unavailable"
+        displayException err `shouldContain` "redis3.local:6381"
+      Right () -> expectationFailure "failed Docker start unexpectedly succeeded"
+
+target :: NodeTarget
+target = NodeTarget
+  { nodeNumber = 3
+  , nodeContainer = "redis-cluster-node3"
+  , targetHost = "redis3.local"
+  , targetPort = 6381
+  }
+
+successfulOperations :: IORef [String] -> NodeLifecycleOps
+successfulOperations events = NodeLifecycleOps
+  { stopNodeOperation = const $ record events "stop"
+  , startNodeOperation = const $ record events "start"
+  , waitNodeReady = const $ record events "ready"
+  }
+
+record :: IORef [String] -> String -> IO ()
+record events event =
+  atomicModifyIORef' events $ \current ->
+    (current ++ [event], ())


### PR DESCRIPTION
## Summary
- add a masked, exception-safe node lifecycle fixture for single- and multi-node outages
- check Docker stop/start exit status with sanitized diagnostics and wait for full cluster rejoin
- convert every LibraryE2E node-failure call site and add focused plus Docker-backed restoration regressions

## Failure and cleanup contract
- restart is attempted after body success, synchronous failure, timeout, or cancellation
- all stopped nodes are started before readiness checks begin
- synchronous primary failures are preserved with cleanup failures; asynchronous cancellation remains terminal while prior failures are reported
- readiness has a real 30-second overall deadline and requires PONG, healthy cluster state, all 16,384 slots, and all five nodes

## Validation
- `nix-shell --run "cabal test NodeLifecycleSpec --test-show-details=direct"` - 14 examples, 0 failures
- targeted Docker restoration sequence - 2 examples, 0 failures
- `nix-build --no-out-link`
- `make test` - including 47 LibraryE2E examples, 0 failures

No performance profile was run because this changes test orchestration only.

Closes #53
