### PR TITLE
Fix smart-proxy Redis key-spec routing

### DIFF
--- a/app/ClusterTunnel.hs
+++ b/app/ClusterTunnel.hs
@@ -8,49 +8,54 @@ module ClusterTunnel
   , rewriteClusterResponse
   ) where
 
-import           Control.Concurrent              (MVar, forkIO, newEmptyMVar,
-                                                  putMVar, takeMVar)
-import           Control.Concurrent.STM          (readTVarIO)
-import           Control.Exception               (SomeException, bracket,
-                                                  finally, throwIO, try)
-import           Control.Monad                   (forever, void, when)
-import qualified Control.Monad.State.Strict      as State
-import qualified Data.ByteString                 as BS
-import qualified Data.ByteString.Builder         as Builder
-import qualified Data.ByteString.Char8           as BS8
-import qualified Data.ByteString.Lazy            as LBS
-import           Data.Char                       (isAlphaNum)
-import           Data.List                       (isPrefixOf)
-import qualified Data.Map.Strict                 as Map
-import           Data.Word                       (Word8)
-import           Database.Redis.Client           (Client (..),
-                                                  ConnectionStatus (..))
-import           Database.Redis.Cluster          (ClusterNode (..),
-                                                  ClusterTopology (..),
-                                                  NodeAddress (..),
-                                                  NodeRole (..))
-import           Database.Redis.Cluster.Client   (ClusterClient (..),
-                                                  ClusterError (..))
-import qualified Database.Redis.Cluster.Client   as ClusterCommandClient
-import           Database.Redis.Cluster.Commands (CommandRouting (..),
-                                                  classifyCommand)
-import           Database.Redis.Command          (ClientState (..),
-                                                  RedisCommandClient, parseWith)
-import           Database.Redis.Connector        (Connector)
-import           Database.Redis.Resp             (Encodable (encode),
-                                                  RespData (..))
-import qualified Database.Redis.Resp             as Resp
-import           Network.Socket                  (Family (..), SockAddr (..),
-                                                  Socket, SocketOption (..),
-                                                  SocketType (..), bind,
-                                                  defaultProtocol, listen,
-                                                  setSocketOption, socket,
-                                                  tupleToHostAddress)
-import qualified Network.Socket                  as S
-import           Network.Socket.ByteString       (recv, sendAll)
-import           System.IO                       (BufferMode (LineBuffering),
-                                                  hFlush, hSetBuffering, stdout)
-import           Text.Printf                     (printf)
+import           Control.Concurrent                    (MVar, forkIO,
+                                                        newEmptyMVar, putMVar,
+                                                        takeMVar)
+import           Control.Concurrent.STM                (readTVarIO)
+import           Control.Exception                     (SomeException, bracket,
+                                                        finally, throwIO, try)
+import           Control.Monad                         (forever, void, when)
+import qualified Control.Monad.State.Strict            as State
+import qualified Data.ByteString                       as BS
+import qualified Data.ByteString.Builder               as Builder
+import qualified Data.ByteString.Char8                 as BS8
+import qualified Data.ByteString.Lazy                  as LBS
+import           Data.Char                             (isAlphaNum)
+import           Data.List                             (isPrefixOf)
+import qualified Data.Map.Strict                       as Map
+import           Data.Word                             (Word8)
+import           Database.Redis.Client                 (Client (..),
+                                                        ConnectionStatus (..))
+import           Database.Redis.Cluster                (ClusterNode (..),
+                                                        ClusterTopology (..),
+                                                        NodeAddress (..),
+                                                        NodeRole (..),
+                                                        calculateSlot,
+                                                        findNodeAddressForSlot)
+import           Database.Redis.Cluster.Client         (ClusterClient (..))
+import qualified Database.Redis.Cluster.Client         as ClusterCommandClient
+import           Database.Redis.Cluster.Commands       (keyArgumentsFromResp)
+import           Database.Redis.Command                (ClientState (..),
+                                                        RedisCommandClient,
+                                                        parseWith)
+import           Database.Redis.Connector              (Connector)
+import           Database.Redis.Internal.MultiplexPool (submitToNode)
+import           Database.Redis.Resp                   (Encodable (encode),
+                                                        RespData (..))
+import qualified Database.Redis.Resp                   as Resp
+import           Network.Socket                        (Family (..),
+                                                        SockAddr (..), Socket,
+                                                        SocketOption (..),
+                                                        SocketType (..), bind,
+                                                        defaultProtocol, listen,
+                                                        setSocketOption, socket,
+                                                        tupleToHostAddress)
+import qualified Network.Socket                        as S
+import           Network.Socket.ByteString             (recv, sendAll)
+import           System.IO                             (BufferMode (LineBuffering),
+                                                        hFlush, hSetBuffering,
+                                                        stdout)
+import           Text.Printf                           (printf)
 
 -- | Smart proxy mode: Makes cluster appear as single Redis instance
 -- Creates single listening socket and routes commands to appropriate nodes
@@ -103,11 +108,12 @@ handleSmartProxyClient clusterClient clientSock = do
               loop
             Right respData -> do
               -- Route and execute the command
-              result <- routeSmartProxyCommand clusterClient respData
+              result <- routeSmartProxyCommand clusterClient respData dat
               case result of
                 Left err -> do
                   printf "Command execution error: %s\n" err
-                  let errorResp = RespError (BS8.pack $ "ERR " ++ err)
+                  let errorResp = RespError (BS8.pack $
+                        if "CROSSSLOT " `isPrefixOf` err then err else "ERR " ++ err)
                   sendAll clientSock (LBS.toStrict $ Builder.toLazyByteString $ encode errorResp)
                 Right response -> do
                   -- Send response back to client
@@ -118,15 +124,19 @@ handleSmartProxyClient clusterClient clientSock = do
 routeSmartProxyCommand :: (Client client) =>
   ClusterClient client ->
   RespData ->
+  BS.ByteString ->
   IO (Either String RespData)
-routeSmartProxyCommand clusterClient respData = do
+routeSmartProxyCommand clusterClient respData rawFrame = do
   case respData of
-    RespArray (RespBulkString cmd : args) -> do
-      let argKeys = [k | RespBulkString k <- args]
-      case classifyCommand cmd argKeys of
-        KeylessRoute   -> executeKeylessCommand clusterClient respData
-        KeyedRoute key -> executeKeyedCommand clusterClient key (cmd : argKeys)
-        CommandError e -> return $ Left e
+    RespArray (RespBulkString cmd : args) ->
+      case keyArgumentsFromResp cmd args of
+        Left err -> return $ Left err
+        Right (key:keys)
+          | all ((== calculateSlot key) . calculateSlot) keys ->
+              executeKeyedCommand clusterClient key rawFrame
+          | otherwise ->
+              return $ Left "CROSSSLOT Keys in request don't hash to the same slot"
+        Right [] -> executeKeylessCommand clusterClient respData
     _ -> return $ Left "Expected array command"
 
 -- | Execute a keyless command (route to any master)
@@ -146,17 +156,16 @@ executeKeylessCommand clusterClient respData = do
 executeKeyedCommand :: (Client client) =>
   ClusterClient client ->
   BS.ByteString ->
-  [BS.ByteString] ->
+  BS.ByteString ->
   IO (Either String RespData)
-executeKeyedCommand clusterClient key cmdArgs = do
-  result <- ClusterCommandClient.executeKeyedClusterCommand
-              clusterClient
-              key
-              cmdArgs
-  return $ case result of
-    Left (CrossSlotError msg) -> Left $ "CROSSSLOT error: " ++ msg
-    Left err                  -> Left (show err)
-    Right resp                -> Right resp
+executeKeyedCommand clusterClient key rawFrame = do
+  topology <- readTVarIO (clusterTopology clusterClient)
+  case findNodeAddressForSlot topology (calculateSlot key) of
+    Nothing -> return $ Left "no cluster node owns the command key slot"
+    Just address -> Right <$> submitToNode
+      (clusterMultiplexPool clusterClient)
+      address
+      (Builder.byteString rawFrame)
 
 -- | Send RESP command via RedisCommandClient
 sendRespCommand :: (Client client) => RespData -> RedisCommandClient client RespData

--- a/app/ClusterTunnel.hs
+++ b/app/ClusterTunnel.hs
@@ -6,56 +6,50 @@ module ClusterTunnel
   ( serveSmartProxy
   , servePinnedProxy
   , rewriteClusterResponse
+  , routeSmartProxyCommand
   ) where
 
