### PR TITLE
Make Redis node outage tests deterministic

### DIFF
--- a/redis-client.cabal
+++ b/redis-client.cabal
@@ -90,6 +90,19 @@ test-suite NodeLifecycleSpec
     other-modules:    LibraryE2E.NodeLifecycle
     hs-source-dirs:   test
 
+test-suite NodeTargetingSpec
+    import:           test-defaults
+    type:             exitcode-stdio-1.0
+    main-is:          NodeTargetingSpec.hs
+    other-modules:    LibraryE2E.NodeLifecycle
+                    , LibraryE2E.NodeTargeting
+    hs-source-dirs:   test
+    build-depends:    bytestring
+                    , containers
+                    , hask-redis-mux
+                    , time
+                    , vector
+
 -- ---------------------------------------------------------------------------
 -- Flags
 -- ---------------------------------------------------------------------------
@@ -171,6 +184,7 @@ executable LibraryE2E
     hs-source-dirs:   test
     other-modules:    LibraryE2E.Utils
                     , LibraryE2E.NodeLifecycle
+                    , LibraryE2E.NodeTargeting
                     , LibraryE2E.ConnectionPoolTests
                     , LibraryE2E.TopologyTests
                     , LibraryE2E.ResilienceTests

--- a/test/LibraryE2E/ConcurrencyTests.hs
+++ b/test/LibraryE2E/ConcurrencyTests.hs
@@ -3,18 +3,24 @@
 
 module LibraryE2E.ConcurrencyTests (spec) where
 
-import           Control.Concurrent            (threadDelay)
-import           Control.Concurrent.Async      (concurrently, mapConcurrently)
-import           Control.Exception             (SomeException, try)
-import           Control.Monad                 (forM_)
-import           Data.IORef                    (atomicModifyIORef', newIORef,
-                                                readIORef)
-import           Database.Redis.Cluster.Client (ClusterError (..),
-                                                closeClusterClient,
-                                                executeKeyedClusterCommand,
-                                                refreshTopology)
-import           Database.Redis.Command        (showBS)
-import           Database.Redis.Resp           (RespData (..))
+import           Control.Concurrent                    (threadDelay)
+import           Control.Concurrent.Async              (concurrently,
+                                                        mapConcurrently)
+import           Control.Exception                     (SomeException, try)
+import           Control.Monad                         (forM_)
+import           Data.ByteString                       (ByteString)
+import           Data.IORef                            (atomicModifyIORef',
+                                                        newIORef, readIORef)
+import           Database.Redis.Client                 (PlainTextClient)
+import           Database.Redis.Cluster.Client         (ClusterClient,
+                                                        ClusterError (..),
+                                                        closeClusterClient,
+                                                        executeKeyedClusterCommand,
+                                                        refreshTopology)
+import           Database.Redis.Cluster.ConnectionPool (PoolConfig (..))
+import           Database.Redis.Command                (showBS)
+import           Database.Redis.Resp                   (RespData (..))
+import           System.Timeout                        (timeout)
 
 import           LibraryE2E.Utils
 
@@ -69,84 +75,117 @@ spec = describe "Concurrent Cluster Operations" $ do
     it "operations continue while topology is being refreshed" $ do
       client <- createTestClient
 
-      successCount <- newIORef (0 :: Int)
-
       -- Run topology refreshes concurrently with SET/GET operations
-      let refreshAction = do
-            forM_ [1..10 :: Int] $ \_ -> do
-              _ <- try (refreshTopology client) :: IO (Either SomeException ())
+      let refreshAction =
+            mapM (\_ -> do
+              result <- try (refreshTopology client)
+                :: IO (Either SomeException ())
               threadDelay 50000  -- 50ms between refreshes
+              return result
+            ) [1..10 :: Int]
 
-          workerAction = do
-            mapConcurrently (\tid -> do
-              forM_ [1..50 :: Int] $ \i -> do
+          workerAction =
+            mapConcurrently (\tid ->
+              mapM (\i -> do
                 let key = "refresh-storm-" <> showBS tid <> "-" <> showBS i
                 r <- executeKeyedClusterCommand client key ["SET", key, "v"]
-                case r of
-                  Right _ -> atomicModifyIORef' successCount (\n -> (n + 1, ()))
-                  Left _  -> return ()
-              ) [1..49 :: Int]
+                return $ r == Right (RespSimpleString "OK")
+              ) [1..50 :: Int]
+            ) [1..49 :: Int]
 
       -- Run refresh + workers concurrently
-      _ <- concurrently refreshAction workerAction
+      (refreshResults, workerResults) <-
+        concurrently refreshAction workerAction
 
-      -- Most operations should succeed (some transient failures during refresh are ok)
-      total <- readIORef successCount
-      -- 49 workers × 50 ops = 2450 total ops; expect at least 90% success
-      total `shouldSatisfy` (> 2200)
+      length [() | Right () <- refreshResults] `shouldBe` 10
+      length (filter id $ concat workerResults) `shouldBe` 2450
 
       flushAllNodes client
       closeClusterClient client
 
   describe "Concurrent ops during node failure" $ do
-    it "operations to healthy nodes continue during node failure" $ do
-      client <- createTestClient
+    it "fails stopped-slot operations while healthy-slot round trips continue" $ do
+      client <- createOutageTestClient
+      scenario <- nodeOutageScenario client 3
+      let targetKey = stoppedNodeKey scenario
+          healthyKey = healthyNodeKey scenario
+          workerCount = maxConnectionsPerNode defaultPoolConfig
 
