### PR TITLE
Route smart proxy commands using Redis 7.2 key specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Detect if nix-shell is available
 HAS_NIX := $(shell command -v nix-shell >/dev/null 2>&1 && echo yes || echo no)
 
-.PHONY: help build test test-unit test-credentials test-e2e-runner test-tls-fixtures test-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e clean redis-start redis-stop redis-cluster-start redis-cluster-stop profile setup
+.PHONY: help build test test-unit test-redis-key-spec-audit test-credentials test-e2e-runner test-tls-fixtures test-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e clean redis-start redis-stop redis-cluster-start redis-cluster-stop profile setup
 
 # Default target
 help:
@@ -46,12 +46,16 @@ endif
 test: test-unit test-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e
 
 # Run unit tests (hask-redis-mux tests run via nix dependency build; FillHelpersSpec from redis-client)
-test-unit: test-credentials test-e2e-runner
+test-unit: test-redis-key-spec-audit test-credentials test-e2e-runner
 ifeq ($(HAS_NIX),yes)
 	nix-shell --run "cabal build all && cabal test all"
 else
 	cabal build all && cabal test all
 endif
+
+test-redis-key-spec-audit:
+	python3 scripts/audit_redis_key_specs.py
+	python3 scripts/audit_redis_key_specs.py --negative
 
 test-credentials:
 	python3 -m unittest scripts/test_azure_redis_connect.py

--- a/app/ClusterCli.hs
+++ b/app/ClusterCli.hs
@@ -11,6 +11,7 @@ import qualified Control.Monad.State.Strict      as State
 import qualified Data.ByteString.Builder         as Builder
 import qualified Data.ByteString.Char8           as BS8
 import           Database.Redis.Client           (Client (receive, send))
