### PR TITLE
test: make multiplexer teardown cancellation deterministic

### DIFF
--- a/.squad/decisions/inbox/performance-deterministic-multiplexer-teardown.md
+++ b/.squad/decisions/inbox/performance-deterministic-multiplexer-teardown.md
@@ -1,0 +1,4 @@
+### 2026-09-04: Synchronize teardown cancellation at transport-close start
+**By:** Performance
+**What:** The multiplexer teardown regression test blocks its test transport's close action and cancels the destroy caller only after that barrier is reached; it no longer infers teardown progress from `muxAlive`.
+**Why:** `muxAlive` changes at admission closure, before the destroy owner has necessarily reached an interruptible teardown operation. The close barrier makes cancellation and resumed teardown deterministic while preserving assertions that active, pending, and queued slots fail exactly once.

--- a/hask-redis-mux/test/MultiplexerSpec.hs
+++ b/hask-redis-mux/test/MultiplexerSpec.hs
@@ -24,6 +24,7 @@ import qualified Data.ByteString.Builder             as Builder
 import qualified Data.ByteString.Lazy                as LBS
 import           Data.IORef                          (IORef, atomicModifyIORef',
                                                       newIORef, readIORef)
+import           Data.List                           (sort)
 import           Database.Redis.Client               (Client (..),
                                                       ConnectionStatus (..))
 import           Database.Redis.Cluster              (NodeAddress (..))
@@ -456,82 +457,85 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
     result <- timeout 1000000 (takeMVar resultVar)
     result `shouldSatisfy` isTimedMultiplexerDead
 
-  it "a later destroy resumes cancelled teardown across active, pending, and queued slots" $ do
-    pool <- createSlotPool 16
-    ( client
-      , awaitFirstSend
-      , awaitSecondSendGate
-      , awaitReceive
-      , releaseSecondSend
-      , awaitCloseStart
-      , releaseClose
-      ) <-
-      createTeardownClient
-    mux <- createMultiplexer client (receive client)
-    firstSlot <- submitCommandAsync pool mux (encodeCmd ["GET", "reader-owned"])
-    firstResult <- waitForSlotInThread pool firstSlot
-    awaitFirstSend
-    awaitReceive
+  it "a later destroy resumes cancelled teardown across active, pending, and queued slots" $
+    runOnCapabilityZero $ do
+      -- All acquisition and release workers are pinned to stripe zero. With
+      -- createSlotPool 16 this starts with exactly four slots, so the eight
+      -- held slots fully characterize the stripe after teardown.
+      pool <- createSlotPool 16
+      ( client
+        , awaitFirstSend
+        , awaitSecondSendGate
+        , awaitReceive
+        , releaseSecondSend
+        , awaitCloseStart
+        , releaseClose
+        ) <-
+        createTeardownClient
+      mux <- createMultiplexer client (receive client)
+      firstSlot <- submitCommandAsync pool mux (encodeCmd ["GET", "reader-owned"])
+      firstResult <- waitForSlotInThread pool firstSlot
+      awaitFirstSend
+      awaitReceive
 
-    secondSlot <- submitCommandAsync pool mux (encodeCmd ["GET", "pending"])
-    secondResult <- waitForSlotInThread pool secondSlot
-    -- This barrier is emitted inside the writer's uninterruptible send gate,
-    -- immediately before its deliberately blocked operation.
-    awaitSecondSendGate
+      secondSlot <- submitCommandAsync pool mux (encodeCmd ["GET", "pending"])
+      secondResult <- waitForSlotInThread pool secondSlot
+      -- This barrier is emitted inside the writer's uninterruptible send gate,
+      -- immediately before its deliberately blocked operation.
+      awaitSecondSendGate
 
