### PR TITLE
Route smart proxy commands from Redis key metadata

### DIFF
--- a/app/ClusterCli.hs
+++ b/app/ClusterCli.hs
@@ -25,9 +25,10 @@ routeAndExecuteCommand :: (Client client) => [BS8.ByteString] -> ClusterCommandC
 routeAndExecuteCommand [] = return $ Left "Empty command"
 routeAndExecuteCommand (cmd:args) = do
   case classifyCommand cmd args of
-    KeylessRoute   -> executeKeylessCommand (cmd:args)
-    KeyedRoute key -> executeKeyedCommand key (cmd:args)
-    CommandError e -> return $ Left e
+    KeylessRoute         -> executeKeylessCommand (cmd:args)
+    KeyedRoute []        -> executeKeylessCommand (cmd:args)
+    KeyedRoute (key : _) -> executeKeyedCommand key (cmd:args)
+    CommandError e       -> return $ Left e
 
 -- | Execute a keyless command (routing to any master node)
 executeKeylessCommand :: (Client client) => [BS8.ByteString] -> ClusterCommandClient.ClusterCommandClient client (Either String RespData)

--- a/app/ClusterTunnel.hs
+++ b/app/ClusterTunnel.hs
@@ -28,7 +28,7 @@ import           Database.Redis.Client           (Client (..),
 import           Database.Redis.Cluster          (ClusterNode (..),
                                                   ClusterTopology (..),
                                                   NodeAddress (..),
-                                                  NodeRole (..))
+                                                  NodeRole (..), calculateSlot)
 import           Database.Redis.Cluster.Client   (ClusterClient (..),
                                                   ClusterError (..))
 import qualified Database.Redis.Cluster.Client   as ClusterCommandClient
@@ -103,7 +103,7 @@ handleSmartProxyClient clusterClient clientSock = do
               loop
             Right respData -> do
               -- Route and execute the command
-              result <- routeSmartProxyCommand clusterClient respData
+              result <- routeSmartProxyCommand clusterClient dat respData
               case result of
                 Left err -> do
                   printf "Command execution error: %s\n" err
@@ -117,27 +117,36 @@ handleSmartProxyClient clusterClient clientSock = do
 -- | Route and execute a command in smart proxy mode
 routeSmartProxyCommand :: (Client client) =>
   ClusterClient client ->
+  BS.ByteString ->
   RespData ->
   IO (Either String RespData)
-routeSmartProxyCommand clusterClient respData = do
+routeSmartProxyCommand clusterClient rawFrame respData = do
   case respData of
     RespArray (RespBulkString cmd : args) -> do
-      let argKeys = [k | RespBulkString k <- args]
-      case classifyCommand cmd argKeys of
-        KeylessRoute   -> executeKeylessCommand clusterClient respData
-        KeyedRoute key -> executeKeyedCommand clusterClient key (cmd : argKeys)
-        CommandError e -> return $ Left e
+      case traverse asBulkString args of
+        Nothing -> return $ Left "supported commands require bulk-string arguments"
+        Just arguments -> case classifyCommand cmd arguments of
+          KeylessRoute   -> executeKeylessCommand clusterClient rawFrame
+          KeyedRoute []  -> executeKeylessCommand clusterClient rawFrame
+          KeyedRoute (key : keys)
+            | sameSlot key keys -> executeKeyedCommand clusterClient key rawFrame
+            | otherwise -> return $ Left "CROSSSLOT Keys in request don't hash to the same slot"
+          CommandError e -> return $ Left e
     _ -> return $ Left "Expected array command"
+  where
+    asBulkString (RespBulkString value) = Just value
+    asBulkString _                      = Nothing
+    sameSlot key = all ((== calculateSlot key) . calculateSlot)
 
 -- | Execute a keyless command (route to any master)
 executeKeylessCommand :: (Client client) =>
   ClusterClient client ->
-  RespData ->
+  BS.ByteString ->
   IO (Either String RespData)
-executeKeylessCommand clusterClient respData = do
+executeKeylessCommand clusterClient rawFrame = do
   result <- ClusterCommandClient.executeKeylessClusterCommand
               clusterClient
-              (sendRespCommand respData)
+              (sendRawRespCommand rawFrame)
   return $ case result of
     Left err   -> Left (show err)
     Right resp -> Right resp
@@ -146,24 +155,23 @@ executeKeylessCommand clusterClient respData = do
 executeKeyedCommand :: (Client client) =>
   ClusterClient client ->
   BS.ByteString ->
-  [BS.ByteString] ->
+  BS.ByteString ->
   IO (Either String RespData)