-      -- Warm up connections
-      forM_ [1..10 :: Int] $ \i -> do
-        let k = "warmup-" <> showBS i
-        _ <- executeKeyedClusterCommand client k ["SET", k, "v"]
-        return ()
+      assertRoundTrip client targetKey "target-before"
+      assertRoundTrip client healthyKey "healthy-before"
 
-      successCount <- newIORef (0 :: Int)
-      failCount <- newIORef (0 :: Int)
+      (stoppedFailure, healthyOutcomes) <- withStoppedNode 3 $
+        concurrently
+          (runStoppedOperation client targetKey)
+          (mapConcurrently
+            (const $ runHealthyOperation client healthyKey)
+            [1..workerCount :: Int])
 
-      -- Run workers, kill a node mid-flight
-      let workerAction = mapConcurrently (\tid -> do
-            forM_ [1..100 :: Int] $ \i -> do
-              let key = "nodefail-" <> showBS tid <> "-" <> showBS i
-              r <- try (executeKeyedClusterCommand client key ["SET", key, "v"])
-                    :: IO (Either SomeException (Either ClusterError RespData))
-              case r of
-                Right (Right _) -> atomicModifyIORef' successCount (\n -> (n + 1, ()))
-                _               -> atomicModifyIORef' failCount (\n -> (n + 1, ()))
-              -- Small delay to spread operations over time
-              threadDelay 10000  -- 10ms
-            ) [1..50 :: Int]
+      let stoppedFailures = fromEnum stoppedFailure
+          healthySuccesses = length $ filter id healthyOutcomes
+          unexpected = (1 - stoppedFailures)
+            + (workerCount - healthySuccesses)
 
-          killerAction = do
-            threadDelay 500000  -- 500ms into the test, kill node 3
-            withStoppedNode 3 $
-              threadDelay 3000000  -- Let it stay dead for 3s
+      stoppedFailures `shouldBe` 1
+      healthySuccesses `shouldBe` workerCount
+      unexpected `shouldBe` 0
+      stoppedFailures `shouldSatisfy` (> 0)
+      healthySuccesses `shouldSatisfy` (> 0)
 
-      _ <- concurrently workerAction killerAction
-
-      -- Some successes (ops to healthy nodes) and some failures (ops to dead node)
-      successes <- readIORef successCount
-      _ <- readIORef failCount
-
-      -- We should have both successes and failures
-      successes `shouldSatisfy` (> 0)
-
-      -- Final verification: cluster is healthy again
-      _ <- try (refreshTopology client) :: IO (Either SomeException ())
-      r <- executeKeyedClusterCommand client "final-check" ["SET", "final-check", "ok"]
-      r `shouldSatisfy` isRight'
+      refreshTopology client
+      assertRoundTrip client targetKey "target-after"
 
       flushAllNodes client
       closeClusterClient client
 
--- | Helper
-isRight' :: Either a b -> Bool
-isRight' (Right _) = True
-isRight' _         = False
+runStoppedOperation
+  :: ClusterClient PlainTextClient
+  -> ByteString
+  -> IO Bool
+runStoppedOperation client targetKey = do
+  targetResult <- timeout 10000000 $
+    executeKeyedClusterCommand client
+      targetKey
+      ["SET", targetKey, "target-during"]
+  return $ isExpectedOutage targetResult
+
+runHealthyOperation
+  :: ClusterClient PlainTextClient
+  -> ByteString
+  -> IO Bool
+runHealthyOperation client healthyKey = do
+  result <- timeout 10000000 $ do
+    healthySet <- executeKeyedClusterCommand client
+      healthyKey
+      ["SET", healthyKey, "healthy-during"]
+    healthyGet <- executeKeyedClusterCommand client
+      healthyKey
+      ["GET", healthyKey]
+    return (healthySet, healthyGet)
+  return $ case result of
+    Just (healthySet, healthyGet) ->
+      healthySet == Right (RespSimpleString "OK")
+        && healthyGet == Right (RespBulkString "healthy-during")
+    Nothing ->
+      False
+
+isExpectedOutage :: Maybe (Either ClusterError RespData) -> Bool
+isExpectedOutage (Just (Left (MaxRetriesExceeded _))) = True
+isExpectedOutage _                                    = False
+
+assertRoundTrip
+  :: ClusterClient PlainTextClient
+  -> ByteString
+  -> ByteString
+  -> Expectation
+assertRoundTrip client key value = do
+  result <- timeout 10000000 $ do
+    setResult <- executeKeyedClusterCommand client key ["SET", key, value]
+    getResult <- executeKeyedClusterCommand client key ["GET", key]
+    return (setResult, getResult)
+  case result of
+    Nothing ->
+      expectationFailure "Key round trip exceeded the 10-second bound"
+    Just (setResult, getResult) -> do
+      setResult `shouldBe` Right (RespSimpleString "OK")
+      getResult `shouldBe` Right (RespBulkString value)