-    queuedSlots <- mapM
-      (\idx -> submitCommandAsync pool mux
-        (encodeCmd ["GET", LBS.toStrict $ Builder.toLazyByteString $ Builder.intDec idx]))
-      [1 :: Int .. 6]
-    queuedResults <- mapM (waitForSlotInThread pool) queuedSlots
-    ownerFinished <- newEmptyMVar
-    owner <- forkFinally (destroyMultiplexer mux) (putMVar ownerFinished)
-    -- This is a separate barrier: it proves the owner entered destroy's
-    -- teardown sequence after the writer was already inside its send gate.
-    awaitCloseStart
+      queuedSlots <- mapM
+        (\idx -> submitCommandAsync pool mux
+          (encodeCmd ["GET", LBS.toStrict $ Builder.toLazyByteString $ Builder.intDec idx]))
+        [1 :: Int .. 6]
+      let destroyedSlots = firstSlot : secondSlot : queuedSlots
+      allDistinctResponseSlots destroyedSlots `shouldBe` True
+      queuedResults <- mapM (waitForSlotInThread pool) queuedSlots
+      ownerFinished <- newEmptyMVar
+      owner <- forkFinally (destroyMultiplexer mux) (putMVar ownerFinished)
+      -- This is a separate barrier: it proves the owner entered destroy's
+      -- teardown sequence after the writer was already inside its send gate.
+      awaitCloseStart
 
-    killThread owner
-    cancelledOwner <- timeout 1000000 (takeMVar ownerFinished)
-    cancelledOwner `shouldSatisfy` isTimedThreadKilled
+      killThread owner
+      cancelledOwner <- timeout 1000000 (takeMVar ownerFinished)
+      cancelledOwner `shouldSatisfy` isTimedThreadKilled
 
-    releaseClose
-    releaseSecondSend
-    resumedDestroy <- timeout 1000000 (destroyMultiplexer mux)
-    resumedDestroy `shouldBe` Just ()
+      releaseClose
+      releaseSecondSend
+      resumedDestroy <- timeout 1000000 (destroyMultiplexer mux)
+      resumedDestroy `shouldBe` Just ()
 
-    results <- timeout 1000000 $
-      mapM takeMVar (firstResult : secondResult : queuedResults)
-    results `shouldSatisfy` \case
-      Just completed -> all isMultiplexerDead completed
-      Nothing        -> False
+      results <- timeout 1000000 $
+        mapM takeMVar (firstResult : secondResult : queuedResults)
+      results `shouldSatisfy` \case
+        Just completed -> all isMultiplexerDead completed
+        Nothing        -> False
 
-    -- Each failed waiter must return its slot once. Reacquire all eight from
-    -- the same pool concurrently, verify their identities are distinct, then
-    -- complete them independently on a fresh multiplexer.
-    (reuseClient, addReuseResponse) <- createMockClient
-    reuseMux <- createMultiplexer reuseClient (receive reuseClient)
-    reuseSlots <- replicateM 8 newEmptyMVar
-    reuseResults <- replicateM 8 newEmptyMVar
-    mapM_ (\(slotVar, resultVar) -> do
-      _ <- forkIO $ do
-        slot <- submitCommandAsync pool reuseMux (encodeCmd ["PING"])
-        putMVar slotVar slot
-        result <- try (waitSlot pool slot) :: IO (Either SomeException RespData)
-        putMVar resultVar result
-      return ()
-      ) (zip reuseSlots reuseResults)
-    acquired <- timeout 1000000 $ mapM takeMVar reuseSlots
-    case acquired of
-      Just slots ->
-        allDistinctResponseSlots slots `shouldBe` True
-      Nothing ->
-        expectationFailure "same-pool reuse did not acquire every returned slot"
-    addReuseResponse $ mconcat $ replicate 8 (encodeResp (RespSimpleString "OK"))
-    reused <- timeout 1000000 $ mapM takeMVar reuseResults
-    reused `shouldSatisfy` \case
-      Just completed -> all isOkResponse completed
-      Nothing        -> False
-    destroyMultiplexer reuseMux
+      -- Reacquisition and its subsequent releases stay on stripe zero. The
+      -- exact identity set proves teardown returned each of the eight failed
+      -- slots once, rather than borrowing a slot from another stripe.
+      (reuseClient, addReuseResponse) <- createMockClient
+      reuseMux <- createMultiplexer reuseClient (receive reuseClient)
+      reuseSlots <- replicateM 8 newEmptyMVar
+      reuseResults <- replicateM 8 newEmptyMVar
+      mapM_ (\(slotVar, resultVar) -> do
+        _ <- forkOn 0 $ do
+          slot <- submitCommandAsync pool reuseMux (encodeCmd ["PING"])
+          putMVar slotVar slot
+          result <- try (waitSlot pool slot) :: IO (Either SomeException RespData)
+          putMVar resultVar result
+        return ()
+        ) (zip reuseSlots reuseResults)
+      acquired <- mapM takeMVar reuseSlots
+      sameResponseSlotSet destroyedSlots acquired `shouldBe` True
+      addReuseResponse $ mconcat
+        [ encodeResp (RespInteger response)
+        | response <- [1 .. 8]
+        ]
+      reused <- mapM takeMVar reuseResults
+      sort (map okResponseInteger reused) `shouldBe` map Just [1 .. 8]
+      destroyMultiplexer reuseMux
 
   it "concurrent destroy calls are idempotent and wake the waiter once" $ do
     pool <- createSlotPool 16