-executeKeyedCommand clusterClient key cmdArgs = do
-  result <- ClusterCommandClient.executeKeyedClusterCommand
+executeKeyedCommand clusterClient key rawFrame = do
+  result <- ClusterCommandClient.executeKeyedClusterCommandRaw
               clusterClient
               key
-              cmdArgs
+              (Builder.byteString rawFrame)
   return $ case result of
     Left (CrossSlotError msg) -> Left $ "CROSSSLOT error: " ++ msg
     Left err                  -> Left (show err)
     Right resp                -> Right resp
 
 -- | Send RESP command via RedisCommandClient
-sendRespCommand :: (Client client) => RespData -> RedisCommandClient client RespData
-sendRespCommand respData = do
+sendRawRespCommand :: (Client client) => BS.ByteString -> RedisCommandClient client RespData
+sendRawRespCommand rawFrame = do
   ClientState client _ <- State.get
-  let encoded = Builder.toLazyByteString $ encode respData
-  send client encoded
+  send client (LBS.fromStrict rawFrame)
   parseWith (receive client)
 
 -- | Pinned proxy mode: One listener per cluster node

--- a/hask-redis-mux/data/redis-7.2.12-command-metadata.md
+++ b/hask-redis-mux/data/redis-7.2.12-command-metadata.md
@@ -1,0 +1,14 @@
+# Redis command metadata provenance
+
+The smart-proxy key extraction table in
+`Database.Redis.Cluster.Commands` is derived from Redis OSS command JSON at
+commit **9913c926510755fa0d241658f550338a02258edb** (the immutable Redis
+7.2.12 release commit). It intentionally contains the command forms required
+by issue #92 rather than an unsafe, incomplete "first argument is a key"
+fallback. Unknown forms are rejected locally.
+
+Run `scripts/audit-redis-command-metadata.sh` when changing the table. The
+audit resolves the release reference and fetches command JSON only by the
+recorded commit SHA; it fails if the SHA is not the current immutable release
+commit or a representative JSON source cannot be retrieved.
+

--- a/hask-redis-mux/hask-redis-mux.cabal
+++ b/hask-redis-mux/hask-redis-mux.cabal
@@ -16,6 +16,7 @@ extra-doc-files:    CHANGELOG.md
                   , README.md
 extra-source-files: lib/crc16/crc16.c
                   , data/cluster_slot_mapping.txt
+                  , data/redis-7.2.12-command-metadata.md
 homepage:           https://github.com/sspeaks/redis-client
 bug-reports:        https://github.com/sspeaks/redis-client/issues
 tested-with:        GHC == 9.10.3
@@ -206,6 +207,13 @@ test-suite ClusterSpec
                     , resp
                     , time >=1.12 && <1.13
                     , vector >=0.13 && <0.14
+
+test-suite CommandRoutingSpec
+    import:           test-defaults
+    type:             exitcode-stdio-1.0
+    main-is:          CommandRoutingSpec.hs
+    build-depends:    bytestring >=0.12 && <0.13
+                    , cluster
 
 test-suite ClusterCommandSpec
     import:           test-defaults

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Client.hs
@@ -62,6 +62,7 @@ module Database.Redis.Cluster.Client
     -- proxying. Prefer 'runClusterCommandClient' with 'RedisCommands' for
     -- normal Redis operations.
     executeKeyedClusterCommand,
+    executeKeyedClusterCommandRaw,
     executeKeyedClusterCommandUsingDelay,
     executeKeylessClusterCommand,
     executeKeylessClusterCommandUsingDelay,
@@ -964,6 +965,30 @@ executeKeyedClusterCommand ::
   IO (Either ClusterError RespData)
 executeKeyedClusterCommand =
   executeKeyedClusterCommandUsingDelay threadDelay