--- a/test/LibraryE2E/NodeTargeting.hs
+++ b/test/LibraryE2E/NodeTargeting.hs
@@ -1,0 +1,189 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module LibraryE2E.NodeTargeting
+  ( NodeOutageScenario (..)
+  , dockerNodeTarget
+  , findKeyForSlotRanges
+  , resolveNodeOutageScenario
+  ) where
+
+import           Data.ByteString          (ByteString)
+import qualified Data.ByteString          as BS
+import           Data.List                (sortOn)
+import qualified Data.Map.Strict          as Map
+import qualified Data.Vector              as V
+import           Data.Word                (Word16, Word64)
+import           Database.Redis.Cluster
+import           LibraryE2E.NodeLifecycle (NodeTarget (..))
+
+data NodeOutageScenario = NodeOutageScenario
+  { stoppedClusterNode :: ClusterNode
+  , stoppedNodeKey     :: ByteString
+  , healthyClusterNode :: ClusterNode
+  , healthyNodeKey     :: ByteString
+  } deriving (Eq, Show)
+
+dockerNodeTarget :: Int -> Either String NodeTarget
+dockerNodeTarget node
+  | node >= 1 && node <= 5 =
+      Right NodeTarget
+        { nodeNumber = node
+        , nodeContainer = "redis-cluster-node" ++ show node
+        , targetHost = "redis" ++ show node ++ ".local"
+        , targetPort = 6378 + node
+        }
+  | otherwise =
+      Left $ "Redis cluster node must be between 1 and 5, got " ++ show node
+
+resolveNodeOutageScenario
+  :: Int
+  -> NodeTarget
+  -> ClusterTopology
+  -> Either String NodeOutageScenario
+resolveNodeOutageScenario searchLimit target topology = do
+  stopped <- resolveTargetNode target topology
+  healthy <- resolveHealthyNode stopped topology
+  stoppedKey <- findKeyForNode
+    searchLimit
+    "library-e2e-stopped-"
+    topology
+    stopped
+  healthyKey <- findKeyForNode
+    searchLimit
+    "library-e2e-healthy-"
+    topology
+    healthy
+  return NodeOutageScenario
+    { stoppedClusterNode = stopped
+    , stoppedNodeKey = stoppedKey
+    , healthyClusterNode = healthy
+    , healthyNodeKey = healthyKey
+    }
+
+findKeyForSlotRanges
+  :: Int
+  -> ByteString
+  -> [SlotRange]
+  -> Either String ByteString
+findKeyForSlotRanges searchLimit prefix ranges
+  | searchLimit <= 0 =
+      Left "Key search limit must be positive"
+  | null ranges =
+      Left "Cannot generate a key for an empty slot range list"
+  | otherwise =
+      search 0
+  where
+    search index
+      | index >= searchLimit =
+          Left $ "Could not find a key in the requested slot ranges after "
+            ++ show searchLimit ++ " attempts"
+      | slotInRanges (calculateSlot candidate) ranges =
+          Right candidate
+      | otherwise =
+          search $ index + 1
+      where
+        candidate = prefix <> encodeCounter (fromIntegral index)
+
+resolveTargetNode
+  :: NodeTarget
+  -> ClusterTopology
+  -> Either String ClusterNode
+resolveTargetNode target topology =
+  case filter matchesTarget $ Map.elems $ topologyNodes topology of
+    [node] -> validateRoutableMaster topology node
+    [] ->
+      Left $ "No cluster node advertises Docker target "
+        ++ renderTargetAddress target
+    _ ->
+      Left $ "Multiple cluster nodes advertise Docker target "
+        ++ renderTargetAddress target
+  where
+    matchesTarget node =
+      nodeAddress node == NodeAddress (targetHost target) (targetPort target)
+
+resolveHealthyNode
+  :: ClusterNode
+  -> ClusterTopology
+  -> Either String ClusterNode
+resolveHealthyNode stopped topology =
+  case validHealthyNodes of
+    node : _ -> Right node
+    [] ->
+      Left "No healthy master with owned slots exists outside the stopped node"
+  where
+    validHealthyNodes =
+      sortOn nodeAddress
+        [ node
+        | node <- Map.elems $ topologyNodes topology
+        , nodeId node /= nodeId stopped
+        , nodeRole node == Master
+        , not $ null $ nodeSlotsServed node
+        , rangesMatchTopology topology node
+        ]
+
+validateRoutableMaster
+  :: ClusterTopology
+  -> ClusterNode
+  -> Either String ClusterNode
+validateRoutableMaster topology node
+  | nodeRole node /= Master =
+      Left $ "Docker target is not a master: " ++ show (nodeAddress node)
+  | not $ null $ nodeReplicas node =
+      Left $ "Docker target has replicas, so an outage may fail over: "
+        ++ show (nodeAddress node)
+  | null $ nodeSlotsServed node =
+      Left $ "Docker target owns no slots: " ++ show (nodeAddress node)
+  | not $ rangesMatchTopology topology node =
+      Left $ "Docker target slot ranges disagree with the routing vector: "
+        ++ show (nodeAddress node)
+  | otherwise =
+      Right node
+
+findKeyForNode
+  :: Int
+  -> ByteString
+  -> ClusterTopology
+  -> ClusterNode
+  -> Either String ByteString
+findKeyForNode searchLimit prefix topology node = do
+  key <- findKeyForSlotRanges searchLimit prefix $ nodeSlotsServed node
+  let slot = calculateSlot key
+  case findNodeAddressForSlot topology slot of
+    Just address
+      | address == nodeAddress node ->
+          Right key
+    actual ->
+      Left $ "Generated slot " ++ show slot
+        ++ " routed to " ++ show actual
+        ++ " instead of " ++ show (nodeAddress node)
+
+rangesMatchTopology :: ClusterTopology -> ClusterNode -> Bool
+rangesMatchTopology topology node =
+  all slotMatches $ concatMap rangeSlots $ nodeSlotsServed node
+  where
+    slotMatches slot =
+      topologySlots topology V.!? fromIntegral slot == Just (nodeId node)
+
+slotInRanges :: Word16 -> [SlotRange] -> Bool
+slotInRanges slot =
+  any $ \range -> slot >= slotStart range && slot <= slotEnd range
+
+rangeSlots :: SlotRange -> [Word16]
+rangeSlots range = [slotStart range .. slotEnd range]
+
+encodeCounter :: Word64 -> ByteString
+encodeCounter value =
+  BS.pack
+    [ fromIntegral $ value `div` 0x100000000000000
+    , fromIntegral $ value `div` 0x1000000000000
+    , fromIntegral $ value `div` 0x10000000000
+    , fromIntegral $ value `div` 0x100000000
+    , fromIntegral $ value `div` 0x1000000
+    , fromIntegral $ value `div` 0x10000
+    , fromIntegral $ value `div` 0x100
+    , fromIntegral value
+    ]
+
+renderTargetAddress :: NodeTarget -> String
+renderTargetAddress target =
+  targetHost target ++ ":" ++ show (targetPort target)

