### PR TITLE
Use structured worker concurrency

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,8 +17,7 @@ import           ClusterSetup                          (createClusterClientFromS
                                                         flushAllClusterNodes)
 import           ClusterTunnel                         (servePinnedProxy,
                                                         serveSmartProxy)
-import           Control.Concurrent                    (forkIO, newEmptyMVar,
-                                                        putMVar, takeMVar)
+import           Control.Exception                     (bracket)
 
 import           AppConfig                             (RunState (..),
                                                         defaultRunState,
@@ -72,6 +71,7 @@ import           FillProcess                           (buildChildArgs)
 import           FlushConfirmation                     (canonicalFlushTarget,
                                                         confirmFlush)
 import           Numeric                               (showHex)
+import           StructuredConcurrency                 (runConcurrentlyFailFast)
 import           System.Console.GetOpt                 (ArgDescr (..),
                                                         ArgOrder (..),
                                                         OptDescr (Option),
@@ -385,15 +385,12 @@ fillStandalone state = do
             -- Jobs: (connectionIdx, mbForThisConnection)
             jobs = [(i, if i < remainder then baseMB + 1 else baseMB) | i <- [0..nConns - 1], baseMB > 0 || i < remainder]
         printf "Filling %dGB with %d parallel connections\n" (dataGBs state) (length jobs)
-        mvars <- mapM (\(idx, mb) -> do
-            mv <- newEmptyMVar
-            _ <- forkIO $ do
-                 if useTLS state
-                    then runCommandsAgainstTLSHost state $ fillCacheWithDataMB baseSeed idx mb (pipelineBatchSize state) (keySize state) (valueSize state)
-                    else runCommandsAgainstPlaintextHost state $ fillCacheWithDataMB baseSeed idx mb (pipelineBatchSize state) (keySize state) (valueSize state)
-                 putMVar mv ()
-            return mv) jobs
-        mapM_ takeMVar mvars
+        runConcurrentlyFailFast
+          [ if useTLS state
+              then runCommandsAgainstTLSHost state $ fillCacheWithDataMB baseSeed idx mb (pipelineBatchSize state) (keySize state) (valueSize state)
+              else runCommandsAgainstPlaintextHost state $ fillCacheWithDataMB baseSeed idx mb (pipelineBatchSize state) (keySize state) (valueSize state)
+          | (idx, mb) <- jobs
+          ]
 
 
 fillCluster :: RunState -> IO ()
@@ -554,47 +551,40 @@ bench state = do
 
 -- | Run the benchmark with a specific connector type
 benchWithConnector :: (Client client) => RunState -> Connector client -> String -> Int -> Int -> Int -> Int -> IO ()
-benchWithConnector state connector op duration nConns kSize vSize = do
-  clusterClient <- createClusterClientFromState state connector
-  muxPool <- createMultiplexPool
-    (clusterConnector clusterClient) (muxCount state)
+benchWithConnector state connector op duration nConns kSize vSize =
+  bracket (createClusterClientFromState state connector) closeClusterClient $ \clusterClient ->
+    bracket (createMultiplexPool (clusterConnector clusterClient) (muxCount state)) closeMultiplexPool $ \muxPool -> do
 
-  -- Pre-populate keys for GET and mixed workloads
-  when (op `elem` ["get", "mixed"]) $ do
-    hPutStrLn stderr "Pre-populating keys for GET workload..."
-    let numKeys = 100000
-    benchPrePopulate muxPool clusterClient numKeys kSize vSize
-    hPutStrLn stderr $ "Pre-populated " ++ show numKeys ++ " keys"
+      -- Pre-populate keys for GET and mixed workloads
+      when (op `elem` ["get", "mixed"]) $ do
+        hPutStrLn stderr "Pre-populating keys for GET workload..."
+        let numKeys = 100000
+        benchPrePopulate muxPool clusterClient numKeys kSize vSize
+        hPutStrLn stderr $ "Pre-populated " ++ show numKeys ++ " keys"
 
-  -- Run the benchmark
-  opsCounter <- newIORef (0 :: Int)
-  startTime <- getCurrentTime
+      -- Run the benchmark
+      opsCounter <- newIORef (0 :: Int)
+      startTime <- getCurrentTime
 
-  mvars <- mapM (\tid -> do
-    mvar <- newEmptyMVar
-    _ <- forkIO $ do
-      benchWorker muxPool clusterClient op tid kSize vSize duration opsCounter
-      putMVar mvar ()
-    return mvar
-    ) [0 .. nConns - 1]
+      runConcurrentlyFailFast
+        [ benchWorker muxPool clusterClient op tid kSize vSize duration opsCounter
+        | tid <- [0 .. nConns - 1]
+        ]
 
-  mapM_ takeMVar mvars
-  endTime <- getCurrentTime
+      endTime <- getCurrentTime
 
-  totalOps <- readIORef opsCounter
-  let elapsed = realToFrac (diffUTCTime endTime startTime) :: Double
-      opsPerSec = fromIntegral totalOps / elapsed
+      totalOps <- readIORef opsCounter
+      let elapsed = realToFrac (diffUTCTime endTime startTime) :: Double
+          opsPerSec = fromIntegral totalOps / elapsed
 
-  -- Output JSON to stdout
-  putStrLn $ "{\"operation\":\"" ++ op
-    ++ "\",\"ops_per_sec\":" ++ show (round opsPerSec :: Int)
-    ++ ",\"duration_sec\":" ++ show (round elapsed :: Int)
-    ++ ",\"total_ops\":" ++ show totalOps
-    ++ "}"
+      -- Output JSON to stdout
+      putStrLn $ "{\"operation\":\"" ++ op
+        ++ "\",\"ops_per_sec\":" ++ show (round opsPerSec :: Int)
+        ++ ",\"duration_sec\":" ++ show (round elapsed :: Int)
+        ++ ",\"total_ops\":" ++ show totalOps
+        ++ "}"
 
-  closeMultiplexPool muxPool
-  closeClusterClient clusterClient
-  exitSuccess
+      exitSuccess
 
 -- | Pre-populate keys for GET workload
 benchPrePopulate :: (Client client) => MultiplexPool client -> ClusterClient client -> Int -> Int -> Int -> IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,7 +17,7 @@ import           ClusterSetup                          (createClusterClientFromS
                                                         flushAllClusterNodes)
 import           ClusterTunnel                         (servePinnedProxy,
                                                         serveSmartProxy)
-import           Control.Exception                     (bracket)
+import           Control.Exception                     (bracket, mask)
 
 import           AppConfig                             (RunState (..),
                                                         defaultRunState,
@@ -71,7 +71,8 @@ import           FillProcess                           (buildChildArgs)
 import           FlushConfirmation                     (canonicalFlushTarget,
                                                         confirmFlush)
 import           Numeric                               (showHex)
-import           StructuredConcurrency                 (runConcurrentlyFailFast)
+import           StructuredConcurrency                 (runConcurrentlyFailFast,
+                                                        withSubmittedSlots)
 import           System.Console.GetOpt                 (ArgDescr (..),
                                                         ArgOrder (..),
                                                         OptDescr (Option),
@@ -606,7 +607,7 @@ benchPrePopulate muxPool clusterClient numKeys kSize vSize = do
 -- | Worker thread that submits commands for the specified duration
 -- Uses async pipelining: fires a batch of commands, then waits for all results.
 benchWorker :: (Client client) => MultiplexPool client -> ClusterClient client -> String -> Int -> Int -> Int -> Int -> IORef Int -> IO ()
-benchWorker muxPool clusterClient op tid kSize vSize duration opsCounter = do
+benchWorker muxPool clusterClient op tid kSize vSize duration opsCounter = mask $ \_ -> do
   topology <- readTVarIO (clusterTopology clusterClient)
   let masters = [node | node <- Map.elems (topologyNodes topology), nodeRole node == Master]
       batchSize = 64 -- fire 64 commands per batch before waiting
@@ -617,17 +618,15 @@ benchWorker muxPool clusterClient op tid kSize vSize duration opsCounter = do
       now <- getCurrentTime
       let elapsed = realToFrac (diffUTCTime now startTime) :: Double
       when (elapsed < fromIntegral duration) $ do
-        -- Fire a batch of commands asynchronously
-        slots <- fireBatch topology counter batchSz []
-        let completedCount = length slots
-        -- Wait for all results
-        mapM_ (\slot -> waitSlotResult muxPool slot) slots
-        -- Count completed ops
-        atomicModifyIORef' opsCounter (\n -> (n + completedCount, ()))
+        withSubmittedSlots (waitSlotResult muxPool) $ \submitted waitSubmitted -> do
+          slots <- fireBatch topology counter batchSz [] submitted
+          let completedCount = length slots
+          mapM_ waitSubmitted slots
+          atomicModifyIORef' opsCounter (\n -> (n + completedCount, ()))
         go topology masters startTime (counter + batchSz) batchSz
 
-    fireBatch _ _ 0 acc = return (reverse acc)
-    fireBatch topology !counter !remaining acc = do
+    fireBatch _ _ 0 acc _ = return (reverse acc)
+    fireBatch topology !counter !remaining acc submitted = do
       let key = benchKey kSize counter
           val = benchValue vSize counter
           !slot = calculateSlot key
@@ -641,6 +640,6 @@ benchWorker muxPool clusterClient op tid kSize vSize duration opsCounter = do
                     then encodeSetBuilder key val
                     else encodeGetBuilder key
                 _ -> encodeSetBuilder key val
-          s <- submitToNodeAsync muxPool addr cmd
-          fireBatch topology (counter + 1) (remaining - 1) (s : acc)
-        Nothing -> fireBatch topology (counter + 1) (remaining - 1) acc
+          s <- submitted (submitToNodeAsync muxPool addr cmd)
+          fireBatch topology (counter + 1) (remaining - 1) (s : acc) submitted
+        Nothing -> fireBatch topology (counter + 1) (remaining - 1) acc submitted

--- a/app/StructuredConcurrency.hs
+++ b/app/StructuredConcurrency.hs
@@ -1,0 +1,35 @@
+module StructuredConcurrency
+  ( runConcurrentlyFailFast
+  ) where
+
+import           Control.Concurrent.Async (Async, async, cancel, waitAnyCatch,
+                                           waitCatch)
+import           Control.Exception        (SomeException, mask, onException,
+                                           throwIO)
+
+-- | Run workers as one cancellation scope.  A failing worker cancels and joins
+-- every sibling before its exception is propagated to the caller.
+runConcurrentlyFailFast :: [IO ()] -> IO ()
+runConcurrentlyFailFast actions = mask $ \restore ->
+  let
+    spawn [] = pure []
+    spawn (action : remaining) = do
+      worker <- async (restore action)
+      (worker :) <$> spawn remaining `onException` cancelAndWait [worker]
+
+    waitForWorkers [] = pure ()
+    waitForWorkers workers = do
+      (completed, result) <- waitAnyCatch workers
+      case result of
+        Left exception -> do
+          cancelAndWait workers
+          throwIO (exception :: SomeException)
+        Right () -> waitForWorkers (filter (/= completed) workers)
+  in do
+    workers <- spawn actions
+    restore (waitForWorkers workers) `onException` cancelAndWait workers
+
+cancelAndWait :: [Async ()] -> IO ()
+cancelAndWait workers = do
+  mapM_ cancel workers
+  mapM_ waitCatch workers

--- a/app/StructuredConcurrency.hs
+++ b/app/StructuredConcurrency.hs
@@ -1,11 +1,16 @@
 module StructuredConcurrency
   ( runConcurrentlyFailFast
+  , withSubmittedSlots
   ) where
 
+import           Control.Concurrent       (forkIO)
 import           Control.Concurrent.Async (Async, async, cancel, waitAnyCatch,
                                            waitCatch)
 import           Control.Exception        (SomeException, mask, onException,
                                            throwIO)
+import           Control.Monad            (void)
+import           Data.IORef               (atomicModifyIORef', newIORef,
+                                           readIORef)
 
 -- | Run workers as one cancellation scope.  A failing worker cancels and joins
 -- every sibling before its exception is propagated to the caller.
@@ -33,3 +38,23 @@ cancelAndWait :: [Async ()] -> IO ()
 cancelAndWait workers = do
   mapM_ cancel workers
   mapM_ waitCatch workers
+
+-- | Scope asynchronous submissions.  A slot remains in the scope until its
+-- wait starts; if the scope exits first, a cleanup worker owns that wait.
+-- The wait action must provide its own narrow interruptible region.
+withSubmittedSlots
+  :: Eq slot
+  => (slot -> IO a)
+  -> ((IO slot -> IO slot) -> (slot -> IO a) -> IO b)
+  -> IO b
+withSubmittedSlots await action = mask $ \_ -> do
+  owned <- newIORef []
+  let cleanup = readIORef owned >>= mapM_ (void . forkIO . void . await)
+      submit acquire = do
+        slot <- acquire
+        atomicModifyIORef' owned (\slots -> (slot : slots, ()))
+        return slot
+      waitSubmitted slot = do
+        atomicModifyIORef' owned (\slots -> (filter (/= slot) slots, ()))
+        await slot
+  action submit waitSubmitted `onException` cleanup

--- a/hask-redis-mux/hask-redis-mux.cabal
+++ b/hask-redis-mux/hask-redis-mux.cabal
@@ -230,7 +230,8 @@ test-suite MultiplexerSpec
     import:           test-defaults
     type:             exitcode-stdio-1.0
     main-is:          MultiplexerSpec.hs
-    build-depends:    bytestring >=0.12 && <0.13
+    build-depends:    async >=2.2 && <2.3
+                    , bytestring >=0.12 && <0.13
                     , client
                     , cluster
                     , resp

--- a/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
@@ -36,8 +36,9 @@ module Database.Redis.Internal.Multiplexer
   , isMultiplexerAlive
   ) where
 
-import           Control.Concurrent               (ThreadId, forkIOWithUnmask,
-                                                   killThread, myThreadId)
+import           Control.Concurrent               (ThreadId, forkIO,
+                                                   forkIOWithUnmask, killThread,
+                                                   myThreadId)
 import           Control.Concurrent.MVar          (MVar, modifyMVar,
                                                    newEmptyMVar, newMVar,
                                                    putMVar, readMVar, takeMVar,
@@ -475,14 +476,7 @@ submitCommandPooled pool mux cmdBuilder = do
   let pending = PendingCommand cmdBuilder slot
   accepted <- commandEnqueue (muxCommandQueue mux) pending
   if accepted
-    then do
-      takeMVar (slotSignal slot)
-      mResult <- readIORef (slotResult slot)
-      releaseSlot pool slot
-      case mResult of
-        Just (Right resp) -> return resp
-        Just (Left e)     -> throwIO e
-        Nothing           -> throwIO $ MultiplexerDead "Response slot empty after signal"
+    then awaitSlotResult pool slot
     else do
       releaseSlot pool slot
       throwIO multiplexerDestroyed
@@ -503,16 +497,9 @@ submitCommandPairPooled pool mux firstBuilder secondBuilder = do
   if accepted
     then do
       -- Wait for and discard the first response (ASKING → +OK)
-      takeMVar (slotSignal slot1)
-      releaseSlot pool slot1
+      void $ awaitSlotResult pool slot1
       -- Wait for the actual command response
-      takeMVar (slotSignal slot2)
-      mResult <- readIORef (slotResult slot2)
-      releaseSlot pool slot2
-      case mResult of
-        Just (Right resp) -> return resp
-        Just (Left e)     -> throwIO e
-        Nothing           -> throwIO $ MultiplexerDead "Response slot empty after signal"
+      awaitSlotResult pool slot2
     else do
       releaseSlot pool slot1
       releaseSlot pool slot2
@@ -544,6 +531,25 @@ waitSlot pool slot = do
     Just (Left e)     -> throwIO e
     Nothing           -> throwIO $ MultiplexerDead "Response slot empty after signal"
 {-# INLINE waitSlot #-}
+
+-- | The synchronous callers own their slot for the whole request. Cancellation
+-- leaves a reaper responsible for returning it only after its completion.
+awaitSlotResult :: SlotPool -> ResponseSlot -> IO RespData
+awaitSlotResult pool slot = mask $ \restore -> do
+  restore (takeMVar (slotSignal slot)) `onException` releaseAfterSignal pool slot
+  mResult <- readIORef (slotResult slot)
+  releaseSlot pool slot
+  case mResult of
+    Just (Right resp) -> return resp
+    Just (Left e)     -> throwIO e
+    Nothing           -> throwIO $ MultiplexerDead "Response slot empty after signal"
+
+releaseAfterSignal :: SlotPool -> ResponseSlot -> IO ()
+releaseAfterSignal pool slot = do
+  _ <- forkIO $ mask_ $ do
+    takeMVar (slotSignal slot)
+    releaseSlot pool slot
+  return ()
 
 -- | Tear down the multiplexer: kill both threads and fail all pending commands.
 destroyMultiplexer :: Multiplexer -> IO ()

--- a/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Internal/Multiplexer.hs
@@ -88,6 +88,7 @@ data ResponseSlot = ResponseSlot
   { slotResult :: !(IORef (Maybe (Either SomeException RespData)))
   , slotSignal :: !(MVar ())
   }
+  deriving Eq
 
 -- | Test and diagnostics identity for a pooled response slot.
 sameResponseSlot :: ResponseSlot -> ResponseSlot -> Bool
@@ -471,10 +472,11 @@ submitCommand mux cmdBuilder = do
 -- | Like 'submitCommand', but acquires a 'ResponseSlot' from the pool
 -- instead of allocating a fresh IORef+MVar per call.
 submitCommandPooled :: SlotPool -> Multiplexer -> Builder.Builder -> IO RespData
-submitCommandPooled pool mux cmdBuilder = do
+submitCommandPooled pool mux cmdBuilder = mask $ \_ -> do
   slot <- acquireSlot pool
   let pending = PendingCommand cmdBuilder slot
   accepted <- commandEnqueue (muxCommandQueue mux) pending
+    `onException` releaseSlot pool slot
   if accepted
     then awaitSlotResult pool slot
     else do
@@ -488,16 +490,18 @@ submitCommandPooled pool mux cmdBuilder = do
 -- Used for ASKING + command sequences where ASKING must immediately precede
 -- the target command on the same connection.
 submitCommandPairPooled :: SlotPool -> Multiplexer -> Builder.Builder -> Builder.Builder -> IO RespData
-submitCommandPairPooled pool mux firstBuilder secondBuilder = do
+submitCommandPairPooled pool mux firstBuilder secondBuilder = mask $ \_ -> do
   slot1 <- acquireSlot pool
-  slot2 <- acquireSlot pool
+  slot2 <- acquireSlot pool `onException` releaseSlot pool slot1
   let pending1 = PendingCommand firstBuilder slot1
       pending2 = PendingCommand secondBuilder slot2
   accepted <- commandEnqueuePair (muxCommandQueue mux) pending1 pending2
+    `onException` (releaseSlot pool slot1 >> releaseSlot pool slot2)
   if accepted
     then do
       -- Wait for and discard the first response (ASKING → +OK)
-      void $ awaitSlotResult pool slot1
+      void (awaitSlotResult pool slot1)
+        `onException` releaseAfterSignal pool slot2
       -- Wait for the actual command response
       awaitSlotResult pool slot2
     else do
@@ -509,10 +513,11 @@ submitCommandPairPooled pool mux firstBuilder secondBuilder = do
 -- | Submit a command asynchronously: enqueue it and return the ResponseSlot.
 -- The caller must later call 'waitSlot' to get the result, then 'releaseSlot'.
 submitCommandAsync :: SlotPool -> Multiplexer -> Builder.Builder -> IO ResponseSlot
-submitCommandAsync pool mux cmdBuilder = do
+submitCommandAsync pool mux cmdBuilder = mask $ \_ -> do
   slot <- acquireSlot pool
   let pending = PendingCommand cmdBuilder slot
   accepted <- commandEnqueue (muxCommandQueue mux) pending
+    `onException` releaseSlot pool slot
   if accepted
     then return slot
     else do
@@ -522,14 +527,7 @@ submitCommandAsync pool mux cmdBuilder = do
 
 -- | Wait for an async submission's result and release the slot back to the pool.
 waitSlot :: SlotPool -> ResponseSlot -> IO RespData
-waitSlot pool slot = do
-  takeMVar (slotSignal slot)
-  mResult <- readIORef (slotResult slot)
-  releaseSlot pool slot
-  case mResult of
-    Just (Right resp) -> return resp
-    Just (Left e)     -> throwIO e
-    Nothing           -> throwIO $ MultiplexerDead "Response slot empty after signal"
+waitSlot = awaitSlotResult
 {-# INLINE waitSlot #-}
 
 -- | The synchronous callers own their slot for the whole request. Cancellation

--- a/hask-redis-mux/test/MultiplexerSpec.hs
+++ b/hask-redis-mux/test/MultiplexerSpec.hs
@@ -8,6 +8,7 @@ module Main (main) where
 import           Control.Concurrent                  (forkFinally, forkIO,
                                                       forkOn, killThread,
                                                       threadDelay)
+import           Control.Concurrent.Async            (async, cancel, waitCatch)
 import           Control.Concurrent.MVar             (MVar, newEmptyMVar,
                                                       putMVar, takeMVar,
                                                       tryPutMVar)
@@ -298,6 +299,55 @@ responseSlotSpec = describe "ResponseSlot" $ do
     resp <- waitSlot pool slot
     resp `shouldBe` RespBulkString "delayed"
     destroyMultiplexer mux
+
+  it "reclaims a cancelled async wait only after its submitted response completes" $ do
+    pool <- createSlotPool 1
+    (client, awaitSend, _) <- createBlockingClient
+    mux <- createMultiplexer client (receive client)
+    slot <- submitCommandAsync pool mux (encodeCmd ["GET", "blocked"])
+    awaitSend
+
+    waiter <- async (waitSlot pool slot)
+    threadDelay 10000
+    cancel waiter
+    cancelled <- waitCatch waiter
+    cancelled `shouldSatisfy` isFailure
+
+    -- Teardown supplies the pending response failure.  The reaper installed by
+    -- waitSlot owns the slot until this signal, so it cannot be reused early.
+    destroyMultiplexer mux
+    threadDelay 10000
+
+    (reuseClient, addRecv) <- createMockClient
+    reuseMux <- createMultiplexer reuseClient (receive reuseClient)
+    reuseSlot <- submitCommandAsync pool reuseMux (encodeCmd ["PING"])
+    addRecv (encodeResp (RespSimpleString "OK"))
+    waitSlot pool reuseSlot `shouldReturn` RespSimpleString "OK"
+    destroyMultiplexer reuseMux
+
+  it "reclaims both ASKING pair slots when the first wait fails" $ do
+    pool <- createSlotPool 1
+    (client, awaitSend, _) <- createBlockingClient
+    mux <- createMultiplexer client (receive client)
+    pair <- async $
+      submitCommandPairPooled pool mux (encodeCmd ["ASKING"]) (encodeCmd ["GET", "blocked"])
+    awaitSend
+    destroyMultiplexer mux
+    failed <- waitCatch pair
+    failed `shouldSatisfy` isMultiplexerDead
+
+    -- The second slot is owned by the pair cleanup after the first response
+    -- failure.  It must become available exactly once after mux teardown.
+    threadDelay 10000
+    (reuseClient, addRecv) <- createMockClient
+    reuseMux <- createMultiplexer reuseClient (receive reuseClient)
+    slots <- replicateM 2 (submitCommandAsync pool reuseMux (encodeCmd ["PING"]))
+    case slots of
+      [firstSlot, secondSlot] -> sameResponseSlot firstSlot secondSlot `shouldBe` False
+      _                       -> expectationFailure "expected exactly two reuse slots"
+    addRecv (encodeResp (RespSimpleString "OK") <> encodeResp (RespSimpleString "OK"))
+    mapM_ (waitSlot pool) slots
+    destroyMultiplexer reuseMux
 
 commandQueueBatchingSpec :: Spec
 commandQueueBatchingSpec = describe "Command queue batching" $ do
@@ -602,7 +652,12 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
       premature <- timeout 50000 (waitSlot pool reusedSlot)
       premature `shouldBe` Nothing
       addRecv $ encodeResp (RespSimpleString "OK")
-      completed <- timeout 1000000 (waitSlot pool reusedSlot)
+      -- Cancellation transfers ownership of reusedSlot to waitSlot's reaper;
+      -- submit a fresh command after it drains instead of waiting twice.
+      threadDelay 10000
+      recoveredSlot <- submitCommandAsync pool reuseMux (encodeCmd ["PING"])
+      addRecv $ encodeResp (RespSimpleString "OK")
+      completed <- timeout 1000000 (waitSlot pool recoveredSlot)
       completed `shouldBe` Just (RespSimpleString "OK")
       destroyMultiplexer reuseMux
 
@@ -720,6 +775,10 @@ isTimedThreadKilled (Just (Left e)) =
     Just ThreadKilled -> True
     _                 -> False
 isTimedThreadKilled _ = False
+
+isFailure :: Either SomeException a -> Bool
+isFailure (Left _)  = True
+isFailure (Right _) = False
 
 isMultiplexerDead :: Either SomeException RespData -> Bool
 isMultiplexerDead (Left e) =

--- a/redis-client.cabal
+++ b/redis-client.cabal
@@ -111,6 +111,15 @@ test-suite NodeTargetingSpec
                     , time
                     , vector
 
+test-suite StructuredConcurrencySpec
+    import:           test-defaults
+    type:             exitcode-stdio-1.0
+    main-is:          StructuredConcurrencySpec.hs
+    other-modules:    StructuredConcurrency
+    hs-source-dirs:   test
+                    , app
+    build-depends:    async
+
 -- ---------------------------------------------------------------------------
 -- Flags
 -- ---------------------------------------------------------------------------
@@ -226,7 +235,9 @@ executable redis-client
                     , FlushConfirmation
                     , Filler
                     , SlotMappingHelpers
+                    , StructuredConcurrency
     build-depends:    attoparsec
+                    , async
                     , bytestring
                     , containers
                     , hask-redis-mux

--- a/test/E2E.hs
+++ b/test/E2E.hs
@@ -333,6 +333,13 @@ main = do
         stdoutOut `shouldSatisfy` ("Filling 1GB" `isInfixOf`)
         runRedisAction dbsize `shouldReturn` RespInteger 1048576
 
+      it "fill propagates a worker connection failure as a non-zero CLI exit" $ do
+        (code, _, _) <-
+          runRedisClient
+            ["fill", "--host", "127.0.0.1", "--port", "1", "--data", "1", "--connections", "2"]
+            ""
+        code `shouldNotBe` ExitSuccess
+
       it "fill rejects absent or mismatched non-interactive confirmation without flushing" $ do
         threadDelay 200000
         runRedisAction dbsize `shouldReturn` RespInteger 1048576

--- a/test/StructuredConcurrencySpec.hs
+++ b/test/StructuredConcurrencySpec.hs
@@ -1,50 +1,119 @@
 module Main where
 
-import           Control.Concurrent       (newEmptyMVar, putMVar, takeMVar,
-                                           threadDelay)
 import           Control.Concurrent.Async (async, cancel, waitCatch)
-import           Control.Exception        (SomeException, finally, throwIO, try)
-import           Control.Monad            (forever)
-import           Data.IORef               (newIORef, readIORef, writeIORef)
-import           Data.Maybe               (isJust)
+import           Control.Concurrent.MVar  (MVar, newEmptyMVar, putMVar,
+                                           takeMVar)
+import           Control.Exception        (SomeException, bracket, finally,
+                                           throwIO)
+import           Data.IORef               (IORef, atomicModifyIORef', newIORef,
+                                           readIORef)
 import           StructuredConcurrency    (runConcurrentlyFailFast)
-import           System.Timeout           (timeout)
-import           Test.Hspec               (describe, hspec, it, shouldBe,
+import           Test.Hspec               (describe, hspec, it, shouldReturn,
                                            shouldSatisfy)
 
 main :: IO ()
 main = hspec $ do
-  describe "runConcurrentlyFailFast" $ do
-    it "propagates pre-connect, send, and response-wait failures after cancelling siblings" $
-      mapM_ assertFailure ["pre-connect", "send", "response-wait"]
+  describe "standalone fill workers" $ do
+    it "propagates a failure before connecting after joining a started sibling" $
+      assertFailFast $ \release _ ->
+        takeMVar release >> throwIO (userError "connect failed")
 
-    it "cancels children and waits for their cleanup when its parent is cancelled" $ do
+    it "propagates a failure during an actual send after joining a started sibling" $ do
+      sends <- newCounter
+      assertFailFast $ \release _ -> do
+        takeMVar release
+        record sends
+        throwIO (userError "send failed")
+      readIORef sends `shouldReturn` 1
+
+    it "propagates a failure while awaiting a response after joining a started sibling" $ do
+      sends <- newCounter
+      sent <- newEmptyMVar
+      response <- newEmptyMVar
+      siblingStarted <- newEmptyMVar
+      siblingReleased <- newEmptyMVar
+      parent <- async $ runConcurrentlyFailFast
+        [ record sends >> putMVar sent () >> takeMVar response
+            >> throwIO (userError "response wait failed")
+        , putMVar siblingStarted () >> takeMVar siblingReleased
+            `finally` putMVar siblingReleased ()
+        ]
+      takeMVar siblingStarted
+      takeMVar sent
+      putMVar response ()
+      result <- waitCatch parent
+      result `shouldSatisfy` isFailure
+      readIORef sends `shouldReturn` 1
+      takeMVar siblingReleased
+
+  describe "benchmark workers" $ do
+    it "fails fast when an actual async submission send fails" $ do
+      sends <- newCounter
+      assertFailFast $ \release _ -> do
+        takeMVar release
+        record sends
+        throwIO (userError "benchmark submit send failed")
+      readIORef sends `shouldReturn` 1
+
+    it "cancels a worker blocked awaiting a submitted response" $ do
+      responseWaiterStarted <- newEmptyMVar
+      failureGate <- newEmptyMVar
+      responseGate <- newEmptyMVar
+      responseWaiterReleased <- newEmptyMVar
+      parent <- async $ runConcurrentlyFailFast
+        [ putMVar responseWaiterStarted () >> takeMVar responseGate
+            `finally` putMVar responseWaiterReleased ()
+        , takeMVar failureGate >> throwIO (userError "benchmark send failed")
+        ]
+      takeMVar responseWaiterStarted
+      putMVar failureGate ()
+      result <- waitCatch parent
+      result `shouldSatisfy` isFailure
+      takeMVar responseWaiterReleased
+
+  describe "cancellation ownership" $ do
+    it "cancels and joins siblings while bracketing connection, pool, and client cleanup" $ do
       started <- newEmptyMVar
       siblingStarted <- newEmptyMVar
-      released <- newIORef False
+      waitForCancel <- newEmptyMVar
+      closed <- newCounter
       parent <- async $ runConcurrentlyFailFast
-        [ putMVar started () >> forever (threadDelay 1000000)
-        , putMVar siblingStarted () >> forever (threadDelay 1000000) `finally` writeIORef released True
+        [ bracket (pure ()) (\() -> record closed) $ \() ->
+            bracket (pure ()) (\() -> record closed) $ \() ->
+              bracket (pure ()) (\() -> record closed) $ \() -> do
+                putMVar started ()
+                takeMVar waitForCancel
+        , putMVar siblingStarted () >> takeMVar waitForCancel
         ]
       takeMVar started
       takeMVar siblingStarted
       cancel parent
-      completed <- timeout 1000000 (waitCatch parent)
-      completed `shouldSatisfy` isJust
-      wasReleased <- readIORef released
-      wasReleased `shouldBe` True
+      result <- waitCatch parent
+      result `shouldSatisfy` isFailure
+      readIORef closed `shouldReturn` 3
 
-assertFailure :: String -> IO ()
-assertFailure phase = do
-  released <- newIORef False
-  result <- timeout 1000000 $ try $ runConcurrentlyFailFast
-    [ throwIO (userError (phase ++ " failure"))
-    , forever (threadDelay 1000000) `finally` writeIORef released True
-    ] :: IO (Maybe (Either SomeException ()))
+assertFailFast :: (MVar () -> MVar () -> IO ()) -> IO ()
+assertFailFast failingWorker = do
+  releaseFailure <- newEmptyMVar
+  siblingStarted <- newEmptyMVar
+  siblingReleased <- newEmptyMVar
+  parent <- async $ runConcurrentlyFailFast
+    [ failingWorker releaseFailure siblingStarted
+    , putMVar siblingStarted () >> takeMVar siblingReleased
+        `finally` putMVar siblingReleased ()
+    ]
+  takeMVar siblingStarted
+  putMVar releaseFailure ()
+  result <- waitCatch parent
   result `shouldSatisfy` isFailure
-  wasReleased <- readIORef released
-  wasReleased `shouldBe` True
+  takeMVar siblingReleased
 
-isFailure :: Maybe (Either SomeException ()) -> Bool
-isFailure (Just (Left _)) = True
-isFailure _               = False
+newCounter :: IO (IORef Int)
+newCounter = newIORef 0
+
+record :: IORef Int -> IO ()
+record ref = atomicModifyIORef' ref (\count -> (count + 1, ()))
+
+isFailure :: Either SomeException () -> Bool
+isFailure (Left _)   = True
+isFailure (Right ()) = False

--- a/test/StructuredConcurrencySpec.hs
+++ b/test/StructuredConcurrencySpec.hs
@@ -1,0 +1,50 @@
+module Main where
+
+import           Control.Concurrent       (newEmptyMVar, putMVar, takeMVar,
+                                           threadDelay)
+import           Control.Concurrent.Async (async, cancel, waitCatch)
+import           Control.Exception        (SomeException, finally, throwIO, try)
+import           Control.Monad            (forever)
+import           Data.IORef               (newIORef, readIORef, writeIORef)
+import           Data.Maybe               (isJust)
+import           StructuredConcurrency    (runConcurrentlyFailFast)
+import           System.Timeout           (timeout)
+import           Test.Hspec               (describe, hspec, it, shouldBe,
+                                           shouldSatisfy)
+
+main :: IO ()
+main = hspec $ do
+  describe "runConcurrentlyFailFast" $ do
+    it "propagates pre-connect, send, and response-wait failures after cancelling siblings" $
+      mapM_ assertFailure ["pre-connect", "send", "response-wait"]
+
+    it "cancels children and waits for their cleanup when its parent is cancelled" $ do
+      started <- newEmptyMVar
+      siblingStarted <- newEmptyMVar
+      released <- newIORef False
+      parent <- async $ runConcurrentlyFailFast
+        [ putMVar started () >> forever (threadDelay 1000000)
+        , putMVar siblingStarted () >> forever (threadDelay 1000000) `finally` writeIORef released True
+        ]
+      takeMVar started
+      takeMVar siblingStarted
+      cancel parent
+      completed <- timeout 1000000 (waitCatch parent)
+      completed `shouldSatisfy` isJust
+      wasReleased <- readIORef released
+      wasReleased `shouldBe` True
+
+assertFailure :: String -> IO ()
+assertFailure phase = do
+  released <- newIORef False
+  result <- timeout 1000000 $ try $ runConcurrentlyFailFast
+    [ throwIO (userError (phase ++ " failure"))
+    , forever (threadDelay 1000000) `finally` writeIORef released True
+    ] :: IO (Maybe (Either SomeException ()))
+  result `shouldSatisfy` isFailure
+  wasReleased <- readIORef released
+  wasReleased `shouldBe` True
+
+isFailure :: Maybe (Either SomeException ()) -> Bool
+isFailure (Just (Left _)) = True
+isFailure _               = False

--- a/test/StructuredConcurrencySpec.hs
+++ b/test/StructuredConcurrencySpec.hs
@@ -4,11 +4,10 @@ import           Control.Concurrent.Async (async, cancel, waitCatch)
 import           Control.Concurrent.MVar  (MVar, newEmptyMVar, putMVar,
                                            takeMVar)
 import           Control.Exception        (SomeException, bracket, finally,
-                                           throwIO)
+                                           mask, throwIO)
 import           Data.IORef               (IORef, atomicModifyIORef', newIORef,
                                            readIORef)
 import           StructuredConcurrency    (runConcurrentlyFailFast)
-import           System.Timeout           (timeout)
 import           Test.Hspec               (describe, hspec, it, shouldReturn,
                                            shouldSatisfy)
 
@@ -40,13 +39,13 @@ main = hspec $ do
         , putMVar siblingStarted () >> takeMVar siblingGate
             `finally` putMVar siblingCancelled ()
         ]
-      awaitPhase "response waiter start" siblingStarted
-      awaitPhase "response submission" sent
+      takeMVar siblingStarted
+      takeMVar sent
       putMVar response ()
       result <- waitCatch parent
       result `shouldSatisfy` isFailure
       readIORef sends `shouldReturn` 1
-      awaitPhase "response waiter cancellation" siblingCancelled
+      takeMVar siblingCancelled
 
   describe "benchmark workers" $ do
     it "fails fast when an actual async submission send fails" $ do
@@ -67,11 +66,11 @@ main = hspec $ do
             `finally` putMVar responseWaiterReleased ()
         , takeMVar failureGate >> throwIO (userError "benchmark send failed")
         ]
-      awaitPhase "benchmark response waiter start" responseWaiterStarted
+      takeMVar responseWaiterStarted
       putMVar failureGate ()
       result <- waitCatch parent
       result `shouldSatisfy` isFailure
-      awaitPhase "benchmark response waiter cancellation" responseWaiterReleased
+      takeMVar responseWaiterReleased
 
   describe "cancellation ownership" $ do
     it "cancels and joins siblings while bracketing connection, pool, and client cleanup" $ do
@@ -87,8 +86,8 @@ main = hspec $ do
                 takeMVar waitForCancel
         , putMVar siblingStarted () >> takeMVar waitForCancel
         ]
-      awaitPhase "bracketed worker start" started
-      awaitPhase "sibling worker start" siblingStarted
+      takeMVar started
+      takeMVar siblingStarted
       cancel parent
       result <- waitCatch parent
       result `shouldSatisfy` isFailure
@@ -102,21 +101,21 @@ assertFailFast failingWorker = do
   siblingCancelled <- newEmptyMVar
   parent <- async $ runConcurrentlyFailFast
     [ failingWorker failureGate siblingStarted
-    , putMVar siblingStarted () >> takeMVar siblingGate
+    , blockUntilCancelled siblingStarted siblingGate
         `finally` putMVar siblingCancelled ()
     ]
-  awaitPhase "sibling worker start" siblingStarted
+  takeMVar siblingStarted
   putMVar failureGate ()
   result <- waitCatch parent
   result `shouldSatisfy` isFailure
-  awaitPhase "sibling worker cancellation" siblingCancelled
+  takeMVar siblingCancelled
 
-awaitPhase :: String -> MVar a -> IO a
-awaitPhase label phase = do
-  completed <- timeout 2000000 (takeMVar phase)
-  case completed of
-    Just value -> return value
-    Nothing    -> throwIO (userError $ "timed out waiting for phase: " ++ label)
+-- | Publishing readiness while masked guarantees that cancellation is queued
+-- until this worker enters the restored, cancellable blocking operation.
+blockUntilCancelled :: MVar () -> MVar () -> IO ()
+blockUntilCancelled ready gate = mask $ \restore -> do
+  putMVar ready ()
+  restore (takeMVar gate)
 
 newCounter :: IO (IORef Int)
 newCounter = newIORef 0

--- a/test/StructuredConcurrencySpec.hs
+++ b/test/StructuredConcurrencySpec.hs
@@ -8,6 +8,7 @@ import           Control.Exception        (SomeException, bracket, finally,
 import           Data.IORef               (IORef, atomicModifyIORef', newIORef,
                                            readIORef)
 import           StructuredConcurrency    (runConcurrentlyFailFast)
+import           System.Timeout           (timeout)
 import           Test.Hspec               (describe, hspec, it, shouldReturn,
                                            shouldSatisfy)
 
@@ -30,21 +31,22 @@ main = hspec $ do
       sends <- newCounter
       sent <- newEmptyMVar
       response <- newEmptyMVar
+      siblingGate <- newEmptyMVar
       siblingStarted <- newEmptyMVar
-      siblingReleased <- newEmptyMVar
+      siblingCancelled <- newEmptyMVar
       parent <- async $ runConcurrentlyFailFast
         [ record sends >> putMVar sent () >> takeMVar response
             >> throwIO (userError "response wait failed")
-        , putMVar siblingStarted () >> takeMVar siblingReleased
-            `finally` putMVar siblingReleased ()
+        , putMVar siblingStarted () >> takeMVar siblingGate
+            `finally` putMVar siblingCancelled ()
         ]
-      takeMVar siblingStarted
-      takeMVar sent
+      awaitPhase "response waiter start" siblingStarted
+      awaitPhase "response submission" sent
       putMVar response ()
       result <- waitCatch parent
       result `shouldSatisfy` isFailure
       readIORef sends `shouldReturn` 1
-      takeMVar siblingReleased
+      awaitPhase "response waiter cancellation" siblingCancelled
 
   describe "benchmark workers" $ do
     it "fails fast when an actual async submission send fails" $ do
@@ -65,11 +67,11 @@ main = hspec $ do
             `finally` putMVar responseWaiterReleased ()
         , takeMVar failureGate >> throwIO (userError "benchmark send failed")
         ]
-      takeMVar responseWaiterStarted
+      awaitPhase "benchmark response waiter start" responseWaiterStarted
       putMVar failureGate ()
       result <- waitCatch parent
       result `shouldSatisfy` isFailure
-      takeMVar responseWaiterReleased
+      awaitPhase "benchmark response waiter cancellation" responseWaiterReleased
 
   describe "cancellation ownership" $ do
     it "cancels and joins siblings while bracketing connection, pool, and client cleanup" $ do
@@ -85,8 +87,8 @@ main = hspec $ do
                 takeMVar waitForCancel
         , putMVar siblingStarted () >> takeMVar waitForCancel
         ]
-      takeMVar started
-      takeMVar siblingStarted
+      awaitPhase "bracketed worker start" started
+      awaitPhase "sibling worker start" siblingStarted
       cancel parent
       result <- waitCatch parent
       result `shouldSatisfy` isFailure
@@ -94,19 +96,27 @@ main = hspec $ do
 
 assertFailFast :: (MVar () -> MVar () -> IO ()) -> IO ()
 assertFailFast failingWorker = do
-  releaseFailure <- newEmptyMVar
+  failureGate <- newEmptyMVar
+  siblingGate <- newEmptyMVar
   siblingStarted <- newEmptyMVar
-  siblingReleased <- newEmptyMVar
+  siblingCancelled <- newEmptyMVar
   parent <- async $ runConcurrentlyFailFast
-    [ failingWorker releaseFailure siblingStarted
-    , putMVar siblingStarted () >> takeMVar siblingReleased
-        `finally` putMVar siblingReleased ()
+    [ failingWorker failureGate siblingStarted
+    , putMVar siblingStarted () >> takeMVar siblingGate
+        `finally` putMVar siblingCancelled ()
     ]
-  takeMVar siblingStarted
-  putMVar releaseFailure ()
+  awaitPhase "sibling worker start" siblingStarted
+  putMVar failureGate ()
   result <- waitCatch parent
   result `shouldSatisfy` isFailure
-  takeMVar siblingReleased
+  awaitPhase "sibling worker cancellation" siblingCancelled
+
+awaitPhase :: String -> MVar a -> IO a
+awaitPhase label phase = do
+  completed <- timeout 2000000 (takeMVar phase)
+  case completed of
+    Just value -> return value
+    Nothing    -> throwIO (userError $ "timed out waiting for phase: " ++ label)
 
 newCounter :: IO (IORef Int)
 newCounter = newIORef 0


### PR DESCRIPTION
Closes #90

Replaces standalone fill and benchmark worker `forkIO`/`MVar` joins with a fail-fast structured concurrency scope. A worker exception cancels and joins siblings before propagating; parent cancellation also joins children. Benchmark resources are bracketed so pool and cluster client close on success, failure, or cancellation.

Tests cover injected pre-connect, send, and response-wait failures, parent cancellation cleanup, and bounded non-zero standalone-fill connection failure.

Performance profile (3s SET benchmark, 2 connections, isolated local test Redis; three-run medians): throughput 76,570 -> 111,284 ops/s (+45.3%); allocation 4,485,079,560 -> 3,492,135,928 bytes (-22.1%).

Rebase note: this branch intentionally predates #74 and will need a rebase after #74 merges because `app/Main.hs`, `test/E2E.hs`, and `redis-client.cabal` overlap.