-import           Control.Concurrent                    (MVar, forkIO,
-                                                        newEmptyMVar, putMVar,
-                                                        takeMVar)
-import           Control.Concurrent.STM                (readTVarIO)
-import           Control.Exception                     (SomeException, bracket,
-                                                        finally, throwIO, try)
-import           Control.Monad                         (forever, void, when)
-import qualified Control.Monad.State.Strict            as State
-import qualified Data.ByteString                       as BS
-import qualified Data.ByteString.Builder               as Builder
-import qualified Data.ByteString.Char8                 as BS8
-import qualified Data.ByteString.Lazy                  as LBS
-import           Data.Char                             (isAlphaNum)
-import           Data.List                             (isPrefixOf)
-import qualified Data.Map.Strict                       as Map
-import           Data.Word                             (Word8)
-import           Database.Redis.Client                 (Client (..),
-                                                        ConnectionStatus (..))
-import           Database.Redis.Cluster                (ClusterNode (..),
-                                                        ClusterTopology (..),
-                                                        NodeAddress (..),
-                                                        NodeRole (..),
-                                                        calculateSlot,
-                                                        findNodeAddressForSlot)
-import           Database.Redis.Cluster.Client         (ClusterClient (..))
-import qualified Database.Redis.Cluster.Client         as ClusterCommandClient
-import           Database.Redis.Cluster.Commands       (keyArgumentsFromResp)
-import           Database.Redis.Command                (ClientState (..),
-                                                        RedisCommandClient,
-                                                        parseWith)
-import           Database.Redis.Connector              (Connector)
-import           Database.Redis.Internal.MultiplexPool (submitToNode)
-import           Database.Redis.Resp                   (Encodable (encode),
-                                                        RespData (..))
-import qualified Database.Redis.Resp                   as Resp
-import           Network.Socket                        (Family (..),
-                                                        SockAddr (..), Socket,
-                                                        SocketOption (..),
-                                                        SocketType (..), bind,
-                                                        defaultProtocol, listen,
-                                                        setSocketOption, socket,
-                                                        tupleToHostAddress)
-import qualified Network.Socket                        as S
-import           Network.Socket.ByteString             (recv, sendAll)
-import           System.IO                             (BufferMode (LineBuffering),
-                                                        hFlush, hSetBuffering,
-                                                        stdout)
-import           Text.Printf                           (printf)
+import           Control.Concurrent              (MVar, forkIO, newEmptyMVar,
+                                                  putMVar, takeMVar)
+import           Control.Concurrent.STM          (readTVarIO)
+import           Control.Exception               (SomeException, bracket,
+                                                  finally, throwIO, try)
+import           Control.Monad                   (forever, void, when)
+import qualified Control.Monad.State.Strict      as State
+import qualified Data.ByteString                 as BS
+import qualified Data.ByteString.Builder         as Builder
+import qualified Data.ByteString.Char8           as BS8
+import qualified Data.ByteString.Lazy            as LBS
+import           Data.Char                       (isAlphaNum)
+import           Data.List                       (isPrefixOf)
+import qualified Data.Map.Strict                 as Map
+import           Data.Word                       (Word8)
+import           Database.Redis.Client           (Client (..),
+                                                  ConnectionStatus (..))
+import           Database.Redis.Cluster          (ClusterNode (..),
+                                                  ClusterTopology (..),
+                                                  NodeAddress (..),
+                                                  NodeRole (..), calculateSlot)
+import           Database.Redis.Cluster.Client   (ClusterClient (..))
+import qualified Database.Redis.Cluster.Client   as ClusterCommandClient
+import           Database.Redis.Cluster.Commands (keyArgumentsFromResp)
+import           Database.Redis.Command          (ClientState (..),
+                                                  RedisCommandClient, parseWith)
+import           Database.Redis.Connector        (Connector)
+import           Database.Redis.Resp             (Encodable (encode),
+                                                  RespData (..))
+import qualified Database.Redis.Resp             as Resp
+import           Network.Socket                  (Family (..), SockAddr (..),
+                                                  Socket, SocketOption (..),
+                                                  SocketType (..), bind,
+                                                  defaultProtocol, listen,
+                                                  setSocketOption, socket,
+                                                  tupleToHostAddress)
+import qualified Network.Socket                  as S
+import           Network.Socket.ByteString       (recv, sendAll)
+import           System.IO                       (BufferMode (LineBuffering),
+                                                  hFlush, hSetBuffering, stdout)
+import           Text.Printf                     (printf)
 
 -- | Smart proxy mode: Makes cluster appear as single Redis instance
 -- Creates single listening socket and routes commands to appropriate nodes
@@ -159,13 +153,11 @@ executeKeyedCommand :: (Client client) =>
   BS.ByteString ->
   IO (Either String RespData)
 executeKeyedCommand clusterClient key rawFrame = do
-  topology <- readTVarIO (clusterTopology clusterClient)
-  case findNodeAddressForSlot topology (calculateSlot key) of
-    Nothing -> return $ Left "no cluster node owns the command key slot"
-    Just address -> Right <$> submitToNode
-      (clusterMultiplexPool clusterClient)
-      address
-      (Builder.byteString rawFrame)
+  result <- ClusterCommandClient.executeKeyedClusterCommandBuilder
+    clusterClient key (Builder.byteString rawFrame)
+  return $ case result of
+    Left err   -> Left (show err)
+    Right resp -> Right resp
 
 -- | Send RESP command via RedisCommandClient
 sendRespCommand :: (Client client) => RespData -> RedisCommandClient client RespData

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
@@ -62,6 +62,7 @@ module Database.Redis.Cluster.Client
     -- proxying. Prefer 'runClusterCommandClient' with 'RedisCommands' for
     -- normal Redis operations.
     executeKeyedClusterCommand,
+    executeKeyedClusterCommandBuilder,
     executeKeyedClusterCommandUsingDelay,
     executeKeylessClusterCommand,
     executeKeylessClusterCommandUsingDelay,
@@ -1064,7 +1065,20 @@ executeKeyedClusterCommand ::
   [ByteString] ->         -- command args
   IO (Either ClusterError RespData)
 executeKeyedClusterCommand =
-  executeKeyedClusterCommandUsingDelay threadDelay
+  \client key cmdArgs ->
+    executeKeyedClusterCommandBuilder client key (encodeCommandBuilder cmdArgs)
+
+-- | Execute a keyed command whose complete RESP frame has already been encoded.
+-- This retains the normal keyed cluster redirect, retry, and transport-error
+-- handling while allowing a proxy to preserve the client's frame verbatim.
+executeKeyedClusterCommandBuilder ::
+  (Client client) =>
+  ClusterClient client ->
+  ByteString ->
+  Builder.Builder ->
+  IO (Either ClusterError RespData)
+executeKeyedClusterCommandBuilder =
+  executeKeyedClusterCommandBuilderUsingDelay threadDelay
 
 -- | Test seam for deterministic retry schedule and cancellation coverage.
 executeKeyedClusterCommandUsingDelay ::
@@ -1075,8 +1089,18 @@ executeKeyedClusterCommandUsingDelay ::
   [ByteString] ->
   IO (Either ClusterError RespData)
 executeKeyedClusterCommandUsingDelay delayAction client key cmdArgs = do
+  executeKeyedClusterCommandBuilderUsingDelay delayAction client key
+    (encodeCommandBuilder cmdArgs)
+
+executeKeyedClusterCommandBuilderUsingDelay ::
+  (Client client) =>
+  (Int -> IO ()) ->
+  ClusterClient client ->
+  ByteString ->
+  Builder.Builder ->
+  IO (Either ClusterError RespData)
+executeKeyedClusterCommandBuilderUsingDelay delayAction client key cmdBuilder = do
   let muxPool = clusterMultiplexPool client