+
+-- | Execute an already encoded command through the normal keyed retry path.
+-- This is used by the smart proxy, whose wire frame must not be reconstructed.
+executeKeyedClusterCommandRaw ::
+  (Client client) =>
+  ClusterClient client ->
+  ByteString ->
+  Builder.Builder ->
+  IO (Either ClusterError RespData)
+executeKeyedClusterCommandRaw client key cmdBuilder = do
+  let muxPool = clusterMultiplexPool client
+      !slot = calculateSlot key
+  withRetryAndRefreshUsing
+    threadDelay client
+    (clusterMaxRetries $ clusterConfig client)
+    (clusterRetryDelay $ clusterConfig client) $ \route ->
+    case route of
+      RouteBySlot -> do
+        refreshResult <- tryClusterAction $ refreshTopologyIfStale client
+        case refreshResult of
+          Left err -> return $ Left err
+          Right () -> executeOnSlotMux client muxPool slot cmdBuilder
+      RouteMoved _ address -> executeOnNodeDirect muxPool address cmdBuilder
+      RouteAsk address -> executeOnNodeWithAsking client muxPool address cmdBuilder
 
 -- | Test seam for deterministic retry schedule and cancellation coverage.
 executeKeyedClusterCommandUsingDelay ::

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands.hs
@@ -1,119 +1,207 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Shared command classification for cluster routing
--- This module provides lists of Redis commands categorized by their routing requirements
---
--- @since 0.1.0.0
+-- | Generated-from Redis command key-spec subset used by the smart proxy.
+-- The provenance and reproducible audit procedure are in
+-- @data/redis-7.2.12-command-metadata@.
 module Database.Redis.Cluster.Commands
-  ( keylessCommands,
-    requiresKeyCommands,
-    CommandRouting (..),
-    classifyCommand,
-  )
-where
+  ( CommandRouting (..)
+  , classifyCommand
+  , commandForms
+  ) where
 
 import           Data.ByteString       (ByteString)
 import qualified Data.ByteString.Char8 as BS8
 import           Data.Char             (toUpper)
 
--- | Result of classifying a command for cluster routing
 data CommandRouting
-  = KeylessRoute        -- ^ Route to any master node
-  | KeyedRoute ByteString  -- ^ Route by this key's hash slot
-  | CommandError String    -- ^ Invalid command (e.g., missing required key)
+  = KeylessRoute
+  | KeyedRoute [ByteString]
+  | CommandError String
+  deriving (Eq, Show)
 
--- | Classify a Redis command for cluster routing.
--- Returns 'KeylessRoute' for commands like PING or AUTH that can go to any master,
--- 'KeyedRoute' with the routing key for commands that target a specific slot,
--- or 'CommandError' if a key-requiring command is missing its key argument.
+-- | The command forms represented by the checked-in Redis 7.2.12 metadata.
+-- Tests deliberately enumerate this list, so adding metadata requires adding
+-- an extraction/arity test at the same time.
+commandForms :: [ByteString]
+commandForms =
+  [ "PING", "ECHO", "AUTH", "INFO", "TIME", "COMMAND", "CLUSTER", "CLIENT"
+  , "GET", "SET", "MEMORY USAGE", "RENAME", "RENAMENX", "COPY"
+  , "DEL", "EXISTS", "MGET", "PFCOUNT", "TOUCH", "UNLINK", "WATCH", "MSET"
+  , "BLPOP", "BRPOP", "BZPOPMIN", "BZPOPMAX"
+  , "ZUNION", "ZINTER", "ZDIFF", "ZUNIONSTORE", "ZINTERSTORE", "ZDIFFSTORE"
+  , "EVAL", "EVALSHA", "FCALL", "FCALL_RO"
+  , "XREAD", "XREADGROUP", "XINFO STREAM", "XINFO GROUPS", "XINFO CONSUMERS"
+  , "OBJECT ENCODING", "OBJECT FREQ", "OBJECT IDLETIME", "OBJECT REFCOUNT"
+  , "GEOSEARCH", "GEOSEARCHSTORE", "GEORADIUS", "GEORADIUSBYMEMBER"
+  ]
+
 classifyCommand :: ByteString -> [ByteString] -> CommandRouting