--- a/test/LibraryE2E/ResilienceTests.hs
+++ b/test/LibraryE2E/ResilienceTests.hs
@@ -3,16 +3,17 @@
 
 module LibraryE2E.ResilienceTests (spec) where
 
-import           Control.Concurrent            (threadDelay)
 import           Control.Exception             (SomeException, displayException,
                                                 throwIO, try)
-import           Database.Redis.Cluster.Client (ClusterConfig (..),
+import           Data.ByteString               (ByteString)
+import           Database.Redis.Client         (PlainTextClient)
+import           Database.Redis.Cluster.Client (ClusterClient,
                                                 ClusterError (..),
                                                 closeClusterClient,
                                                 executeKeyedClusterCommand,
                                                 refreshTopology)
-import           Database.Redis.Command        (showBS)
 import           Database.Redis.Resp           (RespData (..))
+import           System.Timeout                (timeout)
 
 import           LibraryE2E.Utils
 
@@ -34,12 +35,11 @@ spec = describe "Error Handling & Resilience" $ do
 
     it "starts the following example with a healthy cluster" $ do
       waitForClusterReady 5
-      client <- createTestClient
-      result <- executeKeyedClusterCommand
-        client
-        "restoration-followup"
-        ["SET", "restoration-followup", "healthy"]
-      result `shouldSatisfy` isRight'
+      client <- createOutageTestClient
+      scenario <- nodeOutageScenario client 3
+      refreshTopology client
+      assertRoundTrip client (stoppedNodeKey scenario) "restored-target"
+      assertRoundTrip client (healthyNodeKey scenario) "restored-healthy"
       flushAllNodes client
       closeClusterClient client
 
@@ -73,90 +73,89 @@ spec = describe "Error Handling & Resilience" $ do
       closeClusterClient client
 
   describe "Max retries exceeded" $ do
-    it "returns MaxRetriesExceeded when all nodes for a slot are down" $ do
-      -- Create client with very few retries
-      client <- createTestClientWith (\c -> c {
-        clusterMaxRetries = 1,
-        clusterRetryDelay = 10000  -- 10ms to speed up test
-      })
+    it "exhausts retries only for the stopped node's slot" $ do
+      client <- createOutageTestClient
+      scenario <- nodeOutageScenario client 4
+      assertRoundTrip client (stoppedNodeKey scenario) "target-before"
+      assertRoundTrip client (healthyNodeKey scenario) "healthy-before"
 
-      withStoppedNodes [4, 5] $ do
-        threadDelay 3000000  -- 3s for detection
+      withStoppedNode 4 $ do
+        assertBoundedOutage client $ stoppedNodeKey scenario
+        assertRoundTrip client (healthyNodeKey scenario) "healthy-during"
 
-        -- Try operations — some should fail with MaxRetriesExceeded or ConnectionError
-        -- We try several keys to increase odds of hitting a down node's slots
-        let tryKeys = ["maxretry-" <> showBS i | i <- [1..20 :: Int]]
-        results <- mapM (\k ->
-          executeKeyedClusterCommand client k ["SET", k, "v"]
-          ) tryKeys
-
-        -- At least some should fail (nodes 4 & 5 own some slots)
-        let failures = [e | Left e <- results]
-        length failures `shouldSatisfy` (> 0)
-
-        -- Verify failures are the right error types
-        let isExpectedError (MaxRetriesExceeded _) = True
-            isExpectedError (ConnectionError _)    = True
-            isExpectedError _                      = False
-        mapM_ (\e -> e `shouldSatisfy` isExpectedError) failures
-
+      refreshTopology client
+      assertRoundTrip client (stoppedNodeKey scenario) "target-after"
       flushAllNodes client
       closeClusterClient client
 
   describe "ConnectionClosed handling" $ do
-    it "node kill produces ConnectionError, not hang or parse error" $ do
-      client <- createTestClient
-
-      -- Warm up a connection to node 3
-      -- Use hash tag to target specific node's slots
-      _ <- executeKeyedClusterCommand client "conn-close-test" ["SET", "conn-close-test", "v"]
+    it "turns a closed stopped-node connection into bounded retry exhaustion" $ do
+      client <- createOutageTestClient
+      scenario <- nodeOutageScenario client 3
+      assertRoundTrip client (stoppedNodeKey scenario) "target-before"
+      assertRoundTrip client (healthyNodeKey scenario) "healthy-before"
 
       withStoppedNode 3 $ do
-        threadDelay 2000000  -- 2s
+        assertBoundedOutage client $ stoppedNodeKey scenario
+        assertRoundTrip client (healthyNodeKey scenario) "healthy-during"
 
-        -- Try operations — some may fail with ConnectionError
-        results <- mapM (\i -> do
-          let k = "connclose-" <> showBS i
-          try (executeKeyedClusterCommand client k ["SET", k, "v"])
-            :: IO (Either SomeException (Either ClusterError RespData))
-          ) [1..10 :: Int]
-
-        -- Should not hang (test completing is the assertion)
-        -- Any failures should be connection-related, not parse errors
-        let checkResult r = case r of
-              Left _                              -> True  -- Exception is fine
-              Right (Left (ConnectionError _))    -> True
-              Right (Left (MaxRetriesExceeded _)) -> True
-              Right (Right _)                     -> True  -- Success is fine (different node)
-              Right (Left _)                      -> True  -- Other cluster errors ok
-        mapM_ (\r -> r `shouldSatisfy` checkResult) results
-
+      refreshTopology client
+      assertRoundTrip client (stoppedNodeKey scenario) "target-after"
       flushAllNodes client
       closeClusterClient client
 
   describe "Recovery after node restart" $ do
-    it "operations resume after stopped node is restarted" $ do
-      client <- createTestClient
+    it "restores the same stopped-node slot after refresh" $ do
+      client <- createOutageTestClient
+      scenario <- nodeOutageScenario client 3
+      let targetKey = stoppedNodeKey scenario
+          healthyKey = healthyNodeKey scenario
 
-      -- Establish baseline
-      r1 <- executeKeyedClusterCommand client "recovery-key" ["SET", "recovery-key", "before"]
-      r1 `shouldSatisfy` isRight'
+      assertRoundTrip client targetKey "target-before"
+      assertRoundTrip client healthyKey "healthy-before"
 
-      withStoppedNode 3 $
-        threadDelay 3000000
+      withStoppedNode 3 $ do
+        assertBoundedOutage client targetKey
+        assertRoundTrip client healthyKey "healthy-during"
 
-      -- Force topology refresh
-      _ <- try (refreshTopology client) :: IO (Either SomeException ())
-
-      -- Operations should work again
-      r2 <- executeKeyedClusterCommand client "recovery-key2" ["SET", "recovery-key2", "after"]
-      r2 `shouldSatisfy` isRight'
-
-      r3 <- executeKeyedClusterCommand client "recovery-key2" ["GET", "recovery-key2"]
-      r3 `shouldBe` Right (RespBulkString "after")
+      refreshTopology client
+      assertRoundTrip client targetKey "target-after"
 
       flushAllNodes client
       closeClusterClient client
+
+assertRoundTrip
+  :: ClusterClient PlainTextClient
+  -> ByteString
+  -> ByteString
+  -> Expectation
+assertRoundTrip client key value = do
+  result <- timeout 10000000 $ do
+    setResult <- executeKeyedClusterCommand client key ["SET", key, value]
+    getResult <- executeKeyedClusterCommand client key ["GET", key]
+    return (setResult, getResult)
+  case result of
+    Nothing ->
+      expectationFailure "Key round trip exceeded the 10-second bound"
+    Just (setResult, getResult) -> do
+      setResult `shouldBe` Right (RespSimpleString "OK")
+      getResult `shouldBe` Right (RespBulkString value)
+
+assertBoundedOutage
+  :: ClusterClient PlainTextClient
+  -> ByteString
+  -> Expectation
+assertBoundedOutage client key = do
+  result <- timeout 10000000 $
+    executeKeyedClusterCommand client key ["SET", key, "during-outage"]
+  case result of
+    Nothing ->
+      expectationFailure "Stopped-node command exceeded the 10-second bound"
+    Just (Left (MaxRetriesExceeded _)) ->
+      return ()
+    Just other ->
+      expectationFailure $ "Expected MaxRetriesExceeded for stopped-node slot, got "
+        ++ show other
 
 -- | Helper
 isRight' :: Either a b -> Bool

--- a/test/LibraryE2E/TopologyTests.hs
+++ b/test/LibraryE2E/TopologyTests.hs
@@ -7,17 +7,21 @@ import           Control.Concurrent            (threadDelay)
 import           Control.Concurrent.Async      (mapConcurrently)
 import           Control.Concurrent.STM        (readTVarIO)
 import           Control.Exception             (SomeException, try)
+import           Data.ByteString               (ByteString)
 import qualified Data.Map.Strict               as Map
 import           Data.Time.Clock               (diffUTCTime)
 import qualified Data.Vector                   as V
+import           Database.Redis.Client         (PlainTextClient)
 import           Database.Redis.Cluster        (ClusterNode (..),
                                                 ClusterTopology (..),
                                                 NodeRole (..))
 import           Database.Redis.Cluster.Client (ClusterClient (..),
+                                                ClusterError (..),
                                                 closeClusterClient,
                                                 executeKeyedClusterCommand,
                                                 refreshTopology)
 import           Database.Redis.Resp           (RespData (..))
+import           System.Timeout                (timeout)
 
 import           LibraryE2E.Utils
 
@@ -74,38 +78,55 @@ spec = describe "Topology Refresh" $ do
       closeClusterClient client
 
   describe "Refresh on ConnectionError" $ do
-    it "handles node failure and recovers after restart" $ do
-      client <- createTestClient
+    it "keeps healthy slots available and restores the stopped slot" $ do
+      client <- createOutageTestClient
+      scenario <- nodeOutageScenario client 3
+      let targetKey = stoppedNodeKey scenario
+          healthyKey = healthyNodeKey scenario
 
-      -- Write a key to establish baseline
-      r1 <- executeKeyedClusterCommand client "topo-recover-key" ["SET", "topo-recover-key", "alive"]
-      r1 `shouldSatisfy` isRight'
+      assertRoundTrip client targetKey "target-before"
+      assertRoundTrip client healthyKey "healthy-before"
 
       withStoppedNode 3 $ do
-        threadDelay 3000000  -- 3s for cluster to detect failure
+        refreshTopology client
+        assertBoundedOutage client targetKey
+        assertRoundTrip client healthyKey "healthy-during"
 
-        -- Force a topology refresh so the client knows about the change
-        _ <- try (refreshTopology client) :: IO (Either SomeException ())
-
-        -- Operations to other nodes should still work
-        _ <- executeKeyedClusterCommand client "topo-other-node" ["SET", "topo-other-node", "works"]
-        -- This might succeed or fail depending on which node owns the key slot
-        -- The important thing is it doesn't hang
-        return ()
-
-      -- After recovery, all operations should work
-      _ <- try (refreshTopology client) :: IO (Either SomeException ())
-      r3 <- executeKeyedClusterCommand client "topo-recover-key" ["GET", "topo-recover-key"]
-      -- After cluster recovery, the key should still be readable
-      case r3 of
-        Right (RespBulkString "alive") -> return ()
-        Right _                        -> return ()  -- May get redirected, that's fine
-        Left _                         -> return ()  -- Recovery may still be in progress
+      refreshTopology client
+      assertRoundTrip client targetKey "target-after"
 
       flushAllNodes client
       closeClusterClient client
 
--- | Helper
-isRight' :: Either a b -> Bool
-isRight' (Right _) = True
-isRight' _         = False
+assertRoundTrip
+  :: ClusterClient PlainTextClient
+  -> ByteString
+  -> ByteString
+  -> Expectation
+assertRoundTrip client key value = do
+  result <- timeout 10000000 $ do
+    setResult <- executeKeyedClusterCommand client key ["SET", key, value]
+    getResult <- executeKeyedClusterCommand client key ["GET", key]
+    return (setResult, getResult)
+  case result of
+    Nothing ->
+      expectationFailure "Key round trip exceeded the 10-second bound"
+    Just (setResult, getResult) -> do
+      setResult `shouldBe` Right (RespSimpleString "OK")
+      getResult `shouldBe` Right (RespBulkString value)
+
+assertBoundedOutage
+  :: ClusterClient PlainTextClient
+  -> ByteString
+  -> Expectation
+assertBoundedOutage client key = do
+  result <- timeout 10000000 $
+    executeKeyedClusterCommand client key ["GET", key]
+  case result of
+    Nothing ->
+      expectationFailure "Stopped-node command exceeded the 10-second bound"
+    Just (Left (MaxRetriesExceeded _)) ->
+      return ()
+    Just other ->
+      expectationFailure $ "Expected MaxRetriesExceeded for stopped-node slot, got "
+        ++ show other

--- a/test/LibraryE2E/Utils.hs
+++ b/test/LibraryE2E/Utils.hs
@@ -6,6 +6,7 @@ module LibraryE2E.Utils
   ( -- * Client creation
     createTestClient
   , createTestClientWith
+  , createOutageTestClient
   , defaultTestConfig
   , defaultPoolConfig
   , testConnector
@@ -16,6 +17,8 @@ module LibraryE2E.Utils
   , withStoppedNode
   , withStoppedNodes
   , waitForClusterReady
+  , nodeOutageScenario
+  , NodeOutageScenario (..)
     -- * Constants
   , seedNode
   ) where
@@ -52,6 +55,9 @@ import           Database.Redis.Connector              (Connector,
                                                         clusterPlaintextConnector)
 import           Database.Redis.Resp                   (RespData (..))
 import           LibraryE2E.NodeLifecycle
+import           LibraryE2E.NodeTargeting              (NodeOutageScenario (..),
+                                                        dockerNodeTarget,
+                                                        resolveNodeOutageScenario)
 import           System.Process                        (readProcessWithExitCode)
 
 -- | Seed node for cluster discovery
@@ -89,6 +95,15 @@ createTestClient = createClusterClient defaultTestConfig testConnector
 createTestClientWith :: (ClusterConfig -> ClusterConfig) -> IO (ClusterClient PlainTextClient)
 createTestClientWith f = createClusterClient (f defaultTestConfig) testConnector
 
+createOutageTestClient :: IO (ClusterClient PlainTextClient)
+createOutageTestClient = createTestClientWith $ \config -> config
+  { clusterMaxRetries = 2
+  , clusterRetryDelay = 10000
+  , clusterPoolConfig = (clusterPoolConfig config)
+      { connectionTimeout = 1
+      }
+  }
+
 -- | Run a cluster command using the test connector
 runCmd :: ClusterClient PlainTextClient -> ClusterCommandClient PlainTextClient a -> IO a
 runCmd client = runClusterCommandClient client
@@ -109,12 +124,24 @@ flushAllNodes client = do
       Right _                   -> return ()
 
 withStoppedNode :: Int -> IO a -> IO a
-withStoppedNode node =
-  withStoppedNodeUsing nodeLifecycleOperations (nodeTarget node)
+withStoppedNode node action = do
+  target <- requireNodeTarget node
+  withStoppedNodeUsing nodeLifecycleOperations target action
 
 withStoppedNodes :: [Int] -> IO a -> IO a
-withStoppedNodes nodes =
-  withStoppedNodesUsing nodeLifecycleOperations $ map nodeTarget nodes
+withStoppedNodes nodes action = do
+  targets <- mapM requireNodeTarget nodes
+  withStoppedNodesUsing nodeLifecycleOperations targets action
+
+nodeOutageScenario
+  :: ClusterClient PlainTextClient
+  -> Int
+  -> IO NodeOutageScenario
+nodeOutageScenario client node = do
+  topology <- readTVarIO $ clusterTopology client
+  target <- requireNodeTarget node
+  either (throwIO . userError) return $
+    resolveNodeOutageScenario 100000 target topology
 
 nodeLifecycleOperations :: NodeLifecycleOps
 nodeLifecycleOperations = NodeLifecycleOps
@@ -125,23 +152,16 @@ nodeLifecycleOperations = NodeLifecycleOps
   , waitNodeReady = waitForNodeReady 30
   }
 