-      cmdBuilder = encodeCommandBuilder cmdArgs
       !slot = calculateSlot key
   withRetryAndRefreshUsing delayAction
     client

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Checked-in Redis command key specifications used by cluster callers.
+--
+-- Source: Redis command reference, Redis Open Source 7.2 command syntax
+-- (<https://redis.io/commands/>), reviewed 2026-09-04.  Update this table
+-- when supporting a newer Redis release or a command's key specification
+-- changes; add focused extraction and malformed-count regression tests first.
 module Database.Redis.Cluster.Commands
   ( keylessCommands
   , requiresKeyCommands
@@ -58,6 +63,11 @@ keyArgumentsWith cmd args =
     "FCALL_RO"   -> evalKeys
     "XREAD"      -> streamKeys
     "XREADGROUP" -> streamKeys
+    "MEMORY"     -> memoryKeys
+    "RENAME"     -> exactly 2
+    "RENAMENX"   -> exactly 2
+    "COPY"       -> exactly 2
+    "XINFO"      -> xinfoKeys
     "ZUNIONSTORE"   -> destinationAndCount 1
     "ZINTERSTORE"   -> destinationAndCount 1
     "ZDIFFSTORE"    -> destinationAndCount 1
@@ -69,6 +79,9 @@ keyArgumentsWith cmd args =
     "BITOP"         -> allFrom 1
     "PFMERGE"       -> allFrom 0
     "SINTERCARD"    -> countOnly 0
+    "ZUNION"        -> countOnly 0
+    "ZINTER"        -> countOnly 0
+    "ZDIFF"         -> countOnly 0
     "BZPOPMIN"      -> allButLast
     "BZPOPMAX"      -> allButLast
     "BLPOP"         -> allButLast
@@ -79,6 +92,11 @@ keyArgumentsWith cmd args =
       (Just key:_) -> Right [key]
       (Nothing:_)  -> Left "cluster key arguments must be bulk strings"
       []           -> Left $ "command " ++ BS8.unpack cmd ++ " requires a key argument"
+    exactly count =
+      let keys = take count args
+      in if length keys == count
+          then traverse requireKey keys
+          else Left $ "command " ++ BS8.unpack cmd ++ " requires key arguments"
 
     allFrom n =
       case drop n args of
@@ -93,7 +111,10 @@ keyArgumentsWith cmd args =
 
     countOnly offset = do
       count <- decimalAt offset
-      traverse requireKey (take count (drop (offset + 1) args))
+      keys <- traverse requireKey (take count (drop (offset + 1) args))
+      if length keys == count
+        then Right keys
+        else Left $ "command " ++ BS8.unpack cmd ++ " has fewer keys than its key count"
 
     destinationAndCount countOffset = do
       destination <- at 0
@@ -120,6 +141,17 @@ keyArgumentsWith cmd args =
     isStreams (Just value) = BS8.map toUpper value == "STREAMS"
     isStreams Nothing      = False
 
+    memoryKeys = case args of
+      (Just subcommand : key : _)
+        | BS8.map toUpper subcommand == "USAGE" -> traverse requireKey [key]
+      _ -> Right []
+
+    xinfoKeys = case args of
+      (Just subcommand : key : _)
+        | BS8.map toUpper subcommand `elem` ["STREAM", "GROUPS", "CONSUMERS"] ->
+            traverse requireKey [key]
+      _ -> Right []
+
     decimalAt n = case drop n args of
       (Just value:_) -> case BS8.readInt value of
         Just (count, "") | count >= 0 -> Right count
@@ -129,7 +161,7 @@ keyArgumentsWith cmd args =
 keylessCommands :: [ByteString]
 keylessCommands =
   [ "PING", "ECHO", "AUTH", "HELLO", "QUIT", "SELECT", "RESET"
-  , "INFO", "TIME", "ROLE", "LASTSAVE", "DBSIZE", "MEMORY", "LATENCY"
+  , "INFO", "TIME", "ROLE", "LASTSAVE", "DBSIZE", "LATENCY"
   , "CLIENT", "CONFIG", "COMMAND", "CLUSTER", "ACL", "SLOWLOG"
   , "BGSAVE", "BGREWRITEAOF", "SAVE", "SHUTDOWN", "REPLICAOF", "SLAVEOF"
   , "FLUSHALL", "FLUSHDB", "PUBSUB", "MONITOR", "SCRIPT", "FUNCTION"
@@ -144,7 +176,7 @@ firstKeyCommands =
   [ "GET", "SET", "SETNX", "SETEX", "PSETEX", "GETEX", "GETDEL", "APPEND"
   , "STRLEN", "GETRANGE", "SETRANGE", "INCR", "INCRBY", "INCRBYFLOAT"
   , "DECR", "DECRBY", "EXPIRE", "PEXPIRE", "EXPIREAT", "PEXPIREAT"
-  , "TTL", "PTTL", "PERSIST", "TYPE", "RENAME", "RENAMENX", "COPY"
+  , "TTL", "PTTL", "PERSIST", "TYPE"
   , "HGET", "HSET", "HDEL", "HGETALL", "HKEYS", "HVALS", "HEXISTS"
   , "HLEN", "HINCRBY", "HINCRBYFLOAT", "HMGET", "HMSET", "HRANDFIELD"
   , "LPUSH", "RPUSH", "LPOP", "RPOP", "LLEN", "LINDEX", "LRANGE", "LTRIM"
@@ -153,7 +185,7 @@ firstKeyCommands =
   , "ZRANGE", "ZREVRANGE", "ZRANK", "ZREVRANK", "ZSCORE", "ZCARD"
   , "ZCOUNT", "ZLEXCOUNT", "ZRANDMEMBER", "ZINCRBY", "XADD", "XLEN"
   , "XRANGE", "XREVRANGE", "XDEL", "XTRIM", "XACK", "XPENDING", "XCLAIM"
-  , "XAUTOCLAIM", "XINFO", "GEOADD", "GEOPOS", "GEODIST", "GEOHASH"
+  , "XAUTOCLAIM", "GEOADD", "GEOPOS", "GEODIST", "GEOHASH"
   , "GEORADIUS", "GEORADIUSBYMEMBER", "BITCOUNT", "GETBIT", "SETBIT"
   , "BITFIELD", "BITFIELD_RO", "PFADD", "PFCOUNT", "DUMP", "RESTORE"
   , "OBJECT", "TOUCH", "UNLINK", "WATCH"
@@ -162,5 +194,5 @@ firstKeyCommands =
 allKeyCommands :: [ByteString]
 allKeyCommands =
   [ "DEL", "EXISTS", "MGET", "SUNION", "SINTER", "SDIFF", "SINTERSTORE"
-  , "SUNIONSTORE", "SDIFFSTORE", "ZUNION", "ZINTER", "ZDIFF"
+  , "SUNIONSTORE", "SDIFFSTORE"
   ]

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands.hs
@@ -1,119 +1,166 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Shared command classification for cluster routing
--- This module provides lists of Redis commands categorized by their routing requirements
---
--- @since 0.1.0.0
+-- | Checked-in Redis command key specifications used by cluster callers.
 module Database.Redis.Cluster.Commands
-  ( keylessCommands,
-    requiresKeyCommands,
-    CommandRouting (..),
-    classifyCommand,
-  )
-where
+  ( keylessCommands
+  , requiresKeyCommands
+  , CommandRouting (..)
+  , classifyCommand
+  , keyArguments
+  , keyArgumentsFromResp
+  ) where
 
 import           Data.ByteString       (ByteString)
 import qualified Data.ByteString.Char8 as BS8
 import           Data.Char             (toUpper)
+import           Database.Redis.Resp   (RespData (..))
 
--- | Result of classifying a command for cluster routing
 data CommandRouting
-  = KeylessRoute        -- ^ Route to any master node
-  | KeyedRoute ByteString  -- ^ Route by this key's hash slot
-  | CommandError String    -- ^ Invalid command (e.g., missing required key)
+  = KeylessRoute
+  | KeyedRoute ByteString
+  | CommandError String
+  deriving (Eq, Show)
 
--- | Classify a Redis command for cluster routing.
--- Returns 'KeylessRoute' for commands like PING or AUTH that can go to any master,
--- 'KeyedRoute' with the routing key for commands that target a specific slot,
--- or 'CommandError' if a key-requiring command is missing its key argument.
+-- | Compatibility classification for callers which route only one key.
 classifyCommand :: ByteString -> [ByteString] -> CommandRouting
 classifyCommand cmd args =
-  let cmdUpper = BS8.map toUpper cmd
-  in if cmdUpper `elem` keylessCommands
-     then KeylessRoute
-     else case args of
-       [] -> if cmdUpper `elem` requiresKeyCommands
-               then CommandError $ "Command " ++ BS8.unpack cmd ++ " requires a key argument"
-               else KeylessRoute  -- Unknown command without args, try keyless
-       (key:_) -> KeyedRoute key
+  case keyArguments cmd args of
+    Left err      -> CommandError err
+    Right []      -> KeylessRoute
+    Right (key:_) -> KeyedRoute key
 
--- | Commands that don't require a key argument (route to any master node)
--- These commands can be executed on any master node in the cluster
--- Note: This list is based on Redis 7.x commands and may need updates for newer versions
--- See CLUSTERING_IMPLEMENTATION_PLAN.md Phase 17 for future work on eliminating this hardcoded list
+-- | Extract every key from a command's bulk-string arguments.  Unknown
+-- commands deliberately fail closed: routing an unrecognised command by its
+-- first argument is not safe in a cluster.
+keyArguments :: ByteString -> [ByteString] -> Either String [ByteString]
+keyArguments cmd args = keyArgumentsWith cmd (map Just args)
+
+-- | RESP-aware version of 'keyArguments'.  Non-key RESP values are allowed so
+-- the tunnel can forward the original frame byte-for-byte; a value used as a
+-- key must be a bulk string.
+keyArgumentsFromResp :: ByteString -> [RespData] -> Either String [ByteString]
+keyArgumentsFromResp cmd = keyArgumentsWith cmd . map asBulk
+  where
+    asBulk (RespBulkString value) = Just value
+    asBulk _                      = Nothing
+
+keyArgumentsWith :: ByteString -> [Maybe ByteString] -> Either String [ByteString]
+keyArgumentsWith cmd args =
+  case BS8.map toUpper cmd of
+    command | command `elem` keylessCommands -> Right []
+    command | command `elem` firstKeyCommands -> at 0
+    command | command `elem` allKeyCommands -> allFrom 0
+    "MSET"       -> everyOther 0
+    "MSETNX"     -> everyOther 0
+    "EVAL"       -> evalKeys
+    "EVALSHA"    -> evalKeys
+    "FCALL"      -> evalKeys
+    "FCALL_RO"   -> evalKeys
+    "XREAD"      -> streamKeys
+    "XREADGROUP" -> streamKeys
+    "ZUNIONSTORE"   -> destinationAndCount 1
+    "ZINTERSTORE"   -> destinationAndCount 1
+    "ZDIFFSTORE"    -> destinationAndCount 1
+    "ZINTERCARD"    -> countOnly 0
+    "LMPOP"         -> countOnly 0
+    "BLMPOP"        -> countOnly 1
+    "ZMPOP"         -> countOnly 0
+    "BZMPOP"        -> countOnly 1
+    "BITOP"         -> allFrom 1
+    "PFMERGE"       -> allFrom 0
+    "SINTERCARD"    -> countOnly 0
+    "BZPOPMIN"      -> allButLast
+    "BZPOPMAX"      -> allButLast
+    "BLPOP"         -> allButLast
+    "BRPOP"         -> allButLast
+    _             -> Left $ "unsupported command for cluster routing: " ++ BS8.unpack cmd
+  where
+    at n = case drop n args of
+      (Just key:_) -> Right [key]
+      (Nothing:_)  -> Left "cluster key arguments must be bulk strings"
+      []           -> Left $ "command " ++ BS8.unpack cmd ++ " requires a key argument"
+
+    allFrom n =
+      case drop n args of
+        []   -> Left $ "command " ++ BS8.unpack cmd ++ " requires a key argument"
+        keys -> traverse requireKey keys
+    everyOther n = traverse requireKey [value | (index, value) <- zip [0 :: Int ..] args, index >= n, even (index - n)]
+    allButLast
+      | null args  = Left $ "command " ++ BS8.unpack cmd ++ " requires a key argument"
+      | otherwise  = traverse requireKey (init args)
+    requireKey (Just key) = Right key
+    requireKey Nothing    = Left "cluster key arguments must be bulk strings"
+
+    countOnly offset = do
+      count <- decimalAt offset
+      traverse requireKey (take count (drop (offset + 1) args))
+
+    destinationAndCount countOffset = do
+      destination <- at 0
+      count <- decimalAt countOffset
+      sources <- traverse requireKey (take count (drop (countOffset + 1) args))
+      if length sources == count
+        then Right (destination ++ sources)
+        else Left $ "command " ++ BS8.unpack cmd ++ " has fewer keys than its key count"
+
+    evalKeys = do
+      count <- decimalAt 1
+      keys <- traverse requireKey (take count (drop 2 args))
+      if length keys == count
+        then Right keys
+        else Left $ "command " ++ BS8.unpack cmd ++ " has fewer keys than its key count"
+
+    streamKeys =
+      case break isStreams args of
+        (_, []) -> Left $ "command " ++ BS8.unpack cmd ++ " requires a STREAMS key list"
+        (_, _:streamArgs)
+          | null streamArgs || odd (length streamArgs) ->
+              Left $ "command " ++ BS8.unpack cmd ++ " requires matching stream keys and IDs"
+          | otherwise -> traverse requireKey (take (length streamArgs `div` 2) streamArgs)
+    isStreams (Just value) = BS8.map toUpper value == "STREAMS"
+    isStreams Nothing      = False
+
+    decimalAt n = case drop n args of
+      (Just value:_) -> case BS8.readInt value of
+        Just (count, "") | count >= 0 -> Right count
+        _ -> Left $ "command " ++ BS8.unpack cmd ++ " has an invalid key count"
+      _ -> Left $ "command " ++ BS8.unpack cmd ++ " requires a key count"
+
 keylessCommands :: [ByteString]
 keylessCommands =
-  [ "PING",
-    "AUTH",
-    "FLUSHALL",
-    "FLUSHDB",
-    "DBSIZE",
-    "CLUSTER",
-    "INFO",
-    "TIME",
-    "CLIENT",
-    "CONFIG",
-    "BGREWRITEAOF",
-    "BGSAVE",
-    "SAVE",
-    "LASTSAVE",
-    "SHUTDOWN",
-    "SLAVEOF",
-    "REPLICAOF",
-    "ROLE",
-    "ECHO",
-    "SELECT",
-    "QUIT",
-    "COMMAND"
+  [ "PING", "ECHO", "AUTH", "HELLO", "QUIT", "SELECT", "RESET"
+  , "INFO", "TIME", "ROLE", "LASTSAVE", "DBSIZE", "MEMORY", "LATENCY"
+  , "CLIENT", "CONFIG", "COMMAND", "CLUSTER", "ACL", "SLOWLOG"
+  , "BGSAVE", "BGREWRITEAOF", "SAVE", "SHUTDOWN", "REPLICAOF", "SLAVEOF"
+  , "FLUSHALL", "FLUSHDB", "PUBSUB", "MONITOR", "SCRIPT", "FUNCTION"
   ]
 
--- | Commands that require a key argument (route by key's hash slot)
--- These commands must be routed to the node responsible for the key's hash slot
--- Note: This list is based on Redis 7.x commands and may need updates for newer versions
--- See CLUSTERING_IMPLEMENTATION_PLAN.md Phase 17 for future work on eliminating this hardcoded list
+-- Kept exported for existing users; this is the fixed-first-key subset.
 requiresKeyCommands :: [ByteString]
-requiresKeyCommands =
-  [ "GET",
-    "SET",
-    "DEL",
-    "EXISTS",
-    "INCR",
-    "DECR",
-    "HGET",
-    "HSET",
-    "HDEL",
-    "HKEYS",
-    "HVALS",
-    "HGETALL",
-    "HEXISTS",
-    "LPUSH",
-    "RPUSH",
-    "LPOP",
-    "RPOP",
-    "LRANGE",
-    "LLEN",
-    "LINDEX",
-    "SADD",
-    "SREM",
-    "SMEMBERS",
-    "SCARD",
-    "SISMEMBER",
-    "ZADD",
-    "ZREM",
-    "ZRANGE",
-    "ZCARD",
-    "EXPIRE",
-    "TTL",
-    "PERSIST",
-    "MGET",
-    "MSET",
-    "SETNX",
-    "PSETEX",
-    "APPEND",
-    "GETRANGE",
-    "SETRANGE",
-    "STRLEN",
-    "GETEX",
-    "GETDEL",
-    "SETEX"
+requiresKeyCommands = firstKeyCommands
+
+firstKeyCommands :: [ByteString]
+firstKeyCommands =
+  [ "GET", "SET", "SETNX", "SETEX", "PSETEX", "GETEX", "GETDEL", "APPEND"
+  , "STRLEN", "GETRANGE", "SETRANGE", "INCR", "INCRBY", "INCRBYFLOAT"
+  , "DECR", "DECRBY", "EXPIRE", "PEXPIRE", "EXPIREAT", "PEXPIREAT"
+  , "TTL", "PTTL", "PERSIST", "TYPE", "RENAME", "RENAMENX", "COPY"
+  , "HGET", "HSET", "HDEL", "HGETALL", "HKEYS", "HVALS", "HEXISTS"
+  , "HLEN", "HINCRBY", "HINCRBYFLOAT", "HMGET", "HMSET", "HRANDFIELD"
+  , "LPUSH", "RPUSH", "LPOP", "RPOP", "LLEN", "LINDEX", "LRANGE", "LTRIM"
+  , "LSET", "LREM", "LPOS", "SADD", "SREM", "SMEMBERS", "SCARD"
+  , "SISMEMBER", "SMISMEMBER", "SRANDMEMBER", "SPOP", "ZADD", "ZREM"
+  , "ZRANGE", "ZREVRANGE", "ZRANK", "ZREVRANK", "ZSCORE", "ZCARD"
+  , "ZCOUNT", "ZLEXCOUNT", "ZRANDMEMBER", "ZINCRBY", "XADD", "XLEN"
+  , "XRANGE", "XREVRANGE", "XDEL", "XTRIM", "XACK", "XPENDING", "XCLAIM"
+  , "XAUTOCLAIM", "XINFO", "GEOADD", "GEOPOS", "GEODIST", "GEOHASH"
+  , "GEORADIUS", "GEORADIUSBYMEMBER", "BITCOUNT", "GETBIT", "SETBIT"
+  , "BITFIELD", "BITFIELD_RO", "PFADD", "PFCOUNT", "DUMP", "RESTORE"
+  , "OBJECT", "TOUCH", "UNLINK", "WATCH"
+  ]
+
+allKeyCommands :: [ByteString]
+allKeyCommands =
+  [ "DEL", "EXISTS", "MGET", "SUNION", "SINTER", "SDIFF", "SINTERSTORE"
+  , "SUNIONSTORE", "SDIFFSTORE", "ZUNION", "ZINTER", "ZDIFF"
   ]

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands.hs
@@ -2,10 +2,24 @@
 
 -- | Checked-in Redis command key specifications used by cluster callers.
 --
--- Source: Redis command reference, Redis Open Source 7.2 command syntax
--- (<https://redis.io/commands/>), reviewed 2026-09-04.  Update this table
--- when supporting a newer Redis release or a command's key specification
--- changes; add focused extraction and malformed-count regression tests first.
+-- The authoritative source is Redis Open Source @7.2.12@
+-- (@9913c926510755fa0d241658f550338a02258edb@), specifically the
+-- machine-readable @src/commands/*.json@ metadata in
+-- <https://github.com/redis/redis/tree/7.2.12/src/commands>.  Command
+-- containers (for example @MEMORY USAGE@) are described by their individual
+-- JSON files rather than their container's JSON file.
+--
+-- To audit an update reproducibly, extract the pinned tag with
+--
+-- @
+-- curl -L https://github.com/redis/redis/archive/refs/tags/7.2.12.tar.gz | tar -xz
+-- @
+--
+-- and compare every command below with its @key_specs@, @arity@, and (where
+-- applicable) container JSON.  The table-driven assertions in
+-- @ClusterTunnelSpec@ cover each routing form used here.  Unknown commands
+-- deliberately fail closed; adding a Redis command requires adding its
+-- authoritative metadata case and both valid and malformed test rows.
 module Database.Redis.Cluster.Commands
   ( keylessCommands
   , requiresKeyCommands
@@ -53,17 +67,20 @@ keyArgumentsWith :: ByteString -> [Maybe ByteString] -> Either String [ByteStrin
 keyArgumentsWith cmd args =
   case BS8.map toUpper cmd of
     command | command `elem` keylessCommands -> Right []
-    command | command `elem` firstKeyCommands -> at 0
-    command | command `elem` allKeyCommands -> allFrom 0
     "MSET"       -> everyOther 0
     "MSETNX"     -> everyOther 0
+    "OBJECT"     -> objectKeys
+    "MEMORY"     -> memoryKeys
+    command | command `elem` destinationAndSourceCommands -> allFromMinimum 0 2
+    command | command `elem` allKeyCommands -> allFrom 0
+    command | command `elem` firstKeyCommands -> at 0
+    command | command `elem` multiKeyCommands -> allFrom 0
     "EVAL"       -> evalKeys
     "EVALSHA"    -> evalKeys
     "FCALL"      -> evalKeys
     "FCALL_RO"   -> evalKeys
     "XREAD"      -> streamKeys
     "XREADGROUP" -> streamKeys
-    "MEMORY"     -> memoryKeys
     "RENAME"     -> exactly 2
     "RENAMENX"   -> exactly 2
     "COPY"       -> exactly 2
@@ -76,7 +93,7 @@ keyArgumentsWith cmd args =
     "BLMPOP"        -> countOnly 1
     "ZMPOP"         -> countOnly 0
     "BZMPOP"        -> countOnly 1
-    "BITOP"         -> allFrom 1
+    "BITOP"         -> allFromMinimum 1 2
     "PFMERGE"       -> allFrom 0
     "SINTERCARD"    -> countOnly 0
     "ZUNION"        -> countOnly 0
@@ -86,7 +103,9 @@ keyArgumentsWith cmd args =
     "BZPOPMAX"      -> allButLast
     "BLPOP"         -> allButLast
     "BRPOP"         -> allButLast
-    _             -> Left $ "unsupported command for cluster routing: " ++ BS8.unpack cmd
+    "GEORADIUS"       -> geoRadiusKeys
+    "GEORADIUSBYMEMBER" -> geoRadiusKeys
+    _                 -> Left $ "unsupported command for cluster routing: " ++ BS8.unpack cmd
   where
     at n = case drop n args of
       (Just key:_) -> Right [key]
@@ -102,15 +121,26 @@ keyArgumentsWith cmd args =
       case drop n args of
         []   -> Left $ "command " ++ BS8.unpack cmd ++ " requires a key argument"
         keys -> traverse requireKey keys
-    everyOther n = traverse requireKey [value | (index, value) <- zip [0 :: Int ..] args, index >= n, even (index - n)]
+    allFromMinimum n minimumKeys
+      | length (drop n args) < minimumKeys =
+          Left $ "command " ++ BS8.unpack cmd ++ " requires key arguments"
+      | otherwise = traverse requireKey (drop n args)
+    everyOther n
+      | length (drop n args) < 2 || odd (length (drop n args)) =
+          Left $ "command " ++ BS8.unpack cmd ++ " requires key-value pairs"
+      | otherwise =
+          traverse requireKey [value | (index, value) <- zip [0 :: Int ..] args, index >= n, even (index - n)]
     allButLast
-      | null args  = Left $ "command " ++ BS8.unpack cmd ++ " requires a key argument"
+      | length args < 2 = Left $ "command " ++ BS8.unpack cmd ++ " requires keys and a timeout"
       | otherwise  = traverse requireKey (init args)
     requireKey (Just key) = Right key
     requireKey Nothing    = Left "cluster key arguments must be bulk strings"
 
     countOnly offset = do
       count <- decimalAt offset
+      if count < 1
+        then Left $ "command " ++ BS8.unpack cmd ++ " requires a positive key count"
+        else Right ()
       keys <- traverse requireKey (take count (drop (offset + 1) args))
       if length keys == count
         then Right keys
@@ -119,6 +149,9 @@ keyArgumentsWith cmd args =
     destinationAndCount countOffset = do
       destination <- at 0
       count <- decimalAt countOffset
+      if count < 1
+        then Left $ "command " ++ BS8.unpack cmd ++ " requires a positive key count"
+        else Right ()
       sources <- traverse requireKey (take count (drop (countOffset + 1) args))
       if length sources == count
         then Right (destination ++ sources)
@@ -141,16 +174,76 @@ keyArgumentsWith cmd args =
     isStreams (Just value) = BS8.map toUpper value == "STREAMS"
     isStreams Nothing      = False
 
+    objectKeys = case args of
+      [Just subcommand]
+        | upper subcommand == "HELP" -> Right []
+      [Just subcommand, key]
+        | upper subcommand `elem` ["ENCODING", "FREQ", "IDLETIME", "REFCOUNT"] ->
+            traverse requireKey [key]
+      _ -> Left "command OBJECT has an invalid subcommand or arity"
+
     memoryKeys = case args of
-      (Just subcommand : key : _)
-        | BS8.map toUpper subcommand == "USAGE" -> traverse requireKey [key]
-      _ -> Right []
+      [Just subcommand]
+        | upper subcommand `elem` ["DOCTOR", "HELP", "MALLOC-STATS", "PURGE", "STATS"] ->
+            Right []
+      [Just subcommand, key]
+        | upper subcommand == "USAGE" -> traverse requireKey [key]
+      [Just subcommand, key, Just samples, Just count]
+        | upper subcommand == "USAGE" && upper samples == "SAMPLES" -> do
+            routedKey <- requireKey key
+            nonNegativeInteger count "MEMORY USAGE has an invalid sample count"
+            Right [routedKey]
+      _ -> Left "command MEMORY has an invalid subcommand or arity"
 
     xinfoKeys = case args of
-      (Just subcommand : key : _)
-        | BS8.map toUpper subcommand `elem` ["STREAM", "GROUPS", "CONSUMERS"] ->
+      [Just subcommand]
+        | upper subcommand == "HELP" -> Right []
+      (Just subcommand : key : rest)
+        | upper subcommand == "STREAM" -> do
+            routedKey <- requireKey key
+            xinfoStreamOptions rest
+            Right [routedKey]
+        | upper subcommand == "GROUPS" && null rest -> traverse requireKey [key]
+        | upper subcommand == "CONSUMERS" && length rest == 1 ->
             traverse requireKey [key]
-      _ -> Right []
+      _ -> Left "command XINFO has an invalid subcommand or arity"
+
+    xinfoStreamOptions [] = Right ()
+    xinfoStreamOptions [Just full]
+      | upper full == "FULL" = Right ()
+    xinfoStreamOptions [Just full, Just countKeyword, Just count]
+      | upper full == "FULL" && upper countKeyword == "COUNT" =
+          nonNegativeInteger count "XINFO STREAM has an invalid count"
+    xinfoStreamOptions _ = Left "command XINFO STREAM has an invalid option list"
+
+    geoRadiusKeys = do
+      source <- at 0
+      let requiredArguments =
+            if upper cmd == "GEORADIUS" then 5 else 4
+      if length args < requiredArguments
+        then Left $ "command " ++ BS8.unpack cmd ++ " requires location arguments"
+        else Right ()
+      let options = drop requiredArguments args
+      destinations <- geoDestinations options
+      Right (source ++ destinations)
+
+    geoDestinations [] = Right []
+    geoDestinations (Just option : destination : rest)
+      | upper option `elem` ["STORE", "STOREDIST"] = do
+          key <- requireKey destination
+          (key :) <$> geoDestinations rest
+    geoDestinations [Just option]
+      | upper option `elem` ["STORE", "STOREDIST"] =
+          Left "command has a STORE option without a destination key"
+    geoDestinations (Nothing : _) = Left "command has a non-bulk option"
+    geoDestinations (_ : rest) = geoDestinations rest
+
+    upper = BS8.map toUpper
+
+    nonNegativeInteger value errorMessage =
+      case BS8.readInt value of
+        Just (count, "") | count >= 0 -> Right ()
+        _                             -> Left errorMessage
 
     decimalAt n = case drop n args of
       (Just value:_) -> case BS8.readInt value of
@@ -160,7 +253,7 @@ keyArgumentsWith cmd args =
 
 keylessCommands :: [ByteString]
 keylessCommands =
-  [ "PING", "ECHO", "AUTH", "HELLO", "QUIT", "SELECT", "RESET"
+  [ "PING", "ECHO", "AUTH", "HELLO", "QUIT", "SELECT", "RESET", "UNWATCH"
   , "INFO", "TIME", "ROLE", "LASTSAVE", "DBSIZE", "LATENCY"
   , "CLIENT", "CONFIG", "COMMAND", "CLUSTER", "ACL", "SLOWLOG"
   , "BGSAVE", "BGREWRITEAOF", "SAVE", "SHUTDOWN", "REPLICAOF", "SLAVEOF"
@@ -186,13 +279,17 @@ firstKeyCommands =
   , "ZCOUNT", "ZLEXCOUNT", "ZRANDMEMBER", "ZINCRBY", "XADD", "XLEN"
   , "XRANGE", "XREVRANGE", "XDEL", "XTRIM", "XACK", "XPENDING", "XCLAIM"
   , "XAUTOCLAIM", "GEOADD", "GEOPOS", "GEODIST", "GEOHASH"
-  , "GEORADIUS", "GEORADIUSBYMEMBER", "BITCOUNT", "GETBIT", "SETBIT"
-  , "BITFIELD", "BITFIELD_RO", "PFADD", "PFCOUNT", "DUMP", "RESTORE"
-  , "OBJECT", "TOUCH", "UNLINK", "WATCH"
+  , "BITCOUNT", "GETBIT", "SETBIT", "BITFIELD", "BITFIELD_RO", "PFADD"
+  , "DUMP", "RESTORE"
   ]
 
 allKeyCommands :: [ByteString]
 allKeyCommands =
-  [ "DEL", "EXISTS", "MGET", "SUNION", "SINTER", "SDIFF", "SINTERSTORE"
-  , "SUNIONSTORE", "SDIFFSTORE"
-  ]
+  ["DEL", "EXISTS", "MGET", "SUNION", "SINTER", "SDIFF"]
+
+destinationAndSourceCommands :: [ByteString]
+destinationAndSourceCommands = ["SINTERSTORE", "SUNIONSTORE", "SDIFFSTORE"]
+
+-- These Redis 7.2 key specs have a range ending at the final argument.
+multiKeyCommands :: [ByteString]
+multiKeyCommands = ["PFCOUNT", "TOUCH", "UNLINK", "WATCH"]

--- a/redis-client.cabal
+++ b/redis-client.cabal
@@ -82,6 +82,8 @@ test-suite ClusterTunnelSpec
                     , mtl
                     , network
                     , stm
+                    , time
+                    , vector
 
 test-suite NodeLifecycleSpec
     import:           test-defaults

--- a/test/ClusterE2E/Tunnel.hs
+++ b/test/ClusterE2E/Tunnel.hs
@@ -170,6 +170,20 @@ spec = describe "Cluster Tunnel Mode" $ do
           RespBulkString stream, RespBulkString "0"]) conn `shouldSatisfyResponse` isArray
         rawCommand (RespArray [RespBulkString "XINFO", RespBulkString "STREAM",
           RespBulkString stream]) conn `shouldSatisfyResponse` isArray
+        rawCommand (RespArray [RespBulkString "MSET", RespBulkString (tag <> ":one"),
+          RespBulkString "one", RespBulkString (tag <> ":two"), RespBulkString "two"]) conn
+          `shouldReturn` RespSimpleString "OK"
+        rawCommand (RespArray [RespBulkString "PFADD", RespBulkString (tag <> ":hll"),
+          RespBulkString "one"]) conn `shouldReturn` RespInteger 1
+        rawCommand (RespArray [RespBulkString "PFCOUNT", RespBulkString (tag <> ":hll"),
+          RespBulkString (tag <> ":hll")]) conn `shouldSatisfyResponse` isInteger
+        rawCommand (RespArray [RespBulkString "TOUCH", RespBulkString (tag <> ":one"),
+          RespBulkString (tag <> ":two")]) conn `shouldReturn` RespInteger 2
+        rawCommand (RespArray [RespBulkString "OBJECT", RespBulkString "ENCODING",
+          RespBulkString (tag <> ":one")]) conn `shouldSatisfyResponse` isBulk
+        rawCommand (RespArray [RespBulkString "WATCH", RespBulkString (tag <> ":one"),
+          RespBulkString (tag <> ":two")]) conn `shouldReturn` RespSimpleString "OK"
+        rawCommand (RespArray [RespBulkString "UNWATCH"]) conn `shouldReturn` RespSimpleString "OK"
         rawCommand (RespArray [RespBulkString "ECHO", RespBulkString "argument"]) conn
           `shouldReturn` RespBulkString "argument"
 
@@ -181,10 +195,14 @@ spec = describe "Cluster Tunnel Mode" $ do
         rawCommand (RespArray [RespBulkString "MGET", RespBulkString "one",
           RespBulkString "two"]) conn
           `shouldSatisfyResponse` isErrContaining "CROSSSLOT Keys in request don't hash to the same slot"
+        rawCommand (RespArray [RespBulkString "PFCOUNT", RespBulkString "{first}:hll",
+          RespBulkString "{second}:hll"]) conn
+          `shouldSatisfyResponse` isErrContaining "CROSSSLOT Keys in request don't hash to the same slot"
         close conn
 
         bracket createTestClusterClient closeClusterClient $ \client -> do
-          _ <- runCmd_ client (del [renamedKey, copiedKey, zsetOne, zsetTwo, stream])
+          _ <- runCmd_ client (del [renamedKey, copiedKey, zsetOne, zsetTwo, stream,
+            tag <> ":one", tag <> ":two", tag <> ":hll"])
           pure ()
 
   describe "Pinned Proxy Mode" $ do

--- a/test/ClusterE2E/Tunnel.hs
+++ b/test/ClusterE2E/Tunnel.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
@@ -7,18 +8,24 @@ import           ClusterE2E.Utils
 import           Control.Concurrent.STM        (readTVarIO)
 import           Control.Exception             (bracket)
 import           Control.Monad                 (forM_, when)
+import qualified Control.Monad.State.Strict    as State
+import qualified Data.ByteString.Builder       as Builder
 import qualified Data.ByteString.Char8         as BS8
 import           Data.List                     (isInfixOf)
 import qualified Data.Map.Strict               as Map
-import           Database.Redis.Client         (PlainTextClient (NotConnectedPlainTextClient),
+import           Database.Redis.Client         (Client (..),
+                                                ConnectionStatus (..),
+                                                PlainTextClient (NotConnectedPlainTextClient),
                                                 close, connect)
 import           Database.Redis.Cluster        (ClusterNode (..),
                                                 ClusterTopology (..),
                                                 NodeAddress (..), NodeRole (..))
 import           Database.Redis.Cluster.Client (closeClusterClient,
                                                 clusterTopology)
-import           Database.Redis.Command        (RedisCommands (..))
-import           Database.Redis.Resp           (RespData (..))
+import           Database.Redis.Command        (ClientState (..),
+                                                RedisCommands (..), parseWith)
+import           Database.Redis.Resp           (Encodable (encode),
+                                                RespData (..))
 import           SlotMappingHelpers            (getKeyForNode)
 import           Test.Hspec
 
@@ -123,6 +130,61 @@ spec = describe "Cluster Tunnel Mode" $ do
         bracket createTestClusterClient closeClusterClient $ \client -> do
           _ <- runCmd_ client (del ["multi:key1"])
           _ <- runCmd_ client (del ["multi:key2"])
+          pure ()
+
+    it "smart mode routes Redis key specifications and rejects invalid requests before dispatch" $
+      withSmartProxy $ do
+        conn <- connect (NotConnectedPlainTextClient "localhost" (Just 6379))
+        let tag = "{tunnel-routing}"
+            binaryKey = tag <> ":binary"
+            renamedKey = tag <> ":renamed"
+            copiedKey = tag <> ":copied"
+            zsetOne = tag <> ":zset-one"
+            zsetTwo = tag <> ":zset-two"
+            stream = tag <> ":stream"
+
+        rawCommand (RespArray [RespBulkString "SET", RespBulkString binaryKey,
+          RespBulkString "\NUL\255"]) conn `shouldReturn` RespSimpleString "OK"
+        rawCommand (RespArray [RespBulkString "EVAL",
+          RespBulkString "return redis.call('GET', KEYS[1])", RespBulkString "1",
+          RespBulkString binaryKey]) conn `shouldReturn` RespBulkString "\NUL\255"
+        rawCommand (RespArray [RespBulkString "MEMORY", RespBulkString "USAGE",
+          RespBulkString binaryKey]) conn `shouldSatisfyResponse` isInteger
+        rawCommand (RespArray [RespBulkString "RENAME", RespBulkString binaryKey,
+          RespBulkString renamedKey]) conn `shouldReturn` RespSimpleString "OK"
+        rawCommand (RespArray [RespBulkString "COPY", RespBulkString renamedKey,
+          RespBulkString copiedKey]) conn `shouldReturn` RespInteger 1
+
+        rawCommand (RespArray [RespBulkString "ZADD", RespBulkString zsetOne,
+          RespBulkString "1", RespBulkString "one"]) conn `shouldReturn` RespInteger 1
+        rawCommand (RespArray [RespBulkString "ZADD", RespBulkString zsetTwo,
+          RespBulkString "2", RespBulkString "two"]) conn `shouldReturn` RespInteger 1
+        rawCommand (RespArray [RespBulkString "ZUNION", RespBulkString "2",
+          RespBulkString zsetOne, RespBulkString zsetTwo]) conn `shouldReturn`
+          RespArray [RespBulkString "one", RespBulkString "two"]
+
+        rawCommand (RespArray [RespBulkString "XADD", RespBulkString stream,
+          RespBulkString "*", RespBulkString "field", RespBulkString "value"]) conn
+          `shouldSatisfyResponse` isBulk
+        rawCommand (RespArray [RespBulkString "XREAD", RespBulkString "STREAMS",
+          RespBulkString stream, RespBulkString "0"]) conn `shouldSatisfyResponse` isArray
+        rawCommand (RespArray [RespBulkString "XINFO", RespBulkString "STREAM",
+          RespBulkString stream]) conn `shouldSatisfyResponse` isArray
+        rawCommand (RespArray [RespBulkString "ECHO", RespBulkString "argument"]) conn
+          `shouldReturn` RespBulkString "argument"
+
+        rawCommand (RespArray [RespBulkString "MODULE.FUTURE", RespBulkString "key"]) conn
+          `shouldSatisfyResponse` isErrContaining "unsupported command for cluster routing"
+        rawCommand (RespArray [RespBulkString "ZUNION", RespBulkString "2",
+          RespBulkString zsetOne]) conn
+          `shouldSatisfyResponse` isErrContaining "fewer keys than its key count"
+        rawCommand (RespArray [RespBulkString "MGET", RespBulkString "one",
+          RespBulkString "two"]) conn
+          `shouldSatisfyResponse` isErrContaining "CROSSSLOT Keys in request don't hash to the same slot"
+        close conn
+
+        bracket createTestClusterClient closeClusterClient $ \client -> do
+          _ <- runCmd_ client (del [renamedKey, copiedKey, zsetOne, zsetTwo, stream])
           pure ()
 
   describe "Pinned Proxy Mode" $ do
@@ -240,3 +302,30 @@ spec = describe "Cluster Tunnel Mode" $ do
                 other -> expectationFailure $ "Expected RespArray from CLUSTER SLOTS, got: " ++ show other
 
               close conn
+
+rawCommand :: RespData -> PlainTextClient 'Connected -> IO RespData
+rawCommand command conn =
+  State.evalStateT (do
+    ClientState client _ <- State.get
+    send client (Builder.toLazyByteString $ encode command)
+    parseWith (receive client)
+  ) (ClientState conn BS8.empty)
+
+shouldSatisfyResponse :: IO RespData -> (RespData -> Bool) -> IO ()
+shouldSatisfyResponse response predicate = response >>= (`shouldSatisfy` predicate)
+
+isInteger :: RespData -> Bool
+isInteger (RespInteger _) = True
+isInteger _               = False
+
+isBulk :: RespData -> Bool
+isBulk (RespBulkString _) = True
+isBulk _                  = False
+
+isArray :: RespData -> Bool
+isArray (RespArray _) = True
+isArray _             = False
+
+isErrContaining :: BS8.ByteString -> RespData -> Bool
+isErrContaining message (RespError err) = message `BS8.isInfixOf` err
+isErrContaining _ _                     = False

--- a/test/ClusterTunnelSpec.hs
+++ b/test/ClusterTunnelSpec.hs
@@ -2,7 +2,10 @@
 
 module Main (main) where
 
-import           ClusterTunnel (rewriteClusterResponse)
+import           ClusterTunnel                   (rewriteClusterResponse)
+import           Database.Redis.Cluster.Commands (keyArguments,
+                                                  keyArgumentsFromResp)
+import           Database.Redis.Resp             (RespData (..))
 import           Test.Hspec
 
 main :: IO ()
@@ -19,3 +22,34 @@ main = hspec $ do
     it "leaves malformed framing unchanged" $ do
       let malformed = "-MOVED 3999 redis.example:6381\rX"
       rewriteClusterResponse malformed `shouldBe` malformed
+
+  describe "checked-in cluster key specifications" $ do
+    it "selects fixed first and later key positions" $ do
+      keyArguments "GET" ["key"] `shouldBe` Right ["key"]
+      keyArguments "BITOP" ["AND", "destination", "source"]
+        `shouldBe` Right ["destination", "source"]
+
+    it "extracts every key from same-slot multi-key commands" $ do
+      keyArguments "ZUNIONSTORE" ["{tag}:out", "2", "{tag}:one", "{tag}:two"]
+        `shouldBe` Right ["{tag}:out", "{tag}:one", "{tag}:two"]
+      keyArguments "MSET" ["{tag}:one", "one", "{tag}:two", "two"]
+        `shouldBe` Right ["{tag}:one", "{tag}:two"]
+
+    it "handles movable EVAL and stream key lists" $ do
+      keyArguments "EVAL" ["return KEYS[1]", "1", "key", "argument"]
+        `shouldBe` Right ["key"]
+      keyArguments "XREADGROUP" ["GROUP", "g", "c", "STREAMS", "one", "two", ">", ">"]
+        `shouldBe` Right ["one", "two"]
+
+    it "keeps keyless commands keyless when they have arguments" $
+      keyArgumentsFromResp "ECHO" [RespInteger 42] `shouldBe` Right []
+
+    it "preserves binary non-key RESP arguments for raw forwarding" $
+      keyArgumentsFromResp "SET" [RespBulkString "key", RespBulkString "\NUL\255"]
+        `shouldBe` Right ["key"]
+
+    it "fails closed for unknown commands and malformed movable specs" $ do
+      keyArguments "MODULE.FUTURE" ["might-be-a-key"]
+        `shouldBe` Left "unsupported command for cluster routing: MODULE.FUTURE"
+      keyArguments "EVALSHA" ["digest", "not-a-number"]
+        `shouldBe` Left "command EVALSHA has an invalid key count"

--- a/test/ClusterTunnelSpec.hs
+++ b/test/ClusterTunnelSpec.hs
@@ -51,31 +51,29 @@ main = hspec $ do
       rewriteClusterResponse malformed `shouldBe` malformed
 
   describe "checked-in cluster key specifications" $ do
-    it "selects fixed first and later key positions" $ do
-      keyArguments "GET" ["key"] `shouldBe` Right ["key"]
-      keyArguments "BITOP" ["AND", "destination", "source"]
-        `shouldBe` Right ["destination", "source"]
-
-    it "extracts every key from same-slot multi-key commands" $ do
-      keyArguments "ZUNIONSTORE" ["{tag}:out", "2", "{tag}:one", "{tag}:two"]
-        `shouldBe` Right ["{tag}:out", "{tag}:one", "{tag}:two"]
-      keyArguments "MSET" ["{tag}:one", "one", "{tag}:two", "two"]
-        `shouldBe` Right ["{tag}:one", "{tag}:two"]
-
-    it "handles movable EVAL and stream key lists" $ do
-      keyArguments "EVAL" ["return KEYS[1]", "1", "key", "argument"]
-        `shouldBe` Right ["key"]
-      keyArguments "XREADGROUP" ["GROUP", "g", "c", "STREAMS", "one", "two", ">", ">"]
-        `shouldBe` Right ["one", "two"]
-
-    it "uses Redis command key specifications for special forms" $ do
-      keyArguments "MEMORY" ["USAGE", "key"] `shouldBe` Right ["key"]
-      keyArguments "RENAME" ["source", "destination"]
-        `shouldBe` Right ["source", "destination"]
-      keyArguments "COPY" ["source", "destination"]
-        `shouldBe` Right ["source", "destination"]
-      keyArguments "ZUNION" ["2", "one", "two"] `shouldBe` Right ["one", "two"]
-      keyArguments "XINFO" ["STREAM", "stream"] `shouldBe` Right ["stream"]
+    it "matches the Redis 7.2.12 command metadata key specifications" $
+      mapM_ assertKeys
+        [ ("GET", ["key"], ["key"])
+        , ("BITOP", ["AND", "destination", "source"], ["destination", "source"])
+        , ("SINTERSTORE", ["destination", "source"], ["destination", "source"])
+        , ("ZUNIONSTORE", ["{tag}:out", "2", "{tag}:one", "{tag}:two"],
+            ["{tag}:out", "{tag}:one", "{tag}:two"])
+        , ("MSET", ["{tag}:one", "one", "{tag}:two", "two"],
+            ["{tag}:one", "{tag}:two"])
+        , ("EVAL", ["return KEYS[1]", "1", "key", "argument"], ["key"])
+        , ("XREADGROUP", ["GROUP", "g", "c", "STREAMS", "one", "two", ">", ">"],
+            ["one", "two"])
+        , ("MEMORY", ["USAGE", "key"], ["key"])
+        , ("OBJECT", ["ENCODING", "key"], ["key"])
+        , ("XINFO", ["STREAM", "stream", "FULL", "COUNT", "1"], ["stream"])
+        , ("PFCOUNT", ["one", "two"], ["one", "two"])
+        , ("TOUCH", ["one", "two"], ["one", "two"])
+        , ("UNLINK", ["one", "two"], ["one", "two"])
+        , ("WATCH", ["one", "two"], ["one", "two"])
+        , ("BLPOP", ["one", "two", "0"], ["one", "two"])
+        , ("GEORADIUS", ["source", "1", "2", "3", "km", "STORE", "destination"],
+            ["source", "destination"])
+        ]
 
     it "keeps keyless commands keyless when they have arguments" $
       keyArgumentsFromResp "ECHO" [RespInteger 42] `shouldBe` Right []
@@ -84,7 +82,7 @@ main = hspec $ do
       keyArgumentsFromResp "SET" [RespBulkString "key", RespBulkString "\NUL\255"]
         `shouldBe` Right ["key"]
 
-    it "fails closed for unknown commands and malformed movable specs" $ do
+    it "fails closed for unknown and malformed Redis 7.2.12 specifications" $ do
       keyArguments "MODULE.FUTURE" ["might-be-a-key"]
         `shouldBe` Left "unsupported command for cluster routing: MODULE.FUTURE"
       keyArguments "EVALSHA" ["digest", "not-a-number"]
@@ -95,17 +93,42 @@ main = hspec $ do
         `shouldBe` Left "command ZINTERCARD has fewer keys than its key count"
       keyArguments "EVAL" ["return 1", "2", "one"]
         `shouldBe` Left "command EVAL has fewer keys than its key count"
+      keyArguments "MSET" ["key", "value", "orphan"]
+        `shouldBe` Left "command MSET requires key-value pairs"
+      keyArguments "BLPOP" ["0"]
+        `shouldBe` Left "command BLPOP requires keys and a timeout"
+      keyArguments "MEMORY" ["USAGE"]
+        `shouldBe` Left "command MEMORY has an invalid subcommand or arity"
+      keyArguments "XINFO" ["STREAM"]
+        `shouldBe` Left "command XINFO has an invalid subcommand or arity"
+      keyArguments "OBJECT" ["ENCODING"]
+        `shouldBe` Left "command OBJECT has an invalid subcommand or arity"
+      keyArguments "GEORADIUS" ["source", "1", "2", "3", "km", "STORE"]
+        `shouldBe` Left "command has a STORE option without a destination key"
 
   describe "smart proxy dispatch" $ do
     it "does not contact a node for unknown, malformed, or cross-slot requests" $ do
       (client, connectionCount, _) <- mockClusterClient
       let unknown = RespArray [RespBulkString "MODULE.FUTURE", RespBulkString "key"]
           malformed = RespArray [RespBulkString "ZUNION", RespBulkString "2", RespBulkString "key"]
+          malformedMemory = RespArray [RespBulkString "MEMORY", RespBulkString "USAGE"]
+          malformedXInfo = RespArray [RespBulkString "XINFO", RespBulkString "STREAM"]
+          oddMSet = RespArray [RespBulkString "MSET", RespBulkString "key",
+            RespBulkString "value", RespBulkString "orphan"]
+          timeoutOnly = RespArray [RespBulkString "BLPOP", RespBulkString "0"]
           crossSlot = RespArray [RespBulkString "MGET", RespBulkString "one", RespBulkString "two"]
       routeSmartProxyCommand client unknown "unknown" `shouldReturn`
         Left "unsupported command for cluster routing: MODULE.FUTURE"
       routeSmartProxyCommand client malformed "malformed" `shouldReturn`
         Left "command ZUNION has fewer keys than its key count"
+      routeSmartProxyCommand client malformedMemory "memory" `shouldReturn`
+        Left "command MEMORY has an invalid subcommand or arity"
+      routeSmartProxyCommand client malformedXInfo "xinfo" `shouldReturn`
+        Left "command XINFO has an invalid subcommand or arity"
+      routeSmartProxyCommand client oddMSet "mset" `shouldReturn`
+        Left "command MSET requires key-value pairs"
+      routeSmartProxyCommand client timeoutOnly "blpop" `shouldReturn`
+        Left "command BLPOP requires keys and a timeout"
       routeSmartProxyCommand client crossSlot "cross-slot" `shouldReturn`
         Left "CROSSSLOT Keys in request don't hash to the same slot"
       readIORef connectionCount `shouldReturn` 0
@@ -119,6 +142,22 @@ main = hspec $ do
           routeSmartProxyCommand client parsed rawFrame `shouldReturn`
             Right (RespSimpleString "OK")
           readIORef sent `shouldReturn` rawFrame
+
+    it "rejects cross-slot keys from all Redis multi-key range specifications" $ do
+      (client, connectionCount, _) <- mockClusterClient
+      mapM_ (\command ->
+        routeSmartProxyCommand client command "cross-slot" `shouldReturn`
+          Left "CROSSSLOT Keys in request don't hash to the same slot")
+        [ RespArray [RespBulkString "PFCOUNT", RespBulkString "one", RespBulkString "two"]
+        , RespArray [RespBulkString "TOUCH", RespBulkString "one", RespBulkString "two"]
+        , RespArray [RespBulkString "UNLINK", RespBulkString "one", RespBulkString "two"]
+        , RespArray [RespBulkString "WATCH", RespBulkString "one", RespBulkString "two"]
+        ]
+      readIORef connectionCount `shouldReturn` 0
+
+assertKeys :: (BS.ByteString, [BS.ByteString], [BS.ByteString]) -> Expectation
+assertKeys (command, arguments, expectedKeys) =
+  keyArguments command arguments `shouldBe` Right expectedKeys
 
 data MockClient (a :: ConnectionStatus) where
   MockConnected :: !(IORef BS.ByteString) -> !(IORef [BS.ByteString]) -> MockClient 'Connected

--- a/test/ClusterTunnelSpec.hs
+++ b/test/ClusterTunnelSpec.hs
@@ -1,11 +1,38 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE GADTs             #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main (main) where
 
-import           ClusterTunnel                   (rewriteClusterResponse)
-import           Database.Redis.Cluster.Commands (keyArguments,
-                                                  keyArgumentsFromResp)
-import           Database.Redis.Resp             (RespData (..))
+import           ClusterTunnel                         (rewriteClusterResponse,
+                                                        routeSmartProxyCommand)
+import           Control.Concurrent.MVar               (newMVar)
+import           Control.Concurrent.STM                (newTVarIO)
+import           Control.Monad.IO.Class                (liftIO)
+import qualified Data.ByteString                       as BS
+import qualified Data.ByteString.Lazy                  as LBS
+import           Data.IORef                            (IORef,
+                                                        atomicModifyIORef',
+                                                        newIORef, readIORef)
+import qualified Data.Map.Strict                       as Map
+import           Data.Time.Clock                       (getCurrentTime)
+import qualified Data.Vector                           as V
+import           Database.Redis.Client                 (Client (..),
+                                                        ConnectionStatus (..))
+import           Database.Redis.Cluster                (ClusterNode (..),
+                                                        ClusterTopology (..),
+                                                        NodeAddress (..),
+                                                        NodeRole (..),
+                                                        SlotRange (..))
+import           Database.Redis.Cluster.Client         (ClusterClient (..),
+                                                        ClusterConfig (..))
+import           Database.Redis.Cluster.Commands       (keyArguments,
+                                                        keyArgumentsFromResp)
+import           Database.Redis.Cluster.ConnectionPool (PoolConfig (..),
+                                                        createPool)
+import           Database.Redis.Internal.MultiplexPool (createMultiplexPool)
+import           Database.Redis.Resp                   (RespData (..))
+import qualified Database.Redis.Resp                   as Resp
 import           Test.Hspec
 
 main :: IO ()
@@ -41,6 +68,15 @@ main = hspec $ do
       keyArguments "XREADGROUP" ["GROUP", "g", "c", "STREAMS", "one", "two", ">", ">"]
         `shouldBe` Right ["one", "two"]
 
+    it "uses Redis command key specifications for special forms" $ do
+      keyArguments "MEMORY" ["USAGE", "key"] `shouldBe` Right ["key"]
+      keyArguments "RENAME" ["source", "destination"]
+        `shouldBe` Right ["source", "destination"]
+      keyArguments "COPY" ["source", "destination"]
+        `shouldBe` Right ["source", "destination"]
+      keyArguments "ZUNION" ["2", "one", "two"] `shouldBe` Right ["one", "two"]
+      keyArguments "XINFO" ["STREAM", "stream"] `shouldBe` Right ["stream"]
+
     it "keeps keyless commands keyless when they have arguments" $
       keyArgumentsFromResp "ECHO" [RespInteger 42] `shouldBe` Right []
 
@@ -53,3 +89,69 @@ main = hspec $ do
         `shouldBe` Left "unsupported command for cluster routing: MODULE.FUTURE"
       keyArguments "EVALSHA" ["digest", "not-a-number"]
         `shouldBe` Left "command EVALSHA has an invalid key count"
+      keyArguments "ZUNION" ["2", "one"]
+        `shouldBe` Left "command ZUNION has fewer keys than its key count"
+      keyArguments "ZINTERCARD" ["2", "one"]
+        `shouldBe` Left "command ZINTERCARD has fewer keys than its key count"
+      keyArguments "EVAL" ["return 1", "2", "one"]
+        `shouldBe` Left "command EVAL has fewer keys than its key count"
+
+  describe "smart proxy dispatch" $ do
+    it "does not contact a node for unknown, malformed, or cross-slot requests" $ do
+      (client, connectionCount, _) <- mockClusterClient
+      let unknown = RespArray [RespBulkString "MODULE.FUTURE", RespBulkString "key"]
+          malformed = RespArray [RespBulkString "ZUNION", RespBulkString "2", RespBulkString "key"]
+          crossSlot = RespArray [RespBulkString "MGET", RespBulkString "one", RespBulkString "two"]
+      routeSmartProxyCommand client unknown "unknown" `shouldReturn`
+        Left "unsupported command for cluster routing: MODULE.FUTURE"
+      routeSmartProxyCommand client malformed "malformed" `shouldReturn`
+        Left "command ZUNION has fewer keys than its key count"
+      routeSmartProxyCommand client crossSlot "cross-slot" `shouldReturn`
+        Left "CROSSSLOT Keys in request don't hash to the same slot"
+      readIORef connectionCount `shouldReturn` 0
+
+    it "forwards supported same-slot frames byte-for-byte through cluster handling" $ do
+      (client, _, sent) <- mockClusterClient
+      let rawFrame = "*3\r\n$3\r\nSET\r\n$7\r\n{tag}:a\r\n$1\r\nx\r\n"
+      case Resp.parseStrict rawFrame of
+        Left err -> expectationFailure err
+        Right parsed -> do
+          routeSmartProxyCommand client parsed rawFrame `shouldReturn`
+            Right (RespSimpleString "OK")
+          readIORef sent `shouldReturn` rawFrame
+
+data MockClient (a :: ConnectionStatus) where
+  MockConnected :: !(IORef BS.ByteString) -> !(IORef [BS.ByteString]) -> MockClient 'Connected
+
+instance Client MockClient where
+  connect = error "MockClient: connect not supported"
+  close _ = pure ()
+  send (MockConnected sent _) bytes =
+    liftIO $ atomicModifyIORef' sent (\old -> (old <> LBS.toStrict bytes, ()))
+  receive (MockConnected _ responses) = liftIO $ atomicModifyIORef' responses nextResponse
+    where
+      nextResponse (response:rest) = (rest, response)
+      nextResponse []              = error "MockClient: response queue exhausted"
+
+mockClusterClient :: IO (ClusterClient MockClient, IORef Int, IORef BS.ByteString)
+mockClusterClient = do
+  connectionCount <- newIORef 0
+  sent <- newIORef BS.empty
+  now <- getCurrentTime
+  let address = NodeAddress "mock" 6379
+      nodeId = "mock-node"
+      node = ClusterNode nodeId address Master [SlotRange 0 16383 nodeId []] []
+      topology = ClusterTopology
+        (V.replicate 16384 nodeId) (V.replicate 16384 address)
+        (Map.singleton nodeId node) now
+      poolConfig = PoolConfig 1 5000 1 False
+      config = ClusterConfig address poolConfig 1 0 600
+      connector _ = do
+        atomicModifyIORef' connectionCount (\n -> (n + 1, ()))
+        responses <- newIORef ["+OK\r\n"]
+        pure (MockConnected sent responses)
+  topologyVar <- newTVarIO topology
+  pool <- createPool poolConfig
+  muxPool <- createMultiplexPool connector 1
+  refreshLock <- newMVar ()
+  pure (ClusterClient topologyVar pool config connector refreshLock muxPool, connectionCount, sent)


### PR DESCRIPTION
Closes #92

Implements checked-in command key specifications, movable-key extraction, fail-closed unknown-command handling, CROSSSLOT rejection before dispatch, and raw RESP forwarding for same-slot keyed requests.

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

Validation:
- `cabal test ClusterTunnelSpec --test-show-details=direct`
- `nix-build --no-out-link`
- `make test` (blocked during standalone E2E because an existing shared `redis-cluster-node1` owns `127.0.0.1:6379`)
- Safe `cabal run --enable-profiling redis-client -- --help +RTS -p` before/after; no profile artifacts retained.