@@ -687,7 +691,7 @@ waitForSlotInThread
   -> IO (MVar (Either SomeException RespData))
 waitForSlotInThread pool slot = do
   resultVar <- newEmptyMVar
-  _ <- forkIO $ do
+  _ <- forkOn 0 $ do
     result <- try $ waitSlot pool slot
     putMVar resultVar result
   return resultVar
@@ -741,6 +745,14 @@ allDistinctResponseSlots slots =
     , right <- drop (index + 1) slots
     ]
 
+sameResponseSlotSet :: [ResponseSlot] -> [ResponseSlot] -> Bool
+sameResponseSlotSet left right =
+  length left == length right
+    && allDistinctResponseSlots left
+    && allDistinctResponseSlots right
+    && all (\slot -> any (sameResponseSlot slot) right) left
+    && all (\slot -> any (sameResponseSlot slot) left) right
+
 isTimedMultiplexerParseFailure
   :: Maybe (Either SomeException RespData)
   -> Bool
@@ -753,3 +765,7 @@ isTimedMultiplexerParseFailure _ = False
 isOkResponse :: Either SomeException RespData -> Bool
 isOkResponse (Right (RespSimpleString "OK")) = True
 isOkResponse _                               = False
+
+okResponseInteger :: Either SomeException RespData -> Maybe Integer
+okResponseInteger (Right (RespInteger value)) = Just value
+okResponseInteger _                           = Nothing

--- a/hask-redis-mux/test/MultiplexerSpec.hs
+++ b/hask-redis-mux/test/MultiplexerSpec.hs
@@ -109,12 +109,17 @@ data TeardownClient (a :: ConnectionStatus) where
     -> !(MVar ())
     -> !(MVar ())
     -> !(MVar ByteString)
+    -> !(MVar ())
+    -> !(MVar ())
     -> TeardownClient 'Connected
 
 instance Client TeardownClient where
   connect = error "TeardownClient: connect not supported"
-  close _ = return ()
-  send (TeardownConnected sendCount firstSent secondStarted releaseSecond _ _) _ =
+  close (TeardownConnected _ _ _ _ _ _ closeStarted releaseClose) =
+    liftIO $ do
+      void $ tryPutMVar closeStarted ()
+      takeMVar releaseClose
+  send (TeardownConnected sendCount firstSent secondStarted releaseSecond _ _ _ _) _ =
     liftIO $ do
       sendNumber <- atomicModifyIORef' sendCount $ \count ->
         let next = count + 1