-nodeTarget :: Int -> NodeTarget
-nodeTarget node
-  | node >= 1 && node <= 5 = NodeTarget
-      { nodeNumber = node
-      , nodeContainer = "redis-cluster-node" ++ show node
-      , targetHost = "redis" ++ show node ++ ".local"
-      , targetPort = 6378 + node
-      }
-  | otherwise =
-      error $ "Redis cluster node must be between 1 and 5, got "
-        ++ show node
+requireNodeTarget :: Int -> IO NodeTarget
+requireNodeTarget =
+  either (throwIO . userError) return . dockerNodeTarget
 
 -- | Wait for the cluster to become ready after a node restart.
 -- Polls node 1 for PONG and a complete healthy cluster view.
 waitForClusterReady :: Int -> IO ()
-waitForClusterReady maxWaitSeconds =
-  waitForNodeReady maxWaitSeconds $ nodeTarget 1
+waitForClusterReady maxWaitSeconds = do
+  target <- requireNodeTarget 1
+  waitForNodeReady maxWaitSeconds target
 
 waitForNodeReady :: Int -> NodeTarget -> IO ()
 waitForNodeReady maxWaitSeconds =

--- a/test/NodeTargetingSpec.hs
+++ b/test/NodeTargetingSpec.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import qualified Data.ByteString          as BS
+import           Data.List                (isInfixOf)
+import qualified Data.Map.Strict          as Map
+import           Data.Time.Clock.POSIX    (posixSecondsToUTCTime)
+import qualified Data.Vector              as V
+import           Data.Word                (Word16)
+import           Database.Redis.Cluster
+import           LibraryE2E.NodeLifecycle (NodeTarget (..))
+import           LibraryE2E.NodeTargeting
+import           Test.Hspec
+
+main :: IO ()
+main = hspec $ describe "LibraryE2E node targeting" $ do
+  it "maps fixture node numbers to the configured container address" $ do
+    dockerNodeTarget 3 `shouldBe` Right target
+    dockerNodeTarget 0 `shouldBe`
+      Left "Redis cluster node must be between 1 and 5, got 0"
+
+  it "maps a Docker target to its advertised master and owned slots" $ do
+    let scenario = resolveNodeOutageScenario 1000 target fixtureTopology
+    case scenario of
+      Left err -> expectationFailure err
+      Right resolved -> do
+        nodeAddress (stoppedClusterNode resolved)
+          `shouldBe` NodeAddress "redis3.local" 6381
+        calculateSlot (stoppedNodeKey resolved)
+          `shouldSatisfy` inRange stoppedRange
+        nodeAddress (healthyClusterNode resolved)
+          `shouldBe` NodeAddress "redis1.local" 6379
+        calculateSlot (healthyNodeKey resolved)
+          `shouldSatisfy` inRange healthyRange
+
+  it "generates binary keys whose calculated slot is inside the range" $ do
+    let binaryPrefix = BS.pack [0x00, 0xff, 0x80, 0x01]
+    case findKeyForSlotRanges 1000 binaryPrefix [stoppedRange] of
+      Left err -> expectationFailure err
+      Right key -> do
+        binaryPrefix `BS.isPrefixOf` key `shouldBe` True
+        calculateSlot key `shouldSatisfy` inRange stoppedRange
+
+  it "returns a bounded failure when candidates cannot reach the range" $ do
+    let fixedSlot = calculateSlot "{fixed}"
+        unreachable
+          | fixedSlot == 0 = SlotRange 1 1 "other" []
+          | otherwise = SlotRange 0 0 "other" []
+    findKeyForSlotRanges 3 "{fixed}" [unreachable]
+      `shouldBe` Left
+        "Could not find a key in the requested slot ranges after 3 attempts"
+
+  it "rejects ambiguous advertised node mappings" $ do
+    let duplicate = stoppedNode
+          { nodeId = "duplicate"
+          , nodeSlotsServed = [SlotRange 10001 10001 "duplicate" []]
+          }
+        topology = fixtureTopology
+          { topologyNodes = Map.insert "duplicate" duplicate $
+              topologyNodes fixtureTopology
+          }
+    resolveNodeOutageScenario 1000 target topology
+      `shouldBe` Left
+        "Multiple cluster nodes advertise Docker target redis3.local:6381"
+
+  it "rejects a target with replicas because failure is not deterministic" $ do
+    let replicated = stoppedNode
+          { nodeReplicas = ["replica"]
+          }
+        topology = fixtureTopology
+          { topologyNodes = Map.insert "stopped" replicated $
+              topologyNodes fixtureTopology
+          }
+    resolveNodeOutageScenario 1000 target topology `shouldSatisfy` \case
+      Left err -> "has replicas" `isInfixOf` err
+      Right _  -> False
+
+target :: NodeTarget
+target = NodeTarget
+  { nodeNumber = 3
+  , nodeContainer = "redis-cluster-node3"
+  , targetHost = "redis3.local"
+  , targetPort = 6381
+  }
+
+healthyRange :: SlotRange
+healthyRange = SlotRange 0 5000 "healthy" []
+
+stoppedRange :: SlotRange
+stoppedRange = SlotRange 5001 10000 "stopped" []
+
+healthyNode :: ClusterNode
+healthyNode = ClusterNode
+  { nodeId = "healthy"
+  , nodeAddress = NodeAddress "redis1.local" 6379
+  , nodeRole = Master
+  , nodeSlotsServed = [healthyRange]
+  , nodeReplicas = []
+  }
+
+stoppedNode :: ClusterNode
+stoppedNode = ClusterNode
+  { nodeId = "stopped"
+  , nodeAddress = NodeAddress "redis3.local" 6381
+  , nodeRole = Master
+  , nodeSlotsServed = [stoppedRange]
+  , nodeReplicas = []
+  }
+
+otherNode :: ClusterNode
+otherNode = ClusterNode
+  { nodeId = "other"
+  , nodeAddress = NodeAddress "redis5.local" 6383
+  , nodeRole = Master
+  , nodeSlotsServed = [SlotRange 10001 16383 "other" []]
+  , nodeReplicas = []
+  }
+
+fixtureTopology :: ClusterTopology
+fixtureTopology = ClusterTopology
+  { topologySlots = V.generate 16384 slotOwner
+  , topologyAddresses = V.generate 16384 slotAddress
+  , topologyNodes = Map.fromList
+      [ ("stopped", stoppedNode)
+      , ("other", otherNode)
+      , ("healthy", healthyNode)
+      ]
+  , topologyUpdateTime = posixSecondsToUTCTime 0
+  }
+  where
+    slotOwner slot
+      | slot <= 5000 = "healthy"
+      | slot <= 10000 = "stopped"
+      | otherwise = "other"
+    slotAddress slot
+      | slot <= 5000 = nodeAddress healthyNode
+      | slot <= 10000 = nodeAddress stoppedNode
+      | otherwise = nodeAddress otherNode
+
+inRange :: SlotRange -> Word16 -> Bool
+inRange range slot =
+  slot >= slotStart range && slot <= slotEnd range