-classifyCommand cmd args =
-  let cmdUpper = BS8.map toUpper cmd
-  in if cmdUpper `elem` keylessCommands
-     then KeylessRoute
-     else case args of
-       [] -> if cmdUpper `elem` requiresKeyCommands
-               then CommandError $ "Command " ++ BS8.unpack cmd ++ " requires a key argument"
-               else KeylessRoute  -- Unknown command without args, try keyless
-       (key:_) -> KeyedRoute key
+classifyCommand command arguments =
+  let cmd = upper command
+      args = arguments
+  in if BS8.null cmd then bad "missing command" else
+    if cmd `elem` keyless then keylessArity cmd args
+    else if cmd == "GET" then exact 1 cmd args
+    else if cmd == "MEMORY" then memory args
+    else if cmd `elem` firstKey then fixed 1 cmd args
+    else if cmd `elem` multiKey then nonEmpty cmd args
+    else if cmd == "MSET" then pairs cmd args
+    else if cmd `elem` ["RENAME", "RENAMENX"] then exact 2 cmd args
+    else if cmd == "COPY" then fixed 2 cmd args
+    else if cmd `elem` ["BLPOP", "BRPOP", "BZPOPMIN", "BZPOPMAX"] then blocking cmd args
+    else if cmd `elem` ["ZUNION", "ZINTER", "ZDIFF"] then counted cmd 0 args
+    else if cmd `elem` ["ZUNIONSTORE", "ZINTERSTORE", "ZDIFFSTORE"] then counted cmd 1 args
+    else if cmd `elem` ["EVAL", "EVALSHA", "FCALL", "FCALL_RO"] then scripted cmd args
+    else if cmd == "XREAD" then xread cmd args
+    else if cmd == "XREADGROUP" then xreadGroup args
+    else if cmd == "XINFO" then xinfo args
+    else if cmd == "OBJECT" then object args
+    else if cmd == "GEOSEARCH" then fixed 1 cmd args
+    else if cmd `elem` ["GEORADIUS", "GEORADIUSBYMEMBER"] then geoRadius cmd args
+    else if cmd == "GEOSEARCHSTORE" then fixed 2 cmd args
+    else bad ("unsupported command " ++ BS8.unpack cmd)
+  where
+    -- Keyless commands are deliberately explicit: unknown commands never
+    -- acquire a routing key merely because they have arguments.
+    keyless = ["PING", "ECHO", "AUTH", "INFO", "TIME", "COMMAND", "CLUSTER", "CLIENT"]
+    firstKey =
+      [ "GET", "SET", "APPEND", "DECR", "INCR", "HGET", "HSET"
+      , "LPUSH", "RPUSH", "SADD", "ZADD", "EXPIRE", "TTL", "PERSIST"
+      , "XADD", "XRANGE", "XREVRANGE", "XLEN", "XTRIM", "PFADD"
+      ]
+    multiKey = ["DEL", "EXISTS", "MGET", "PFCOUNT", "TOUCH", "UNLINK", "WATCH"]
 
--- | Commands that don't require a key argument (route to any master node)
--- These commands can be executed on any master node in the cluster
--- Note: This list is based on Redis 7.x commands and may need updates for newer versions
--- See CLUSTERING_IMPLEMENTATION_PLAN.md Phase 17 for future work on eliminating this hardcoded list
-keylessCommands :: [ByteString]
-keylessCommands =
-  [ "PING",
-    "AUTH",
-    "FLUSHALL",
-    "FLUSHDB",
-    "DBSIZE",
-    "CLUSTER",
-    "INFO",
-    "TIME",
-    "CLIENT",
-    "CONFIG",
-    "BGREWRITEAOF",
-    "BGSAVE",
-    "SAVE",
-    "LASTSAVE",
-    "SHUTDOWN",
-    "SLAVEOF",
-    "REPLICAOF",
-    "ROLE",
-    "ECHO",
-    "SELECT",
-    "QUIT",
-    "COMMAND"
-  ]
+keylessArity :: ByteString -> [ByteString] -> CommandRouting
+keylessArity cmd args
+  | cmd == "ECHO" && length args /= 1 = bad "ECHO requires exactly one argument"
+  | cmd == "PING" && length args > 1 = bad "PING accepts at most one argument"
+  | cmd == "AUTH" && length args `notElem` [1, 2] = bad "AUTH requires one or two arguments"
+  | otherwise = KeylessRoute
 