@@ -125,7 +130,7 @@ instance Client TeardownClient where
           void $ tryPutMVar secondStarted ()
           uninterruptibleMask_ $ takeMVar releaseSecond
         _ -> return ()
-  receive (TeardownConnected _ _ _ _ receiveStarted replies) =
+  receive (TeardownConnected _ _ _ _ receiveStarted replies _ _) =
     liftIO $ do
       void $ tryPutMVar receiveStarted ()
       takeMVar replies
@@ -133,6 +138,8 @@ instance Client TeardownClient where
 createTeardownClient
   :: IO
        ( TeardownClient 'Connected
+       , IO ()
+       , IO ()
        , IO ()
        , IO ()
        , IO ()
@@ -145,16 +152,21 @@ createTeardownClient = do
   releaseSecond <- newEmptyMVar
   receiveStarted <- newEmptyMVar
   replies <- newEmptyMVar
+  closeStarted <- newEmptyMVar
+  releaseClose <- newEmptyMVar
   let await barrier = do
         observed <- timeout 1000000 (takeMVar barrier)
         observed `shouldBe` Just ()
   return
     ( TeardownConnected
         sendCount firstSent secondStarted releaseSecond receiveStarted replies
+        closeStarted releaseClose
     , await firstSent
     , await secondStarted
     , await receiveStarted
     , putMVar releaseSecond ()
+    , await closeStarted
+    , putMVar releaseClose ()
     )
 
 data AcquisitionClient (a :: ConnectionStatus) where
@@ -445,7 +457,14 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
 
   it "a later destroy resumes cancelled teardown across active, pending, and queued slots" $ do
     pool <- createSlotPool 16
-    (client, awaitFirstSend, awaitSecondSend, awaitReceive, releaseSecondSend) <-
+    ( client
+      , awaitFirstSend
+      , awaitSecondSend
+      , awaitReceive
+      , releaseSecondSend
+      , awaitCloseStart
+      , releaseClose
+      ) <-
       createTeardownClient
     mux <- createMultiplexer client (receive client)
     firstSlot <- submitCommandAsync pool mux (encodeCmd ["GET", "reader-owned"])
@@ -462,11 +481,12 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
         (encodeCmd ["GET", LBS.toStrict $ Builder.toLazyByteString $ Builder.intDec idx]))
       [1 :: Int .. 6]
     queuedResults <- mapM (waitForSlotInThread pool) queuedSlots
-
     ownerFinished <- newEmptyMVar
     owner <- forkFinally (destroyMultiplexer mux) (putMVar ownerFinished)
-    closureStarted <- timeout 1000000 (waitUntilTeardownStarted mux)
-    closureStarted `shouldBe` Just ()
+    -- The finalizer owns close in a separate thread. This barrier proves the
+    -- destroy owner has reached teardown without relying on muxAlive's early
+    -- admission-closure transition.
+    awaitCloseStart
 
     killThread owner
     cancelledOwner <- timeout 1000000 (takeMVar ownerFinished)
@@ -474,6 +494,7 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
       Just (Left _) -> True
       _             -> False
 
+    releaseClose
     releaseSecondSend
     resumedDestroy <- timeout 1000000 (destroyMultiplexer mux)
     resumedDestroy `shouldBe` Just ()
@@ -642,13 +663,6 @@ waitForSlotInThread pool slot = do
     result <- try $ waitSlot pool slot
     putMVar resultVar result
   return resultVar
-
-waitUntilTeardownStarted :: Multiplexer -> IO ()
-waitUntilTeardownStarted mux = do
-  alive <- isMultiplexerAlive mux
-  if alive
-    then threadDelay 1000 >> waitUntilTeardownStarted mux
-    else return ()
 
 runOnCapabilityZero :: IO () -> IO ()
 runOnCapabilityZero action = do