### PR DESCRIPTION
## Summary
- derive stopped and healthy masters from the discovered cluster topology instead of arbitrary keys
- validate Docker container/address mapping, slot ranges, routing-vector ownership, and the fixture's no-replica precondition
- require exact bounded outage failures, healthy-master round trips, explicit refresh, and same-key recovery
- replace permissive concurrency counters and ignored refresh results with exact assertions

## Mapping and key design
- fixture node numbers resolve to their configured container and advertised `redisN.local:port`
- the advertised address must identify exactly one master with owned slots and no replicas
- every declared slot range is checked against `topologySlots`
- binary-safe candidate keys are searched with a fixed bound and revalidated through `findNodeAddressForSlot`
- a separate healthy master is selected deterministically by advertised address

## Assertion contract
- before outage: exact SET/GET round trips on stopped-node and healthy-node keys
- during outage: stopped-node commands must finish within 10 seconds with `MaxRetriesExceeded`; healthy-node SET/GET must succeed within 10 seconds
- retry configuration performs the initial attempt plus one retry with a one-second connection deadline
- after lifecycle readiness: explicit topology refresh and exact SET/GET on the same stopped-node key
- concurrency: exactly one expected stopped-slot exhaustion, four healthy round trips, and zero unexpected outcomes
- refresh concurrency: all 10 refreshes and all 2,450 commands must succeed

## Validation
- `NodeTargetingSpec`: 6 examples, 0 failures
- targeted real-Docker sequence: 8 examples across lifecycle, resilience, topology, and concurrency; 0 failures
- `nix-build --no-out-link`
- `make test`, including LibraryE2E: 47 examples, 0 failures

No profiling was run because this patch changes test selection and assertions rather than runtime client behavior.

Closes #49