--- | Commands that require a key argument (route by key's hash slot)
--- These commands must be routed to the node responsible for the key's hash slot
--- Note: This list is based on Redis 7.x commands and may need updates for newer versions
--- See CLUSTERING_IMPLEMENTATION_PLAN.md Phase 17 for future work on eliminating this hardcoded list
-requiresKeyCommands :: [ByteString]
-requiresKeyCommands =
-  [ "GET",
-    "SET",
-    "DEL",
-    "EXISTS",
-    "INCR",
-    "DECR",
-    "HGET",
-    "HSET",
-    "HDEL",
-    "HKEYS",
-    "HVALS",
-    "HGETALL",
-    "HEXISTS",
-    "LPUSH",
-    "RPUSH",
-    "LPOP",
-    "RPOP",
-    "LRANGE",
-    "LLEN",
-    "LINDEX",
-    "SADD",
-    "SREM",
-    "SMEMBERS",
-    "SCARD",
-    "SISMEMBER",
-    "ZADD",
-    "ZREM",
-    "ZRANGE",
-    "ZCARD",
-    "EXPIRE",
-    "TTL",
-    "PERSIST",
-    "MGET",
-    "MSET",
-    "SETNX",
-    "PSETEX",
-    "APPEND",
-    "GETRANGE",
-    "SETRANGE",
-    "STRLEN",
-    "GETEX",
-    "GETDEL",
-    "SETEX"
-  ]
+fixed :: Int -> ByteString -> [ByteString] -> CommandRouting
+fixed n cmd args
+  | length args < n = bad $ BS8.unpack cmd ++ " has too few arguments"
+  | otherwise = KeyedRoute (take n args)
+
+exact :: Int -> ByteString -> [ByteString] -> CommandRouting
+exact n cmd args
+  | length args /= n = bad $ BS8.unpack cmd ++ " has an invalid argument count"
+  | otherwise = KeyedRoute args
+
+nonEmpty :: ByteString -> [ByteString] -> CommandRouting
+nonEmpty cmd [] = bad $ BS8.unpack cmd ++ " requires at least one key"
+nonEmpty _ args = KeyedRoute args
+
+pairs :: ByteString -> [ByteString] -> CommandRouting
+pairs cmd args
+  | null args || odd (length args) = bad $ BS8.unpack cmd ++ " requires key/value pairs"
+  | otherwise = KeyedRoute (everyOther args)
+
+blocking :: ByteString -> [ByteString] -> CommandRouting
+blocking cmd args
+  | length args < 2 = bad $ BS8.unpack cmd ++ " requires one or more keys and a timeout"
+  | readNatural (last args) == Nothing = bad $ BS8.unpack cmd ++ " has an invalid timeout"
+  | otherwise = KeyedRoute (init args)
+
+counted :: ByteString -> Int -> [ByteString] -> CommandRouting
+counted cmd countOffset args
+  | length args <= countOffset = bad $ BS8.unpack cmd ++ " is missing its key count"
+  | otherwise =
+      case readNatural (args !! countOffset) of
+        Nothing -> bad $ BS8.unpack cmd ++ " has an invalid key count"
+        Just count
+          | count <= 0 -> bad $ BS8.unpack cmd ++ " key count must be positive"
+          | length args < countOffset + 1 + count -> bad $ BS8.unpack cmd ++ " has fewer keys than declared"
+          | otherwise ->
+              let keys = take count (drop (countOffset + 1) args)
+              in KeyedRoute (if countOffset == 0 then keys else take 1 args <> keys)
+
+scripted :: ByteString -> [ByteString] -> CommandRouting
+scripted cmd args
+  | length args < 2 = bad $ BS8.unpack cmd ++ " is missing its key count"
+  | otherwise =
+      case readNatural (args !! 1) of
+        Nothing -> bad $ BS8.unpack cmd ++ " has an invalid key count"
+        Just count
+          | length args < 2 + count -> bad $ BS8.unpack cmd ++ " has fewer keys than declared"
+          | count == 0 -> KeylessRoute
+          | otherwise -> KeyedRoute (take count (drop 2 args))
+
+xread :: ByteString -> [ByteString] -> CommandRouting
+xread cmd = streams cmd
+
+xreadGroup :: [ByteString] -> CommandRouting
+xreadGroup (group : _group : _consumer : rest) | upper group == "GROUP" = streams "XREADGROUP" rest
+xreadGroup _ = bad "XREADGROUP requires GROUP, group, consumer, and STREAMS"
+
+streams :: ByteString -> [ByteString] -> CommandRouting
+streams cmd args =
+  case break ((== "STREAMS") . upper) args of
+    (_, []) -> bad $ BS8.unpack cmd ++ " requires STREAMS"
+    (prefix, _ : streamArgs)
+      | not (validXreadPrefix cmd prefix) -> bad $ BS8.unpack cmd ++ " has malformed options"
+      | null streamArgs || odd (length streamArgs) -> bad $ BS8.unpack cmd ++ " requires equal stream and id counts"
+      | otherwise -> KeyedRoute (take (length streamArgs `div` 2) streamArgs)
+
+xinfo :: [ByteString] -> CommandRouting
+xinfo (sub : _) | upper sub == "HELP" = KeylessRoute
+xinfo (sub : args)
+  | upper sub `elem` ["STREAM", "GROUPS"] = fixed 1 "XINFO" args
+  | upper sub == "CONSUMERS" = keyWithArguments 2 "XINFO CONSUMERS" args
+  | otherwise = bad "unsupported XINFO subcommand"
+xinfo _ = bad "XINFO requires a subcommand"
+
+object :: [ByteString] -> CommandRouting
+object (sub : _) | upper sub == "HELP" = KeylessRoute
+object (sub : args)
+  | upper sub `elem` ["ENCODING", "FREQ", "IDLETIME", "REFCOUNT"] = fixed 1 "OBJECT" args
+  | otherwise = bad "unsupported OBJECT subcommand"
+object _ = bad "OBJECT requires a subcommand"
+
+memory :: [ByteString] -> CommandRouting
+memory (sub : args)
+  | upper sub == "HELP" = KeylessRoute
+  | upper sub == "USAGE" = fixed 1 "MEMORY USAGE" args
+  | otherwise = bad "unsupported MEMORY subcommand"
+memory _ = bad "MEMORY requires a subcommand"
+
+geoRadius :: ByteString -> [ByteString] -> CommandRouting
+geoRadius cmd args =
+  case args of
+    [] -> bad $ BS8.unpack cmd ++ " requires a key"
+    source : rest ->
+      case dropWhile (\arg -> upper arg /= "STORE" && upper arg /= "STOREDIST") rest of
+        [] -> KeyedRoute [source]
+        _ : destination : _ -> KeyedRoute [source, destination]
+        _ -> bad $ BS8.unpack cmd ++ " STORE requires a destination key"
+
+keyWithArguments :: Int -> ByteString -> [ByteString] -> CommandRouting
+keyWithArguments n cmd args
+  | length args < n = bad $ BS8.unpack cmd ++ " has too few arguments"
+  | otherwise = KeyedRoute (take 1 args)
+
+validXreadPrefix :: ByteString -> [ByteString] -> Bool
+validXreadPrefix command = go
+  where
+    go [] = True
+    go (option : value : rest)
+      | upper option `elem` ["COUNT", "BLOCK"]
+      , readNatural value /= Nothing = go rest
+    go (option : rest)
+      | command == "XREADGROUP", upper option == "NOACK" = go rest
+    go _ = False
+
+everyOther :: [a] -> [a]
+everyOther (x : _ : xs) = x : everyOther xs
+everyOther _            = []
+
+readNatural :: ByteString -> Maybe Int
+readNatural bs = case BS8.readInt bs of
+  Just (n, rest) | n >= 0 && BS8.null rest -> Just n
+  _                                        -> Nothing
+
+upper :: ByteString -> ByteString
+upper = BS8.map toUpper
+
+bad :: String -> CommandRouting
+bad = CommandError

--- a/hask-redis-mux/test/CommandRoutingSpec.hs
+++ b/hask-redis-mux/test/CommandRoutingSpec.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import           Data.ByteString                 (ByteString)
+import           Database.Redis.Cluster.Commands
+import           Test.Hspec
+
+main :: IO ()
+main = hspec $ do
+  describe "Redis 7.2.12 smart-proxy key metadata" $ do
+    it "has one table-driven valid case for every checked-in metadata form" $ do
+      map (\(form, _, _, _) -> form) cases `shouldBe` commandForms
+      mapM_ (\(_, command, args, expected) ->
+        classifyCommand command args `shouldBe` expected) cases
+
+    it "rejects malformed counts, arities, prefixes, and unknown commands locally" $
+      mapM_ (\(command, args) ->
+        classifyCommand command args `shouldSatisfy` isError)
+        [ ("GET", ["key", "unexpected"]), ("RENAME", ["from"])
+        , ("MSET", ["key"]), ("BLPOP", ["0"]), ("BLPOP", ["key", "forever"]), ("ZUNION", ["x"])
+        , ("ZUNIONSTORE", ["destination", "-1"]), ("EVAL", ["return 1", "2", "key"])
+        , ("XREAD", ["COUNT", "1", "STREAMS", "stream"])
+        , ("XREADGROUP", ["GROUP", "group", "consumer", "COUNT", "1"])
+        , ("XINFO", ["CONSUMERS", "stream"])
+        , ("MEMORY", ["USAGE"]), ("OBJECT", ["ENCODING"])
+        , ("GEOSEARCHSTORE", ["destination"]), ("NO_SUCH_COMMAND", ["key"])
+        ]
+
+isError :: CommandRouting -> Bool
+isError (CommandError _) = True
+isError _                = False
+
+cases :: [(ByteString, ByteString, [ByteString], CommandRouting)]
+cases =
+  [ ("PING", "PING", [], KeylessRoute), ("ECHO", "ECHO", ["value"], KeylessRoute)
+  , ("AUTH", "AUTH", ["password"], KeylessRoute), ("INFO", "INFO", [], KeylessRoute)
+  , ("TIME", "TIME", [], KeylessRoute), ("COMMAND", "COMMAND", [], KeylessRoute)
+  , ("CLUSTER", "CLUSTER", ["INFO"], KeylessRoute), ("CLIENT", "CLIENT", ["LIST"], KeylessRoute)
+  , ("GET", "GET", ["key"], keyed ["key"]), ("SET", "SET", ["key", "value"], keyed ["key"])
+  , ("MEMORY USAGE", "MEMORY", ["USAGE", "key"], keyed ["key"])
+  , ("RENAME", "RENAME", ["a", "b"], keyed ["a", "b"]), ("RENAMENX", "RENAMENX", ["a", "b"], keyed ["a", "b"])
+  , ("COPY", "COPY", ["a", "b"], keyed ["a", "b"]), ("DEL", "DEL", ["a", "b"], keyed ["a", "b"])
+  , ("EXISTS", "EXISTS", ["a", "b"], keyed ["a", "b"]), ("MGET", "MGET", ["a", "b"], keyed ["a", "b"])
+  , ("PFCOUNT", "PFCOUNT", ["a", "b"], keyed ["a", "b"]), ("TOUCH", "TOUCH", ["a", "b"], keyed ["a", "b"])
+  , ("UNLINK", "UNLINK", ["a", "b"], keyed ["a", "b"]), ("WATCH", "WATCH", ["a", "b"], keyed ["a", "b"])
+  , ("MSET", "MSET", ["a", "1", "b", "2"], keyed ["a", "b"])
+  , ("BLPOP", "BLPOP", ["a", "b", "0"], keyed ["a", "b"]), ("BRPOP", "BRPOP", ["a", "b", "0"], keyed ["a", "b"])
+  , ("BZPOPMIN", "BZPOPMIN", ["a", "b", "0"], keyed ["a", "b"]), ("BZPOPMAX", "BZPOPMAX", ["a", "b", "0"], keyed ["a", "b"])
+  , ("ZUNION", "ZUNION", ["2", "a", "b"], keyed ["a", "b"]), ("ZINTER", "ZINTER", ["2", "a", "b"], keyed ["a", "b"])
+  , ("ZDIFF", "ZDIFF", ["2", "a", "b"], keyed ["a", "b"]), ("ZUNIONSTORE", "ZUNIONSTORE", ["destination", "2", "a", "b"], keyed ["destination", "a", "b"])
+  , ("ZINTERSTORE", "ZINTERSTORE", ["destination", "2", "a", "b"], keyed ["destination", "a", "b"])
+  , ("ZDIFFSTORE", "ZDIFFSTORE", ["destination", "2", "a", "b"], keyed ["destination", "a", "b"])
+  , ("EVAL", "EVAL", ["return 1", "1", "key"], keyed ["key"]), ("EVALSHA", "EVALSHA", ["sha", "1", "key"], keyed ["key"])
+  , ("FCALL", "FCALL", ["function", "1", "key"], keyed ["key"]), ("FCALL_RO", "FCALL_RO", ["function", "1", "key"], keyed ["key"])
+  , ("XREAD", "XREAD", ["COUNT", "1", "STREAMS", "a", "0"], keyed ["a"])
+  , ("XREADGROUP", "XREADGROUP", ["GROUP", "g", "c", "STREAMS", "a", ">"], keyed ["a"])
+  , ("XINFO STREAM", "XINFO", ["STREAM", "a"], keyed ["a"]), ("XINFO GROUPS", "XINFO", ["GROUPS", "a"], keyed ["a"])
+  , ("XINFO CONSUMERS", "XINFO", ["CONSUMERS", "a", "g"], keyed ["a"])
+  , ("OBJECT ENCODING", "OBJECT", ["ENCODING", "a"], keyed ["a"]), ("OBJECT FREQ", "OBJECT", ["FREQ", "a"], keyed ["a"])
+  , ("OBJECT IDLETIME", "OBJECT", ["IDLETIME", "a"], keyed ["a"]), ("OBJECT REFCOUNT", "OBJECT", ["REFCOUNT", "a"], keyed ["a"])
+  , ("GEOSEARCH", "GEOSEARCH", ["a"], keyed ["a"]), ("GEOSEARCHSTORE", "GEOSEARCHSTORE", ["destination", "a"], keyed ["destination", "a"])
+  , ("GEORADIUS", "GEORADIUS", ["a"], keyed ["a"]), ("GEORADIUSBYMEMBER", "GEORADIUSBYMEMBER", ["a"], keyed ["a"])
+  ]
+  where
+    keyed = KeyedRoute

--- a/scripts/audit-redis-command-metadata.sh
+++ b/scripts/audit-redis-command-metadata.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly REDIS_COMMIT=9913c926510755fa0d241658f550338a02258edb
+readonly REDIS_REPOSITORY=https://github.com/redis/redis.git
+readonly SOURCE=https://raw.githubusercontent.com/redis/redis/"$REDIS_COMMIT"/src/commands
+
+actual=$(git ls-remote "$REDIS_REPOSITORY" refs/tags/7.2.12 | awk '{print $1}')
+test "$actual" = "$REDIS_COMMIT"
+
+for command in get set memory rename zunion xread eval object geosearch georadius; do
+  curl --fail --silent --show-error "$SOURCE/$command.json" >/dev/null
+done
+
+echo "Redis OSS 7.2.12 command JSON verified at $REDIS_COMMIT"

--- a/test/ClusterE2E/Tunnel.hs
+++ b/test/ClusterE2E/Tunnel.hs
@@ -7,20 +7,37 @@ import           ClusterE2E.Utils
 import           Control.Concurrent.STM        (readTVarIO)
 import           Control.Exception             (bracket)
 import           Control.Monad                 (forM_, when)
+import qualified Control.Monad.State           as State
+import qualified Data.ByteString               as BS
+import qualified Data.ByteString.Builder       as Builder
 import qualified Data.ByteString.Char8         as BS8
 import           Data.List                     (isInfixOf)
 import qualified Data.Map.Strict               as Map
-import           Database.Redis.Client         (PlainTextClient (NotConnectedPlainTextClient),
+import           Database.Redis.Client         (Client (..),
+                                                PlainTextClient (NotConnectedPlainTextClient),
                                                 close, connect)
 import           Database.Redis.Cluster        (ClusterNode (..),
                                                 ClusterTopology (..),
                                                 NodeAddress (..), NodeRole (..))
 import           Database.Redis.Cluster.Client (closeClusterClient,
                                                 clusterTopology)
-import           Database.Redis.Command        (RedisCommands (..))
-import           Database.Redis.Resp           (RespData (..))
+import           Database.Redis.Command        (ClientState (..),
+                                                RedisCommandClient (..),
+                                                RedisCommands (..), parseWith)
+import           Database.Redis.Resp           (Encodable (encode),
+                                                RespData (..))
 import           SlotMappingHelpers            (getKeyForNode)
 import           Test.Hspec
+
+raw :: [BS.ByteString] -> RedisCommandClient PlainTextClient RespData
+raw parts = do
+  ClientState client _ <- State.get
+  send client (Builder.toLazyByteString $ encode (RespArray $ map RespBulkString parts))
+  parseWith (receive client)
+
+isError :: RespData -> Bool
+isError (RespError _) = True
+isError _             = False
 
 spec :: Spec
 spec = describe "Cluster Tunnel Mode" $ do
@@ -91,6 +108,28 @@ spec = describe "Cluster Tunnel Mode" $ do
 
         bracket createTestClusterClient closeClusterClient $ \client -> do
           _ <- runCmd_ client (del ["various:test"])
+          pure ()
+
+    it "routes script, stream, keyless, binary, unknown, and cross-slot requests" $
+      withSmartProxy $ do
+        conn <- connect (NotConnectedPlainTextClient "localhost" (Just 6379))
+        let key = "{metadata}:stream"
+            binary = BS.pack [0, 255, 13, 10]
+        runRedisCommand_ conn (raw ["SET", key, binary])
+        eval <- runRedisCommand conn (raw ["EVAL", "return redis.call('GET', KEYS[1])", "1", key])
+        eval `shouldBe` RespBulkString binary
+        runRedisCommand_ conn (raw ["XADD", key, "*", "field", "value"])
+        xread <- runRedisCommand conn (raw ["XREAD", "COUNT", "1", "STREAMS", key, "0"])
+        xread `shouldSatisfy` (/= RespError "ERR unsupported command XREAD")
+        echo <- runRedisCommand conn (raw ["ECHO", binary])
+        echo `shouldBe` RespBulkString binary
+        unknown <- runRedisCommand conn (raw ["NOT_A_REDIS_COMMAND", "not-a-key"])
+        unknown `shouldSatisfy` isError
+        crossSlot <- runRedisCommand conn (raw ["MGET", "different-one", "different-two"])
+        crossSlot `shouldSatisfy` isError
+        close conn
+        bracket createTestClusterClient closeClusterClient $ \client -> do
+          _ <- runCmd_ client (del [key])
           pure ()
 
     it "smart mode handles multiple separate connections" $


### PR DESCRIPTION
Closes #92

Clean-room reimplementation from origin/main 3a99c42e92a7074e1af24b32d74dc9061aa28f7f.

⚠️ This medium feature needs Squad review.