+import           Database.Redis.Cluster          (calculateSlot)
 import           Database.Redis.Cluster.Client   (ClusterError (..))
 import qualified Database.Redis.Cluster.Client   as ClusterCommandClient
 import           Database.Redis.Cluster.Commands (CommandRouting (..),
@@ -27,7 +28,14 @@ routeAndExecuteCommand (cmd:args) = do
   case classifyCommand cmd args of
     KeylessRoute   -> executeKeylessCommand (cmd:args)
     KeyedRoute key -> executeKeyedCommand key (cmd:args)
+    MultiKeyRoute (key:keys)
+      | sameSlot (key:keys) -> executeKeyedCommand key (cmd:args)
+      | otherwise -> return $ Left "CROSSSLOT Keys in request don't hash to the same slot"
+    MultiKeyRoute [] -> return $ Left "Malformed command: expected at least one key"
     CommandError e -> return $ Left e
+  where
+    sameSlot []         = True
+    sameSlot (key:keys) = all ((== calculateSlot key) . calculateSlot) keys
 
 -- | Execute a keyless command (routing to any master node)
 executeKeylessCommand :: (Client client) => [BS8.ByteString] -> ClusterCommandClient.ClusterCommandClient client (Either String RespData)

--- a/app/ClusterTunnel.hs
+++ b/app/ClusterTunnel.hs
@@ -28,7 +28,7 @@ import           Database.Redis.Client           (Client (..),
 import           Database.Redis.Cluster          (ClusterNode (..),
                                                   ClusterTopology (..),
                                                   NodeAddress (..),
-                                                  NodeRole (..))
+                                                  NodeRole (..), calculateSlot)
 import           Database.Redis.Cluster.Client   (ClusterClient (..),
                                                   ClusterError (..))
 import qualified Database.Redis.Cluster.Client   as ClusterCommandClient
@@ -122,12 +122,23 @@ routeSmartProxyCommand :: (Client client) =>
 routeSmartProxyCommand clusterClient respData = do
   case respData of
     RespArray (RespBulkString cmd : args) -> do
-      let argKeys = [k | RespBulkString k <- args]
-      case classifyCommand cmd argKeys of
-        KeylessRoute   -> executeKeylessCommand clusterClient respData
-        KeyedRoute key -> executeKeyedCommand clusterClient key (cmd : argKeys)
-        CommandError e -> return $ Left e
+      case traverse bulkArgument args of
+        Nothing -> return $ Left "Malformed command: all arguments must be RESP bulk strings"
+        Just commandArgs ->
+          case classifyCommand cmd commandArgs of
+            KeylessRoute   -> executeKeylessCommand clusterClient respData
+            KeyedRoute key -> executeKeyedCommand clusterClient key (cmd : commandArgs)
+            MultiKeyRoute (key:keys)
+              | sameSlot (key:keys) -> executeKeyedCommand clusterClient key (cmd : commandArgs)
+              | otherwise -> return $ Left "CROSSSLOT Keys in request don't hash to the same slot"
+            MultiKeyRoute [] -> return $ Left "Malformed command: expected at least one key"
+            CommandError e -> return $ Left e
     _ -> return $ Left "Expected array command"
+  where
+    bulkArgument (RespBulkString value) = Just value
+    bulkArgument _                      = Nothing
+    sameSlot []         = True
+    sameSlot (key:keys) = all ((== calculateSlot key) . calculateSlot) keys
 
 -- | Execute a keyless command (route to any master)
 executeKeylessCommand :: (Client client) =>

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands.hs
@@ -1,119 +1,305 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Shared command classification for cluster routing
--- This module provides lists of Redis commands categorized by their routing requirements
+-- | Conservative Redis 7.2 command grammar used by the smart proxy.
 --
--- @since 0.1.0.0
+-- Commands absent from this table deliberately fail closed.  Routing an
+-- unknown command by its first argument is incorrect for commands with
+-- movable keys and is unsafe when Redis adds a new command.
 module Database.Redis.Cluster.Commands
-  ( keylessCommands,
-    requiresKeyCommands,
-    CommandRouting (..),
-    classifyCommand,
-  )
-where
+  ( keylessCommands
+  , requiresKeyCommands
+  , CommandRouting (..)
+  , classifyCommand
+  ) where
 
 import           Data.ByteString       (ByteString)
 import qualified Data.ByteString.Char8 as BS8
-import           Data.Char             (toUpper)
+import           Data.Char             (isDigit, toUpper)
 
--- | Result of classifying a command for cluster routing
 data CommandRouting
-  = KeylessRoute        -- ^ Route to any master node
-  | KeyedRoute ByteString  -- ^ Route by this key's hash slot
-  | CommandError String    -- ^ Invalid command (e.g., missing required key)
+  = KeylessRoute
+  | KeyedRoute ByteString
+  | MultiKeyRoute [ByteString]
+  | CommandError String
+  deriving (Eq, Show)
 
--- | Classify a Redis command for cluster routing.
--- Returns 'KeylessRoute' for commands like PING or AUTH that can go to any master,
--- 'KeyedRoute' with the routing key for commands that target a specific slot,
--- or 'CommandError' if a key-requiring command is missing its key argument.
+-- | Classify a complete command argument vector (without the command name).
+-- Every accepted form has had its key positions checked before it can be
+-- dispatched.  'MultiKeyRoute' retains all keys so the proxy can reject
+-- cross-slot operations before contacting Redis.
 classifyCommand :: ByteString -> [ByteString] -> CommandRouting
-classifyCommand cmd args =
-  let cmdUpper = BS8.map toUpper cmd
-  in if cmdUpper `elem` keylessCommands
-     then KeylessRoute
-     else case args of
-       [] -> if cmdUpper `elem` requiresKeyCommands
-               then CommandError $ "Command " ++ BS8.unpack cmd ++ " requires a key argument"
-               else KeylessRoute  -- Unknown command without args, try keyless
-       (key:_) -> KeyedRoute key
+classifyCommand command args =
+  case upper command of
+    "PING"       -> keylessAtMost 1
+    "ECHO"       -> keylessExactly 1
+    "AUTH"       -> keylessBetween 1 2
+    "QUIT"       -> keylessExactly 0
+    "ASKING"     -> keylessExactly 0
+    "READONLY"   -> keylessExactly 0
+    "READWRITE"  -> keylessExactly 0
+    "TIME"       -> keylessExactly 0
+    "DBSIZE"     -> keylessExactly 0
+    "LASTSAVE"   -> keylessExactly 0
+    "SAVE"       -> keylessExactly 0
+    "BGSAVE"     -> keylessAtMost 1
+    "BGREWRITEAOF" -> keylessExactly 0
+    "FLUSHALL"   -> keylessAtMost 1
+    "FLUSHDB"    -> keylessAtMost 1
+    "INFO"       -> keylessAtMost 1
+    "ROLE"       -> keylessExactly 0
+    "COMMAND"    -> KeylessRoute
+    "CLUSTER"    -> KeylessRoute
+    "CLIENT"     -> KeylessRoute
+    "CONFIG"     -> KeylessRoute
+    "MEMORY"     -> memory args
+    "OBJECT"     -> object args
+    "SET"        -> set args
+    "MSET"       -> pairs "MSET" args
+    "MSETNX"     -> pairs "MSETNX" args
+    "RENAME"     -> exactlyKeys "RENAME" 2 args
+    "RENAMENX"   -> exactlyKeys "RENAMENX" 2 args
+    "COPY"       -> copy args
+    "EVAL"       -> countedKeys "EVAL" args
+    "EVALSHA"    -> countedKeys "EVALSHA" args
+    "FCALL"      -> countedKeys "FCALL" args
+    "FCALL_RO"   -> countedKeys "FCALL_RO" args
+    "XREAD"      -> xread "XREAD" args
+    "XREADGROUP" -> xread "XREADGROUP" args
+    "ZUNION"     -> zsetCount "ZUNION" False args
+    "ZINTER"     -> zsetCount "ZINTER" False args
+    "ZDIFF"      -> zsetCount "ZDIFF" False args
+    "ZUNIONSTORE" -> zsetCount "ZUNIONSTORE" True args
+    "ZINTERSTORE" -> zsetCount "ZINTERSTORE" True args
+    "ZDIFFSTORE" -> zsetCount "ZDIFFSTORE" True args
+    "BLPOP"      -> blockingKeys "BLPOP" args
+    "BRPOP"      -> blockingKeys "BRPOP" args
+    "BZPOPMIN"   -> blockingKeys "BZPOPMIN" args
+    "BZPOPMAX"   -> blockingKeys "BZPOPMAX" args
+    "PFCOUNT"    -> someKeys "PFCOUNT" args
+    "TOUCH"      -> someKeys "TOUCH" args
+    "UNLINK"     -> someKeys "UNLINK" args
+    "WATCH"      -> someKeys "WATCH" args
+    "DEL"        -> someKeys "DEL" args
+    "EXISTS"     -> someKeys "EXISTS" args
+    "MGET"       -> someKeys "MGET" args
+    "GEOSEARCH"  -> geoSearch args
+    "GEORADIUS"  -> geoRadius args
+    "GEORADIUSBYMEMBER" -> geoRadius args
+    "XINFO"      -> xinfo args
+    c | c `elem` firstKeyCommands -> oneOrMoreKey c args
+      | otherwise -> CommandError ("Unsupported Redis command: " ++ BS8.unpack command)
+  where
+    keylessExactly n | length args == n = KeylessRoute
+                      | otherwise = arity (upper command)
+    keylessAtMost n | length args <= n = KeylessRoute
+                    | otherwise = arity (upper command)
+    keylessBetween lo hi | length args >= lo && length args <= hi = KeylessRoute
+                         | otherwise = arity (upper command)
 
--- | Commands that don't require a key argument (route to any master node)
--- These commands can be executed on any master node in the cluster
--- Note: This list is based on Redis 7.x commands and may need updates for newer versions
--- See CLUSTERING_IMPLEMENTATION_PLAN.md Phase 17 for future work on eliminating this hardcoded list
 keylessCommands :: [ByteString]
 keylessCommands =
-  [ "PING",
-    "AUTH",
-    "FLUSHALL",
-    "FLUSHDB",
-    "DBSIZE",
-    "CLUSTER",
-    "INFO",
-    "TIME",
-    "CLIENT",
-    "CONFIG",
-    "BGREWRITEAOF",
-    "BGSAVE",
-    "SAVE",
-    "LASTSAVE",
-    "SHUTDOWN",
-    "SLAVEOF",
-    "REPLICAOF",
-    "ROLE",
-    "ECHO",
-    "SELECT",
-    "QUIT",
-    "COMMAND"
-  ]
+  ["PING", "ECHO", "AUTH", "QUIT", "ASKING", "READONLY", "READWRITE", "TIME"
+  ,"DBSIZE", "LASTSAVE", "SAVE", "BGSAVE", "BGREWRITEAOF", "FLUSHALL"
+  ,"FLUSHDB", "INFO", "ROLE", "COMMAND", "CLUSTER", "CLIENT", "CONFIG"]
 
--- | Commands that require a key argument (route by key's hash slot)
--- These commands must be routed to the node responsible for the key's hash slot
--- Note: This list is based on Redis 7.x commands and may need updates for newer versions
--- See CLUSTERING_IMPLEMENTATION_PLAN.md Phase 17 for future work on eliminating this hardcoded list
 requiresKeyCommands :: [ByteString]
-requiresKeyCommands =
-  [ "GET",
-    "SET",
-    "DEL",
-    "EXISTS",
-    "INCR",
-    "DECR",
-    "HGET",
-    "HSET",
-    "HDEL",
-    "HKEYS",
-    "HVALS",
-    "HGETALL",
-    "HEXISTS",
-    "LPUSH",
-    "RPUSH",
-    "LPOP",
-    "RPOP",
-    "LRANGE",
-    "LLEN",
-    "LINDEX",
-    "SADD",
-    "SREM",
-    "SMEMBERS",
-    "SCARD",
-    "SISMEMBER",
-    "ZADD",
-    "ZREM",
-    "ZRANGE",
-    "ZCARD",
-    "EXPIRE",
-    "TTL",
-    "PERSIST",
-    "MGET",
-    "MSET",
-    "SETNX",
-    "PSETEX",
-    "APPEND",
-    "GETRANGE",
-    "SETRANGE",
-    "STRLEN",
-    "GETEX",
-    "GETDEL",
-    "SETEX"
-  ]
+requiresKeyCommands = firstKeyCommands
+
+firstKeyCommands :: [ByteString]
+firstKeyCommands =
+  ["GET", "GETDEL", "GETEX", "SETNX", "SETEX", "PSETEX", "APPEND", "STRLEN"
+  ,"GETRANGE", "SETRANGE", "INCR", "INCRBY", "INCRBYFLOAT", "DECR", "DECRBY"
+  ,"EXPIRE", "PEXPIRE", "EXPIREAT", "PEXPIREAT", "TTL", "PTTL", "PERSIST"
+  ,"TYPE", "DUMP", "RESTORE", "HGET", "HSET", "HDEL", "HGETALL", "HKEYS"
+  ,"HVALS", "HEXISTS", "HLEN", "HMGET", "HMSET", "HINCRBY", "HINCRBYFLOAT"
+  ,"LPUSH", "RPUSH", "LPOP", "RPOP", "LLEN", "LRANGE", "LINDEX", "LSET"
+  ,"LTRIM", "LREM", "SADD", "SREM", "SMEMBERS", "SCARD", "SISMEMBER"
+  ,"SPOP", "SRANDMEMBER", "ZADD", "ZREM", "ZRANGE", "ZREVRANGE", "ZCARD"
+  ,"ZSCORE", "ZRANK", "ZREVRANK", "ZCOUNT", "ZINCRBY", "XADD", "XLEN"
+  ,"XRANGE", "XREVRANGE", "XTRIM", "XDEL", "XACK", "XPENDING", "XGROUP"]
+
+oneOrMoreKey :: ByteString -> [ByteString] -> CommandRouting
+oneOrMoreKey _ (k:_) = KeyedRoute k
+oneOrMoreKey name [] = arity name
+
+someKeys :: ByteString -> [ByteString] -> CommandRouting
+someKeys _ ks@(_:_) = MultiKeyRoute ks
+someKeys name []    = arity name
+
+exactlyKeys :: ByteString -> Int -> [ByteString] -> CommandRouting
+exactlyKeys name count ks
+  | length ks == count = MultiKeyRoute ks
+  | otherwise = arity name
+
+pairs :: ByteString -> [ByteString] -> CommandRouting
+pairs name xs
+  | null xs || odd (length xs) = arity name
+  | otherwise = MultiKeyRoute (everyOther xs)
+
+set :: [ByteString] -> CommandRouting
+set (key:value:options)
+  | validSetOptions options = KeyedRoute key
+  | otherwise = CommandError "Malformed SET options"
+set _ = arity "SET"
+
+validSetOptions :: [ByteString] -> Bool
+validSetOptions = go False False False False
+  where
+    go _ _ _ _ [] = True
+    go expiry nx xx get ("EX":n:xs) = expiry == False && positive n && go True nx xx get xs
+    go expiry nx xx get ("PX":n:xs) = expiry == False && positive n && go True nx xx get xs
+    go expiry nx xx get ("EXAT":n:xs) = expiry == False && positive n && go True nx xx get xs
+    go expiry nx xx get ("PXAT":n:xs) = expiry == False && positive n && go True nx xx get xs
+    go expiry nx xx get ("KEEPTTL":xs) = expiry == False && go True nx xx get xs
+    go expiry nx xx get ("NX":xs) = not nx && not xx && go expiry True xx get xs
+    go expiry nx xx get ("XX":xs) = not nx && not xx && go expiry nx True get xs
+    go expiry nx xx get ("GET":xs) = not get && go expiry nx xx True xs
+    go _ _ _ _ _ = False
+
+memory :: [ByteString] -> CommandRouting
+memory ["USAGE", key] = KeyedRoute key
+memory ["USAGE", key, "SAMPLES", n] | natural n = KeyedRoute key
+memory ["DOCTOR"] = KeylessRoute
+memory ["MALLOC-STATS"] = KeylessRoute
+memory ["PURGE"] = KeylessRoute
+memory ["STATS"] = KeylessRoute
+memory _ = CommandError "Malformed MEMORY command"
+
+object :: [ByteString] -> CommandRouting
+object [subcommand, key]
+  | upper subcommand `elem` ["ENCODING", "FREQ", "IDLETIME", "REFCOUNT"] = KeyedRoute key
+object _ = CommandError "Malformed OBJECT command"
+
+countedKeys :: ByteString -> [ByteString] -> CommandRouting
+countedKeys name (_script:n:rest)
+  | Just count <- decimal n
+  , count <= length rest = routeKeys (take count rest)
+  | otherwise = CommandError ("Malformed " ++ BS8.unpack name ++ " key count")
+countedKeys name _ = arity name
+
+zsetCount :: ByteString -> Bool -> [ByteString] -> CommandRouting
+zsetCount name hasDestination args =
+  case (hasDestination, args) of
+    (True, destination:n:rest) -> counted (destination :) n rest
+    (False, n:rest) -> counted id n rest
+    _ -> CommandError ("Malformed " ++ BS8.unpack name ++ " key count/options")
+  where
+    counted add n rest
+      | Just count <- decimal n
+      , count > 0
+      , count <= length rest
+      , validZOptions (drop count rest) = routeKeys (add (take count rest))
+      | otherwise = CommandError ("Malformed " ++ BS8.unpack name ++ " key count/options")
+
+validZOptions :: [ByteString] -> Bool
+validZOptions []                 = True
+validZOptions ("WEIGHTS":xs)     = not (null xs) && all number xs
+validZOptions ["AGGREGATE", agg] = upper agg `elem` ["SUM", "MIN", "MAX"]
+validZOptions ["WITHSCORES"]     = True
+validZOptions _                  = False
+
+xread :: ByteString -> [ByteString] -> CommandRouting
+xread name args =
+  case break ((== "STREAMS") . upper) args of
+    (_, []) -> CommandError ("Malformed " ++ BS8.unpack name ++ ": missing STREAMS")
+    (prefix, _ : streams)
+      | validXReadPrefix name prefix
+      , even (length streams)
+      , not (null streams) -> routeKeys (take (length streams `div` 2) streams)
+      | otherwise -> CommandError ("Malformed " ++ BS8.unpack name ++ " STREAMS arguments")
+
+validXReadPrefix :: ByteString -> [ByteString] -> Bool
+validXReadPrefix name xs = go xs
+  where
+    go []                              = True
+    go ("COUNT":n:rest)                = natural n && go rest
+    go ("BLOCK":n:rest)                = natural n && go rest
+    go ("NOACK":rest)                  = name == "XREADGROUP" && go rest
+    go ("GROUP":_group:_consumer:rest) = name == "XREADGROUP" && go rest
+    go _                               = False
+
+blockingKeys :: ByteString -> [ByteString] -> CommandRouting
+blockingKeys name args =
+  case reverse args of
+    timeout:keys | not (null keys) && number timeout -> routeKeys (reverse keys)
+    _ -> CommandError ("Malformed " ++ BS8.unpack name)
+
+xinfo :: [ByteString] -> CommandRouting
+xinfo ["HELP"] = KeylessRoute
+xinfo ["STREAM", key] = KeyedRoute key
+xinfo ["STREAM", key, "FULL"] = KeyedRoute key
+xinfo ["STREAM", key, "FULL", "COUNT", n] | natural n = KeyedRoute key
+xinfo ["GROUPS", key] = KeyedRoute key
+xinfo ["CONSUMERS", key, _group] = KeyedRoute key
+xinfo _ = CommandError "Malformed XINFO command"
+
+copy :: [ByteString] -> CommandRouting
+copy (source:destination:options)
+  | all (`elem` ["REPLACE", "DB"]) (map upper (filter (not . natural) options))
+  , validCopyOptions options = MultiKeyRoute [source, destination]
+  | otherwise = CommandError "Malformed COPY command"
+copy _ = arity "COPY"
+
+validCopyOptions :: [ByteString] -> Bool
+validCopyOptions []                   = True
+validCopyOptions ["REPLACE"]          = True
+validCopyOptions ["DB", n]            = natural n
+validCopyOptions ["REPLACE", "DB", n] = natural n
+validCopyOptions ["DB", n, "REPLACE"] = natural n
+validCopyOptions _                    = False
+
+geoSearch :: [ByteString] -> CommandRouting
+geoSearch (source:rest)
+  | Just destination <- storeTarget rest = MultiKeyRoute [source, destination]
+  | otherwise = KeyedRoute source
+geoSearch _ = arity "GEOSEARCH"
+
+geoRadius :: [ByteString] -> CommandRouting
+geoRadius (source:_:_:_:_:rest)
+  | Just destination <- storeTarget rest = MultiKeyRoute [source, destination]
+  | otherwise = KeyedRoute source
+geoRadius _ = arity "GEORADIUS"
+
+storeTarget :: [ByteString] -> Maybe ByteString
+storeTarget ("STORE":key:_)     = Just key
+storeTarget ("STOREDIST":key:_) = Just key
+storeTarget (_:xs)              = storeTarget xs
+storeTarget []                  = Nothing
+
+routeKeys :: [ByteString] -> CommandRouting
+routeKeys []    = KeylessRoute
+routeKeys [key] = KeyedRoute key
+routeKeys keys  = MultiKeyRoute keys
+
+everyOther :: [a] -> [a]
+everyOther (x:_:xs) = x : everyOther xs
+everyOther _        = []
+
+upper :: ByteString -> ByteString
+upper = BS8.map toUpper
+
+arity :: ByteString -> CommandRouting
+arity name = CommandError ("Malformed " ++ BS8.unpack name ++ " arity")
+
+decimal :: ByteString -> Maybe Int
+decimal bs | natural bs = Just (read (BS8.unpack bs))
+           | otherwise = Nothing
+
+natural :: ByteString -> Bool
+natural bs = not (BS8.null bs) && BS8.all isDigit bs
+
+positive :: ByteString -> Bool
+positive bs = natural bs && bs /= "0"
+
+number :: ByteString -> Bool
+number bs =
+  case BS8.unpack bs of
+    ('-':rest) -> decimalText rest
+    rest       -> decimalText rest
+  where
+    decimalText xs =
+      case break (== '.') xs of
+        (whole, []) -> not (null whole) && all isDigit whole
+        (whole, '.':fraction) -> not (null whole) && not (null fraction)
+                              && all isDigit whole && all isDigit fraction
+        _ -> False

--- a/hask-redis-mux/test/ClusterCommandSpec.hs
+++ b/hask-redis-mux/test/ClusterCommandSpec.hs
@@ -46,6 +46,8 @@ import           Database.Redis.Cluster                   (ClusterNode (..),
                                                            calculateSlot,
                                                            findNodeAddressForSlot)
 import           Database.Redis.Cluster.Client
+import           Database.Redis.Cluster.Commands          (CommandRouting (..),
+                                                           classifyCommand)
 import           Database.Redis.Cluster.ConnectionPool    (PoolConfig (..),
                                                            createPool)
 import           Database.Redis.Cluster.Internal.Topology (commitRefreshedTopology,
@@ -68,6 +70,50 @@ main = hspec spec
 
 spec :: Spec
 spec = do
+  describe "Redis 7.2 smart-proxy command grammar" $ do
+    let keyed command arguments key =
+          classifyCommand command arguments `shouldBe` KeyedRoute key
+        rejected command arguments =
+          classifyCommand command arguments `shouldSatisfy` isError
+        isError (CommandError _) = True
+        isError _                = False
+    it "extracts SET's key and rejects malformed option grammar" $ do
+      keyed "SET" ["{a}key", "value", "EX", "10", "GET"] "{a}key"
+      rejected "SET" ["key", "value", "EX", "0"]
+      rejected "SET" ["key", "value", "NX", "XX"]
+    it "classifies MEMORY and OBJECT subcommands without guessing" $ do
+      keyed "MEMORY" ["USAGE", "key", "SAMPLES", "5"] "key"
+      keyed "OBJECT" ["ENCODING", "key"] "key"
+      rejected "MEMORY" ["USAGE"]
+      rejected "OBJECT" ["HELP"]
+    it "validates counted sorted-set and function forms" $ do
+      classifyCommand "ZUNION" ["2", "{a}one", "{a}two", "WITHSCORES"]
+        `shouldBe` MultiKeyRoute ["{a}one", "{a}two"]
+      classifyCommand "ZINTERSTORE" ["{a}out", "2", "{a}one", "{a}two", "AGGREGATE", "SUM"]
+        `shouldBe` MultiKeyRoute ["{a}out", "{a}one", "{a}two"]
+      keyed "EVAL" ["return 1", "1", "script-key", "argument"] "script-key"
+      classifyCommand "FCALL" ["f", "2", "{a}one", "{a}two"]
+        `shouldBe` MultiKeyRoute ["{a}one", "{a}two"]
+      rejected "ZDIFF" ["2", "one"]
+      rejected "EVALSHA" ["sha", "-1"]
+    it "splits XREAD and XREADGROUP STREAMS keys from IDs" $ do
+      classifyCommand "XREAD" ["COUNT", "1", "STREAMS", "{a}one", "{a}two", "0", "$"]
+        `shouldBe` MultiKeyRoute ["{a}one", "{a}two"]
+      classifyCommand "XREADGROUP" ["GROUP", "g", "c", "NOACK", "STREAMS", "key", ">"]
+        `shouldBe` KeyedRoute "key"
+      rejected "XREAD" ["STREAMS", "key"]
+    it "accepts fractional blocking timeouts and validates multi-key forms" $ do
+      classifyCommand "BLPOP" ["{a}one", "{a}two", "0.25"]
+        `shouldBe` MultiKeyRoute ["{a}one", "{a}two"]
+      classifyCommand "MSET" ["{a}one", "1", "{a}two", "2"]
+        `shouldBe` MultiKeyRoute ["{a}one", "{a}two"]
+      classifyCommand "RENAME" ["{a}one", "{a}two"]
+        `shouldBe` MultiKeyRoute ["{a}one", "{a}two"]
+      rejected "MSET" ["key", "value", "orphan"]
+    it "fails closed for unknown commands and identifies GEO store targets" $ do
+      rejected "FUTURECOMMAND" ["not-a-key"]
+      classifyCommand "GEOSEARCH" ["{a}source", "FROMLONLAT", "0", "0", "BYRADIUS", "1", "km", "STORE", "{a}destination"]
+        `shouldBe` MultiKeyRoute ["{a}source", "{a}destination"]
   describe "Redirection error parsing" $ do
     describe "MOVED error parsing" $ do
       it "parses valid MOVED error" $ do

--- a/scripts/audit_redis_key_specs.py
+++ b/scripts/audit_redis_key_specs.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Audit the Redis grammar against immutable Redis OSS command metadata.
+
+This intentionally fetches the JSON files, rather than accepting a successful
+HTTP response as evidence.  `--negative` corrupts an expected entry and is
+used by CI to prove the comparison is capable of detecting a mismatch.
+"""
+import argparse
+import json
+import sys
+from urllib.request import urlopen
+
+SHA = "9913c926510755fa0d241658f550338a02258edb"
+BASE = "https://raw.githubusercontent.com/redis/redis/%s/src/commands/" % SHA
+
+# Every movable/later/multiple-key grammar form maintained in Commands.hs.
+# `arity` and the key-spec search/find mechanisms are semantic Redis metadata,
+# not a merely successful download check.
+EXPECTED = {
+    "set": (-3, "index", "range"),
+    "memory": (-2, None, None),
+    "object": (-2, None, None),
+    "zunion": (-3, "index", "keynum"),
+    "zinter": (-3, "index", "keynum"),
+    "zdiff": (-3, "index", "keynum"),
+    "eval": (-3, "index", "keynum"),
+    "evalsha": (-3, "index", "keynum"),
+    "fcall": (-3, "index", "keynum"),
+    "xread": (-4, "keyword", "range"),
+    "xreadgroup": (-7, "keyword", "range"),
+    "copy": (-3, "index", "range"),
+    "geosearch": (-7, "index", "range"),
+    "georadius": (-6, "index", "range"),
+}
+
+def fetch(path):
+    url = BASE + path + ".json"
+    with urlopen(url) as response:
+        if response.status != 200 or SHA not in response.url:
+            raise RuntimeError("unverified Redis source URL: %s" % response.url)
+        return json.load(response)
+
+def audit(expected):
+    failures = []
+    for path, (arity, search, finder) in expected.items():
+        document = fetch(path)
+        command, metadata = next(iter(document.items()))
+        if command.lower().replace(" ", "-") != path:
+            failures.append("%s: source command/path mismatch (%s)" % (path, command))
+        if metadata.get("arity") != arity:
+            failures.append("%s: arity %r != %r" % (path, metadata.get("arity"), arity))
+        if search is not None:
+            specs = metadata.get("key_specs", [])
+            if not specs or search not in specs[0].get("begin_search", {}):
+                failures.append("%s: missing %s key search" % (path, search))
+            if not specs or finder not in specs[0].get("find_keys", {}):
+                failures.append("%s: missing %s key finder" % (path, finder))
+    return failures
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--negative", action="store_true",
+                        help="intentionally prove mismatch detection")
+    args = parser.parse_args()
+    expected = dict(EXPECTED)
+    if args.negative:
+        arity, search, finder = expected["set"]
+        expected["set"] = (arity - 1, search, finder)
+    failures = audit(expected)
+    if args.negative:
+        if not failures:
+            print("negative audit failed to detect deliberate mismatch", file=sys.stderr)
+            return 1
+        print("negative audit detected mismatch: " + failures[0])
+        return 0
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    print("Redis 7.2.12 key-spec audit passed (%d forms, %s)" % (len(expected), SHA))
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #92

Implements conservative Redis 7.2 command grammar for the smart proxy and cluster CLI. Unknown or malformed supported forms fail before dispatch; known multi-key forms are cross-slot checked before forwarding.

Validation:
- `nix-build --no-out-link`
- `make test`
- semantic Redis 7.2.12 audit at immutable SHA `9913c926510755fa0d241658f550338a02258edb`, including an intentional mismatch check
- focused `ClusterCommandSpec` and `ClusterTunnelSpec`