--- a/hask-redis-mux/test/MultiplexerSpec.hs
+++ b/hask-redis-mux/test/MultiplexerSpec.hs
@@ -11,7 +11,8 @@ import           Control.Concurrent                  (forkFinally, forkIO,
 import           Control.Concurrent.MVar             (MVar, newEmptyMVar,
                                                       putMVar, takeMVar,
                                                       tryPutMVar)
-import           Control.Exception                   (SomeException,
+import           Control.Exception                   (AsyncException (ThreadKilled),
+                                                      SomeException,
                                                       fromException, throwIO,
                                                       try, uninterruptibleMask_)
 import           Control.Monad                       (replicateM, replicateM_,
@@ -119,16 +120,16 @@ instance Client TeardownClient where
     liftIO $ do
       void $ tryPutMVar closeStarted ()
       takeMVar releaseClose
-  send (TeardownConnected sendCount firstSent secondStarted releaseSecond _ _ _ _) _ =
+  send (TeardownConnected sendCount firstSent secondSendGated releaseSecond _ _ _ _) _ =
     liftIO $ do
       sendNumber <- atomicModifyIORef' sendCount $ \count ->
         let next = count + 1
         in (next, next)
       case sendNumber of
         1 -> void $ tryPutMVar firstSent ()
-        2 -> do
-          void $ tryPutMVar secondStarted ()
-          uninterruptibleMask_ $ takeMVar releaseSecond
+        2 -> uninterruptibleMask_ $ do
+          void $ tryPutMVar secondSendGated ()
+          takeMVar releaseSecond
         _ -> return ()
   receive (TeardownConnected _ _ _ _ receiveStarted replies _ _) =
     liftIO $ do
@@ -148,7 +149,7 @@ createTeardownClient
 createTeardownClient = do
   sendCount <- newIORef 0
   firstSent <- newEmptyMVar
-  secondStarted <- newEmptyMVar
+  secondSendGated <- newEmptyMVar
   releaseSecond <- newEmptyMVar
   receiveStarted <- newEmptyMVar
   replies <- newEmptyMVar
@@ -159,10 +160,10 @@ createTeardownClient = do
         observed `shouldBe` Just ()
   return
     ( TeardownConnected
-        sendCount firstSent secondStarted releaseSecond receiveStarted replies
+        sendCount firstSent secondSendGated releaseSecond receiveStarted replies
         closeStarted releaseClose
     , await firstSent
-    , await secondStarted
+    , await secondSendGated
     , await receiveStarted
     , putMVar releaseSecond ()
     , await closeStarted
@@ -459,7 +460,7 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
     pool <- createSlotPool 16
     ( client
       , awaitFirstSend
-      , awaitSecondSend
+      , awaitSecondSendGate
       , awaitReceive
       , releaseSecondSend
       , awaitCloseStart
@@ -474,7 +475,9 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
 
     secondSlot <- submitCommandAsync pool mux (encodeCmd ["GET", "pending"])
     secondResult <- waitForSlotInThread pool secondSlot
-    awaitSecondSend
+    -- This barrier is emitted inside the writer's uninterruptible send gate,
+    -- immediately before its deliberately blocked operation.
+    awaitSecondSendGate
 
     queuedSlots <- mapM
       (\idx -> submitCommandAsync pool mux
@@ -483,16 +486,13 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
     queuedResults <- mapM (waitForSlotInThread pool) queuedSlots
     ownerFinished <- newEmptyMVar
     owner <- forkFinally (destroyMultiplexer mux) (putMVar ownerFinished)
-    -- The finalizer owns close in a separate thread. This barrier proves the
-    -- destroy owner has reached teardown without relying on muxAlive's early
-    -- admission-closure transition.
+    -- This is a separate barrier: it proves the owner entered destroy's
+    -- teardown sequence after the writer was already inside its send gate.
     awaitCloseStart
 
     killThread owner
     cancelledOwner <- timeout 1000000 (takeMVar ownerFinished)
-    cancelledOwner `shouldSatisfy` \case
-      Just (Left _) -> True
-      _             -> False
+    cancelledOwner `shouldSatisfy` isTimedThreadKilled
 
     releaseClose
     releaseSecondSend
@@ -504,6 +504,34 @@ multiplexerLifecycleSpec = describe "Multiplexer lifecycle" $ do
     results `shouldSatisfy` \case
       Just completed -> all isMultiplexerDead completed
       Nothing        -> False
+
+    -- Each failed waiter must return its slot once. Reacquire all eight from
+    -- the same pool concurrently, verify their identities are distinct, then
+    -- complete them independently on a fresh multiplexer.
+    (reuseClient, addReuseResponse) <- createMockClient
+    reuseMux <- createMultiplexer reuseClient (receive reuseClient)
+    reuseSlots <- replicateM 8 newEmptyMVar
+    reuseResults <- replicateM 8 newEmptyMVar
+    mapM_ (\(slotVar, resultVar) -> do
+      _ <- forkIO $ do
+        slot <- submitCommandAsync pool reuseMux (encodeCmd ["PING"])
+        putMVar slotVar slot
+        result <- try (waitSlot pool slot) :: IO (Either SomeException RespData)
+        putMVar resultVar result
+      return ()
+      ) (zip reuseSlots reuseResults)
+    acquired <- timeout 1000000 $ mapM takeMVar reuseSlots
+    case acquired of
+      Just slots ->
+        allDistinctResponseSlots slots `shouldBe` True
+      Nothing ->
+        expectationFailure "same-pool reuse did not acquire every returned slot"
+    addReuseResponse $ mconcat $ replicate 8 (encodeResp (RespSimpleString "OK"))
+    reused <- timeout 1000000 $ mapM takeMVar reuseResults
+    reused `shouldSatisfy` \case
+      Just completed -> all isOkResponse completed
+      Nothing        -> False
+    destroyMultiplexer reuseMux
 
   it "concurrent destroy calls are idempotent and wake the waiter once" $ do
     pool <- createSlotPool 16
@@ -682,6 +710,13 @@ isTimedMultiplexerDead
 isTimedMultiplexerDead (Just result) = isMultiplexerDead result
 isTimedMultiplexerDead Nothing       = False
 
+isTimedThreadKilled :: Maybe (Either SomeException ()) -> Bool
+isTimedThreadKilled (Just (Left e)) =
+  case fromException e of
+    Just ThreadKilled -> True
+    _                 -> False
+isTimedThreadKilled _ = False
+
 isMultiplexerDead :: Either SomeException RespData -> Bool
 isMultiplexerDead (Left e) =
   case fromException e of
@@ -697,6 +732,14 @@ isMultiplexerFailure (Left e) =
     Just MultiplexerConnectionClosed -> True
     Nothing                          -> False
 isMultiplexerFailure (Right _) = False
+
+allDistinctResponseSlots :: [ResponseSlot] -> Bool
+allDistinctResponseSlots slots =
+  and
+    [ not (sameResponseSlot left right)
+    | (index, left) <- zip [0 :: Int ..] slots
+    , right <- drop (index + 1) slots
+    ]
 
 isTimedMultiplexerParseFailure
   :: Maybe (Either SomeException RespData)


### PR DESCRIPTION
Closes #124

Replaces the teardown test's scheduler-dependent `muxAlive` poll with a transport-close barrier. The test now establishes an active reader-owned slot, a pending writer-owned slot, and queued commands before blocking close, cancelling the destroy owner, then resuming teardown and asserting every waiter fails.

Validation:
- Captured seed `1417822123` focused at `-N1` and `-N4`, `-C0.001`
- Lifecycle group: 100/100 each at `-N1`, `-N2`, `-N4`, `-C0.001`
- Full `MultiplexerSpec`: seeds 1..100 plus captured seed at `-N4`, `-C0.001`
- `nix-build --no-out-link`
- `make test` three consecutive clean runs

No runtime hot-path changed; profiling is not applicable.