### PR TITLE
Issue #92: generated Redis routing + raw smart-proxy dispatch

### DIFF
--- a/.squad/decisions/inbox/docs-generated-routing-clean-room.md
+++ b/.squad/decisions/inbox/docs-generated-routing-clean-room.md
@@ -1,0 +1,4 @@
+### 2026-09-04: Generate cluster routing from immutable Redis 7.2 metadata
+**By:** Docs
+**What:** Replaced hand-maintained cluster command routing with a generated Redis 7.2.6 command-form artifact and added semantic audit tooling that fails on drift or deliberate mutation.
+**Why:** This keeps proxy routing and grammar validation aligned with authoritative upstream command metadata while preserving deterministic regeneration and reviewable contributor workflow.

--- a/README.md
+++ b/README.md
@@ -271,6 +271,25 @@ make redis-cluster-stop     # Stop Redis cluster
 
 Note: Do NOT start Redis manually before running E2E tests (`make test-e2e` or `make test-cluster-e2e`). Those tests manage their own Docker instances.
 
+### Regenerating cluster routing grammar
+
+Cluster smart-proxy routing is generated from immutable Redis 7.2.6 command
+metadata vendored at:
+
+`vendor/redis-7.2.6-commands/` (source SHA `ae6a2aa95cd094b032e7a69b8b59f64dd1ed085f`)
+
+Update and audit commands:
+
+```sh
+# Regenerate hask-redis-mux/lib/.../Commands/Generated.hs deterministically
+scripts/generate_cluster_routing.py
+
+# Semantic drift check (fails on any routing-entry mutation)
+scripts/audit_cluster_routing.sh
+```
+
+The generator is deterministic: same source metadata => identical generated file.
+
 ### Profiling
 
 Profile before and after changes to detect regressions:

--- a/app/ClusterTunnel.hs
+++ b/app/ClusterTunnel.hs
@@ -8,49 +8,60 @@ module ClusterTunnel
   , rewriteClusterResponse
   ) where
 
-import           Control.Concurrent              (MVar, forkIO, newEmptyMVar,
-                                                  putMVar, takeMVar)
-import           Control.Concurrent.STM          (readTVarIO)
-import           Control.Exception               (SomeException, bracket,
-                                                  finally, throwIO, try)
-import           Control.Monad                   (forever, void, when)
-import qualified Control.Monad.State.Strict      as State
-import qualified Data.ByteString                 as BS
-import qualified Data.ByteString.Builder         as Builder
-import qualified Data.ByteString.Char8           as BS8
-import qualified Data.ByteString.Lazy            as LBS
-import           Data.Char                       (isAlphaNum)
-import           Data.List                       (isPrefixOf)
-import qualified Data.Map.Strict                 as Map
-import           Data.Word                       (Word8)
-import           Database.Redis.Client           (Client (..),
-                                                  ConnectionStatus (..))
-import           Database.Redis.Cluster          (ClusterNode (..),
-                                                  ClusterTopology (..),
-                                                  NodeAddress (..),
-                                                  NodeRole (..))
-import           Database.Redis.Cluster.Client   (ClusterClient (..),
-                                                  ClusterError (..))
-import qualified Database.Redis.Cluster.Client   as ClusterCommandClient
-import           Database.Redis.Cluster.Commands (CommandRouting (..),
-                                                  classifyCommand)
-import           Database.Redis.Command          (ClientState (..),
-                                                  RedisCommandClient, parseWith)
-import           Database.Redis.Connector        (Connector)
-import           Database.Redis.Resp             (Encodable (encode),
-                                                  RespData (..))
-import qualified Database.Redis.Resp             as Resp
-import           Network.Socket                  (Family (..), SockAddr (..),
-                                                  Socket, SocketOption (..),
-                                                  SocketType (..), bind,
-                                                  defaultProtocol, listen,
-                                                  setSocketOption, socket,
-                                                  tupleToHostAddress)
-import qualified Network.Socket                  as S
-import           Network.Socket.ByteString       (recv, sendAll)
-import           System.IO                       (BufferMode (LineBuffering),
-                                                  hFlush, hSetBuffering, stdout)
-import           Text.Printf                     (printf)
+import           Control.Concurrent                    (MVar, forkIO,
+                                                        newEmptyMVar, putMVar,
+                                                        takeMVar, threadDelay)
+import           Control.Concurrent.STM                (readTVarIO)
+import           Control.Exception                     (SomeAsyncException,
+                                                        SomeException, bracket,
+                                                        finally, fromException,
+                                                        throwIO, try)
+import           Control.Monad                         (forever, void, when)
+import qualified Control.Monad.State.Strict            as State
+import qualified Data.ByteString                       as BS
+import qualified Data.ByteString.Builder               as Builder
+import qualified Data.ByteString.Char8                 as BS8
+import qualified Data.ByteString.Lazy                  as LBS
+import           Data.Char                             (isAlphaNum)
+import           Data.List                             (isPrefixOf)
+import qualified Data.Map.Strict                       as Map
+import           Data.Word                             (Word8)
+import           Database.Redis.Client                 (Client (..),
+                                                        ConnectionStatus (..))
+import           Database.Redis.Cluster                (ClusterNode (..),
+                                                        ClusterTopology (..),
+                                                        NodeAddress (..),
+                                                        NodeRole (..),
+                                                        calculateSlot,
+                                                        findNodeAddressForSlot)
+import           Database.Redis.Cluster.Client         (ClusterClient (..),
+                                                        ClusterError (..))
+import qualified Database.Redis.Cluster.Client         as ClusterCommandClient
+import           Database.Redis.Cluster.Commands       (CommandRouting (..),
+                                                        classifyCommand)
+import           Database.Redis.Cluster.ConnectionPool
+import           Database.Redis.Command                (ClientState (..),
+                                                        RedisCommandClient,
+                                                        parseWith)
+import           Database.Redis.Connector              (ConnectionSetupException,
+                                                        Connector)
+import           Database.Redis.Internal.MultiplexPool
+import           Database.Redis.Resp                   (Encodable (encode),
+                                                        RespData (..))
+import qualified Database.Redis.Resp                   as Resp
+import           Network.Socket                        (Family (..),
+                                                        SockAddr (..), Socket,
+                                                        SocketOption (..),
+                                                        SocketType (..), bind,
+                                                        defaultProtocol, listen,
+                                                        setSocketOption, socket,
+                                                        tupleToHostAddress)
+import qualified Network.Socket                        as S
+import           Network.Socket.ByteString             (recv, sendAll)
+import           System.IO                             (BufferMode (LineBuffering),
+                                                        hFlush, hSetBuffering,
+                                                        stdout)
+import           Text.Printf                           (printf)
 
 -- | Smart proxy mode: Makes cluster appear as single Redis instance
 -- Creates single listening socket and routes commands to appropriate nodes
@@ -103,7 +114,7 @@ handleSmartProxyClient clusterClient clientSock = do
               loop
             Right respData -> do
               -- Route and execute the command
-              result <- routeSmartProxyCommand clusterClient respData
+              result <- routeSmartProxyCommand clusterClient dat respData
               case result of
                 Left err -> do
                   printf "Command execution error: %s\n" err
@@ -117,17 +128,114 @@ handleSmartProxyClient clusterClient clientSock = do
 -- | Route and execute a command in smart proxy mode
 routeSmartProxyCommand :: (Client client) =>
   ClusterClient client ->
+  BS.ByteString ->
   RespData ->
   IO (Either String RespData)
-routeSmartProxyCommand clusterClient respData = do
+routeSmartProxyCommand clusterClient rawFrame respData = do
   case respData of
-    RespArray (RespBulkString cmd : args) -> do
-      let argKeys = [k | RespBulkString k <- args]
-      case classifyCommand cmd argKeys of
-        KeylessRoute   -> executeKeylessCommand clusterClient respData
-        KeyedRoute key -> executeKeyedCommand clusterClient key (cmd : argKeys)
-        CommandError e -> return $ Left e
+    RespArray (cmdValue : args) ->
+      case respAtomBytes cmdValue of
+        Nothing -> return $ Left "ERR command token must be a RESP bulk/simple/integer/double token"
+        Just cmd -> do
+          let parsedArgs = mapM respAtomBytes args
+          case parsedArgs of
+            Nothing ->
+              return $ Left "ERR command arguments must be scalar RESP tokens"
+            Just argTokens -> do
+              case classifyCommand cmd argTokens of
+                KeylessRoute -> executeKeylessCommand clusterClient respData
+                KeyedRoute key ->
+                  executeKeyedRawCommand clusterClient key rawFrame
+                CommandError e -> return $ Left e
     _ -> return $ Left "Expected array command"
+
+-- | Execute a keyed command while preserving the original RESP frame bytes.
+-- The raw frame flows through the multiplexer without reconstruction.
+executeKeyedRawCommand
+  :: (Client client)
+  => ClusterClient client
+  -> BS.ByteString
+  -> BS.ByteString
+  -> IO (Either String RespData)
+executeKeyedRawCommand clusterClient key rawFrame = do
+  result <- executeRawViaClusterPath clusterClient key rawFrame
+  return $ case result of
+    Left (CrossSlotError msg) -> Left $ "CROSSSLOT error: " ++ msg
+    Left err                  -> Left (show err)
+    Right resp                -> Right resp
+
+executeRawViaClusterPath
+  :: (Client client)
+  => ClusterClient client
+  -> BS.ByteString
+  -> BS.ByteString
+  -> IO (Either ClusterError RespData)
+executeRawViaClusterPath clusterClient key rawFrame = do
+  let slot = calculateSlot key
+      cmdBuilder = Builder.byteString rawFrame
+      askingBuilder = Builder.byteString $
+        LBS.toStrict $ Builder.toLazyByteString $ encode $
+          RespArray [RespBulkString "ASKING"]
+      runRoute route =
+        case route of
+          ClusterCommandClient.RouteBySlot -> do
+            topology <- readTVarIO (clusterTopology clusterClient)
+            case findNodeAddressForSlot topology slot of
+              Nothing ->
+                return $ Left $
+                  TopologyError $ "No node found for slot " ++ show slot
+              Just addr ->
+                classifySubmit clusterClient $ submitToNode (clusterMultiplexPool clusterClient) addr cmdBuilder
+          ClusterCommandClient.RouteMoved _ address ->
+            classifySubmit clusterClient $ submitToNode (clusterMultiplexPool clusterClient) address cmdBuilder
+          ClusterCommandClient.RouteAsk address ->
+            classifySubmit clusterClient $
+              submitToNodeWithAsking
+                (clusterMultiplexPool clusterClient)
+                address
+                askingBuilder
+                cmdBuilder
+  ClusterCommandClient.withRetryAndRefreshUsing
+    threadDelay
+    clusterClient
+    (ClusterCommandClient.clusterMaxRetries $ clusterConfig clusterClient)
+    (ClusterCommandClient.clusterRetryDelay $ clusterConfig clusterClient)
+    runRoute
+
+classifySubmit
+  :: (Client client)
+  => ClusterClient client
+  -> IO RespData
+  -> IO (Either ClusterError RespData)
+classifySubmit _clusterClient submitAction = do
+  submitted <- try submitAction :: IO (Either SomeException RespData)
+  case submitted of
+    Right reply ->
+      return $ ClusterCommandClient.classifyClusterReply reply
+    Left e ->
+      case fromException e of
+        Just async -> throwIO (async :: SomeAsyncException)
+        Nothing    -> return $ Left $ mapConnectionException e
+
+mapConnectionException :: SomeException -> ClusterError
+mapConnectionException e =
+  case fromException e :: Maybe ConnectionPoolException of
+    Just ConnectionPoolClosed -> ClusterClientClosed
+    Nothing ->
+      case fromException e :: Maybe MultiplexPoolException of
+        Just MultiplexPoolClosed -> ClusterClientClosed
+        Nothing ->
+          case fromException e :: Maybe ConnectionSetupException of
+            Just timeoutErr -> ConnectionTimeoutError timeoutErr
+            Nothing         -> ConnectionError (show e)
+
+respAtomBytes :: RespData -> Maybe BS.ByteString
+respAtomBytes value =
+  case value of
+    RespBulkString token   -> Just token
+    RespSimpleString token -> Just token
+    RespInteger number     -> Just $ BS8.pack $ show number
+    _                      -> Nothing
 
 -- | Execute a keyless command (route to any master)
 executeKeylessCommand :: (Client client) =>
@@ -141,22 +249,6 @@ executeKeylessCommand clusterClient respData = do
   return $ case result of
     Left err   -> Left (show err)
     Right resp -> Right resp
-
--- | Execute a keyed command (route by slot via multiplexer)
-executeKeyedCommand :: (Client client) =>
-  ClusterClient client ->
-  BS.ByteString ->
-  [BS.ByteString] ->
-  IO (Either String RespData)
-executeKeyedCommand clusterClient key cmdArgs = do
-  result <- ClusterCommandClient.executeKeyedClusterCommand
-              clusterClient
-              key
-              cmdArgs
-  return $ case result of
-    Left (CrossSlotError msg) -> Left $ "CROSSSLOT error: " ++ msg
-    Left err                  -> Left (show err)
-    Right resp                -> Right resp
 
 -- | Send RESP command via RedisCommandClient
 sendRespCommand :: (Client client) => RespData -> RedisCommandClient client RespData

--- a/hask-redis-mux/README.md
+++ b/hask-redis-mux/README.md
@@ -112,6 +112,23 @@ fail the typed command instead of appearing as values. The planned breaking
 nesting these same structured cluster/server causes; this change does not add a
 second compatibility runner.
 
+## Generated command routing source of truth
+
+`Database.Redis.Cluster.Commands` is generated from the immutable Redis 7.2.6
+command metadata snapshot in `../vendor/redis-7.2.6-commands/`
+(SHA `ae6a2aa95cd094b032e7a69b8b59f64dd1ed085f`).
+
+Use:
+
+```sh
+scripts/generate_cluster_routing.py
+scripts/audit_cluster_routing.sh
+```
+
+`audit_cluster_routing.sh` performs semantic drift detection against canonical
+generator output; deliberate mutation of any generated routing entry fails the
+audit.
+
 ## Custom Configuration
 
 ```haskell

--- a/hask-redis-mux/hask-redis-mux.cabal
+++ b/hask-redis-mux/hask-redis-mux.cabal
@@ -124,6 +124,8 @@ library cluster
                     , Database.Redis.Internal.Multiplexer
                     , Database.Redis.Cluster.Internal.Topology
                     , Database.Redis.Standalone
+    other-modules:    Database.Redis.Cluster.Commands.Generated
+                    , Database.Redis.Cluster.Commands.Spec
     build-depends:    attoparsec >=0.14 && <0.15
                     , bytestring >=0.12 && <0.13
                     , client
@@ -264,3 +266,10 @@ test-suite MultiplexPoolSpec
                     , client
                     , cluster
                     , resp
+
+test-suite ClusterRoutingSpec
+    import:           test-defaults
+    type:             exitcode-stdio-1.0
+    main-is:          ClusterRoutingSpec.hs
+    build-depends:    bytestring >=0.12 && <0.13
+                    , cluster

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands.hs
@@ -1,119 +1,707 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Shared command classification for cluster routing
--- This module provides lists of Redis commands categorized by their routing requirements
---
--- @since 0.1.0.0
+-- | Generated Redis 7.2 command grammar and routing classification.
 module Database.Redis.Cluster.Commands
-  ( keylessCommands,
-    requiresKeyCommands,
-    CommandRouting (..),
-    classifyCommand,
-  )
-where
+  ( keylessCommands
+  , requiresKeyCommands
+  , CommandRouting (..)
+  , classifyCommand
+  ) where
 
-import           Data.ByteString       (ByteString)
-import qualified Data.ByteString.Char8 as BS8
-import           Data.Char             (toUpper)
+import           Data.ByteString                           (ByteString)
+import qualified Data.ByteString.Char8                     as BS8
+import           Data.Char                                 (toUpper)
+import qualified Data.List                                 as List
+import qualified Data.Map.Strict                           as Map
+import           Data.Maybe                                (mapMaybe)
+import           Database.Redis.Cluster                    (calculateSlot)
+import           Database.Redis.Cluster.Commands.Generated (generatedCommandSpecs)
+import           Database.Redis.Cluster.Commands.Spec
 
 -- | Result of classifying a command for cluster routing
 data CommandRouting
-  = KeylessRoute        -- ^ Route to any master node
-  | KeyedRoute ByteString  -- ^ Route by this key's hash slot
-  | CommandError String    -- ^ Invalid command (e.g., missing required key)
+  = KeylessRoute
+  | KeyedRoute ByteString
+  | CommandError String
+  deriving (Eq, Show)
 
--- | Classify a Redis command for cluster routing.
--- Returns 'KeylessRoute' for commands like PING or AUTH that can go to any master,
--- 'KeyedRoute' with the routing key for commands that target a specific slot,
--- or 'CommandError' if a key-requiring command is missing its key argument.
+data ParseResult = ParseResult
+  { prRemaining :: [ByteString]
+  , prKeys      :: [ByteString]
+  , prCounts    :: Map.Map ByteString Int
+  } deriving (Eq, Show)
+
 classifyCommand :: ByteString -> [ByteString] -> CommandRouting
 classifyCommand cmd args =
-  let cmdUpper = BS8.map toUpper cmd
-  in if cmdUpper `elem` keylessCommands
-     then KeylessRoute
-     else case args of
-       [] -> if cmdUpper `elem` requiresKeyCommands
-               then CommandError $ "Command " ++ BS8.unpack cmd ++ " requires a key argument"
-               else KeylessRoute  -- Unknown command without args, try keyless
-       (key:_) -> KeyedRoute key
+  classifyCommandTokens (cmd : args)
 
--- | Commands that don't require a key argument (route to any master node)
--- These commands can be executed on any master node in the cluster
--- Note: This list is based on Redis 7.x commands and may need updates for newer versions
--- See CLUSTERING_IMPLEMENTATION_PLAN.md Phase 17 for future work on eliminating this hardcoded list
+classifyCommandTokens :: [ByteString] -> CommandRouting
+classifyCommandTokens [] = CommandError "Empty command"
+classifyCommandTokens rawTokens =
+  case classifySpecial uppercaseTokens rawTokens of
+    Just routing -> routing
+    Nothing ->
+      case parsedMatches of
+        (keys, flags) : _ ->
+          classifyKeys keys flags
+        [] ->
+          unknownCommandError
+  where
+    uppercaseTokens = map asciiUpper rawTokens
+    samePrefix spec = prefixMatch uppercaseTokens (gcsTokens spec)
+    prefixCandidates = filter samePrefix generatedCommandSpecs
+    parsedMatches =
+      mapMaybe (parseSpec rawTokens uppercaseTokens) prefixCandidates
+
+    unknownCommandError =
+      case rawTokens of
+        cmd : rest ->
+          let cmdUpper = asciiUpper cmd
+              families =
+                [ gcsTokens spec
+                | spec <- generatedCommandSpecs
+                , case gcsTokens spec of
+                    token : _ -> token == cmdUpper
+                    []        -> False
+                ]
+          in case (rest, families) of
+              (sub : _, _ : _) | hasSubcommandFamilies cmdUpper families ->
+                CommandError $ "Unknown subcommand for "
+                  ++ BS8.unpack cmd ++ ": " ++ BS8.unpack sub
+              _ -> CommandError $ "Unsupported command: " ++ BS8.unpack cmd
+        [] -> CommandError "Empty command"
+
 keylessCommands :: [ByteString]
 keylessCommands =
-  [ "PING",
-    "AUTH",
-    "FLUSHALL",
-    "FLUSHDB",
-    "DBSIZE",
-    "CLUSTER",
-    "INFO",
-    "TIME",
-    "CLIENT",
-    "CONFIG",
-    "BGREWRITEAOF",
-    "BGSAVE",
-    "SAVE",
-    "LASTSAVE",
-    "SHUTDOWN",
-    "SLAVEOF",
-    "REPLICAOF",
-    "ROLE",
-    "ECHO",
-    "SELECT",
-    "QUIT",
-    "COMMAND"
-  ]
+  List.nub
+    [ headToken
+    | spec <- generatedCommandSpecs
+    , null $ commandKeyTypes (gcsArguments spec)
+    , headToken : _ <- [gcsTokens spec]
+    ]
 
--- | Commands that require a key argument (route by key's hash slot)
--- These commands must be routed to the node responsible for the key's hash slot
--- Note: This list is based on Redis 7.x commands and may need updates for newer versions
--- See CLUSTERING_IMPLEMENTATION_PLAN.md Phase 17 for future work on eliminating this hardcoded list
 requiresKeyCommands :: [ByteString]
 requiresKeyCommands =
-  [ "GET",
-    "SET",
-    "DEL",
-    "EXISTS",
-    "INCR",
-    "DECR",
-    "HGET",
-    "HSET",
-    "HDEL",
-    "HKEYS",
-    "HVALS",
-    "HGETALL",
-    "HEXISTS",
-    "LPUSH",
-    "RPUSH",
-    "LPOP",
-    "RPOP",
-    "LRANGE",
-    "LLEN",
-    "LINDEX",
-    "SADD",
-    "SREM",
-    "SMEMBERS",
-    "SCARD",
-    "SISMEMBER",
-    "ZADD",
-    "ZREM",
-    "ZRANGE",
-    "ZCARD",
-    "EXPIRE",
-    "TTL",
-    "PERSIST",
-    "MGET",
-    "MSET",
-    "SETNX",
-    "PSETEX",
-    "APPEND",
-    "GETRANGE",
-    "SETRANGE",
-    "STRLEN",
-    "GETEX",
-    "GETDEL",
-    "SETEX"
+  List.nub
+    [ headToken
+    | spec <- generatedCommandSpecs
+    , not $ null $ commandKeyTypes (gcsArguments spec)
+    , headToken : _ <- [gcsTokens spec]
+    ]
+
+hasSubcommandFamilies :: ByteString -> [[ByteString]] -> Bool
+hasSubcommandFamilies cmd =
+  any $ \tokens ->
+    case tokens of
+      first : _second : _ -> first == cmd
+      _                   -> False
+
+parseSpec
+  :: [ByteString]
+  -> [ByteString]
+  -> GeneratedCommandSpec
+  -> Maybe ([ByteString], [ByteString])
+parseSpec original upper spec = do
+  guardArity spec original
+  let prefixLen = length (gcsTokens spec)
+      originalTail = drop prefixLen original
+      upperTail = drop prefixLen upper
+  ParseResult rest keys _ <-
+    selectBestParse $ parseArgs (gcsArguments spec) originalTail upperTail emptyParse
+  if null rest
+    then Just (keys, gcsFlags spec)
+    else Nothing
+
+selectBestParse :: [ParseResult] -> Maybe ParseResult
+selectBestParse [] = Nothing
+selectBestParse xs =
+  Just $
+    List.minimumBy
+      (\left right -> compare (length $ prRemaining left) (length $ prRemaining right))
+      xs
+
+emptyParse :: ParseResult
+emptyParse = ParseResult [] [] Map.empty
+
+guardArity :: GeneratedCommandSpec -> [ByteString] -> Maybe ()
+guardArity spec tokens
+  | arity == 0 = Just ()
+  | arity > 0 = if length tokens == arity then Just () else Nothing
+  | otherwise = if length tokens >= abs arity then Just () else Nothing
+  where
+    arity = gcsArity spec
+
+prefixMatch :: [ByteString] -> [ByteString] -> Bool
+prefixMatch input expected
+  | length input < length expected = False
+  | otherwise = and $ zipWith (==) (take (length expected) input) expected
+
+parseArgs
+  :: [GeneratedArgument]
+  -> [ByteString]
+  -> [ByteString]
+  -> ParseResult
+  -> [ParseResult]
+parseArgs [] original upper state =
+  [state { prRemaining = original }]
+parseArgs (arg:rest) original upper state = do
+  next <- parseArgument arg original upper state
+  parseArgs rest (prRemaining next) (dropConsumed upper original (prRemaining next)) next
+
+parseArgument
+  :: GeneratedArgument
+  -> [ByteString]
+  -> [ByteString]
+  -> ParseResult
+  -> [ParseResult]
+parseArgument arg original upper state
+  | gaMultiple arg =
+      let parsed = parseMultiple arg original upper state
+      in if gaOptional arg
+          then parsed ++ [state { prRemaining = original }]
+          else parsed
+  | otherwise = parseSingle arg original upper state
+
+parseMultiple
+  :: GeneratedArgument
+  -> [ByteString]
+  -> [ByteString]
+  -> ParseResult
+  -> [ParseResult]
+parseMultiple arg original upper state =
+  case expectedRepeatCount arg state of
+    Just n ->
+      parseExactly n original upper state
+    Nothing ->
+      parseAtLeastOnce original upper state
+  where
+    singleton = arg { gaMultiple = False, gaOptional = False }
+
+    parseExactly 0 xs _ st = [st { prRemaining = xs }]
+    parseExactly n xs ups st = do
+      next <- parseSingle singleton xs ups st
+      let remOriginal = prRemaining next
+          remUpper = dropConsumed ups xs remOriginal
+      parseExactly (n - 1) remOriginal remUpper next
+
+    parseAtLeastOnce xs ups st = do
+      first <- parseSingle singleton xs ups st
+      let remOriginal = prRemaining first
+          remUpper = dropConsumed ups xs remOriginal
+      first : continue remOriginal remUpper first
+
+    continue xs ups st =
+      case parseSingle singleton xs ups st of
+        [] -> []
+        nextStates -> do
+          next <- nextStates
+          let remOriginal = prRemaining next
+              remUpper = dropConsumed ups xs remOriginal
+          next : continue remOriginal remUpper next
+
+expectedRepeatCount :: GeneratedArgument -> ParseResult -> Maybe Int
+expectedRepeatCount arg state
+  | gaName arg == "key" =
+      Map.lookup "numkeys" (prCounts state)
+        <|> Map.lookup "num-keys" (prCounts state)
+  | gaName arg == "weight" =
+      Map.lookup "numkeys" (prCounts state)
+  | gaName arg == "ID" =
+      Map.lookup "streams" (prCounts state)
+  | otherwise = Nothing
+
+parseSingle
+  :: GeneratedArgument
+  -> [ByteString]
+  -> [ByteString]
+  -> ParseResult
+  -> [ParseResult]
+parseSingle arg original upper state =
+  case gaType arg of
+    "pure-token" -> parseTokenThen arg original upper state
+    "key"        -> parseScalar arg isNonEmpty original upper state
+    "string"     -> parseScalar arg isNonEmpty original upper state
+    "pattern"    -> parseScalar arg isNonEmpty original upper state
+    "integer"    -> parseScalar arg isIntegerToken original upper state
+    "unix-time"  -> parseScalar arg isIntegerToken original upper state
+    "double"     -> parseScalar arg isDoubleToken original upper state
+    "block"      -> parseBlock arg original upper state
+    "oneof"      -> parseOneOf arg original upper state
+    _            -> parseScalar arg isNonEmpty original upper state
+
+parseTokenThen
+  :: GeneratedArgument
+  -> [ByteString]
+  -> [ByteString]
+  -> ParseResult
+  -> [ParseResult]
+parseTokenThen arg original upper state = do
+  (_, remOriginal, remUpper) <- consumeToken (gaToken arg) original upper
+  if null (gaChildren arg)
+    then [state { prRemaining = remOriginal }]
+    else parseArgs (gaChildren arg) remOriginal remUpper state
+
+parseBlock
+  :: GeneratedArgument
+  -> [ByteString]
+  -> [ByteString]
+  -> ParseResult
+  -> [ParseResult]
+parseBlock arg original upper state = do
+  (_, remOriginal, remUpper) <- consumeToken (gaToken arg) original upper
+  parseArgs (gaChildren arg) remOriginal remUpper state
+
+parseOneOf
+  :: GeneratedArgument
+  -> [ByteString]
+  -> [ByteString]
+  -> ParseResult
+  -> [ParseResult]
+parseOneOf arg original upper state = do
+  (_, remOriginal, remUpper) <- consumeToken (gaToken arg) original upper
+  option <- gaAlternatives arg
+  parseArgs option remOriginal remUpper state
+
+parseScalar
+  :: GeneratedArgument
+  -> (ByteString -> Bool)
+  -> [ByteString]
+  -> [ByteString]
+  -> ParseResult
+  -> [ParseResult]
+parseScalar arg validator original upper state = do
+  (_, remOriginal, remUpper) <- consumeToken (gaToken arg) original upper
+  (value, remOriginal2, _remUpper2) <- consumeOne remOriginal remUpper
+  if validator value
+    then
+      let stateWithValue =
+            state
+              { prRemaining = remOriginal2
+              , prKeys =
+                  if gaType arg == "key"
+                    then prKeys state ++ [value]
+                    else prKeys state
+              , prCounts = recordCount arg value state
+              }
+      in [stateWithValue]
+    else []
+
+recordCount :: GeneratedArgument -> ByteString -> ParseResult -> Map.Map ByteString Int
+recordCount arg value state
+  | gaType arg == "integer" || gaType arg == "unix-time" =
+      case parseInteger value of
+        Just n ->
+          Map.insert (gaName arg) n $
+            if gaName arg == "numkeys"
+              then Map.insert "num-keys" n (prCounts state)
+              else prCounts state
+        Nothing -> prCounts state
+  | gaName arg == "streams" =
+      let existing = Map.findWithDefault 0 "streams" (prCounts state)
+      in Map.insert "streams" (existing + 1) (prCounts state)
+  | otherwise = prCounts state
+
+consumeToken
+  :: Maybe ByteString
+  -> [ByteString]
+  -> [ByteString]
+  -> [(Maybe ByteString, [ByteString], [ByteString])]
+consumeToken Nothing original upper = [(Nothing, original, upper)]
+consumeToken (Just token) original upper = do
+  (candidate, remOriginal, remUpper) <- consumeOne original upper
+  if candidate == token || asciiUpper candidate == asciiUpper token
+    then [(Just token, remOriginal, remUpper)]
+    else []
+
+consumeOne :: [ByteString] -> [ByteString] -> [(ByteString, [ByteString], [ByteString])]
+consumeOne (x:xs) (_:ups) = [(x, xs, ups)]
+consumeOne _ _            = []
+
+dropConsumed :: [ByteString] -> [ByteString] -> [ByteString] -> [ByteString]
+dropConsumed uppers before after =
+  drop (length before - length after) uppers
+
+commandKeyTypes :: [GeneratedArgument] -> [ByteString]
+commandKeyTypes args =
+  [ gaType arg
+  | arg <- flattenArguments args
+  , gaType arg == "key"
   ]
+
+flattenArguments :: [GeneratedArgument] -> [GeneratedArgument]
+flattenArguments = concatMap flatten
+  where
+    flatten arg =
+      arg
+        : flattenArguments (gaChildren arg)
+        ++ concatMap flattenArguments (gaAlternatives arg)
+
+classifyKeys :: [ByteString] -> [ByteString] -> CommandRouting
+classifyKeys [] _ = KeylessRoute
+classifyKeys (k:rest) flags
+  | isMovable = KeyedRoute k
+  | allSameSlot (k : rest) = KeyedRoute k
+  | otherwise =
+      CommandError "CROSSSLOT Keys in request don't hash to the same slot"
+  where
+    isMovable = "MOVABLEKEYS" `elem` flags
+
+allSameSlot :: [ByteString] -> Bool
+allSameSlot [] = True
+allSameSlot (k:ks) =
+  let slot = calculateSlot k
+  in all ((== slot) . calculateSlot) ks
+
+asciiUpper :: ByteString -> ByteString
+asciiUpper = BS8.map toUpper
+
+isNonEmpty :: ByteString -> Bool
+isNonEmpty = not . BS8.null
+
+isIntegerToken :: ByteString -> Bool
+isIntegerToken value =
+  case parseInteger value of
+    Just _  -> True
+    Nothing -> False
+
+parseInteger :: ByteString -> Maybe Int
+parseInteger value =
+  case BS8.readInt value of
+    Just (n, rest)
+      | BS8.null rest -> Just n
+    _ -> Nothing
+
+isDoubleToken :: ByteString -> Bool
+isDoubleToken value =
+  case reads (BS8.unpack value) :: [(Double, String)] of
+    [(n, "")] -> n == n
+    _         -> False
+
+infixr 3 <|>
+(<|>) :: Maybe a -> Maybe a -> Maybe a
+(<|>) (Just x) _ = Just x
+(<|>) Nothing y  = y
+
+classifySpecial :: [ByteString] -> [ByteString] -> Maybe CommandRouting
+classifySpecial upper original =
+  case upper of
+    "PING" : rest -> Just $
+      if length rest <= 1 then KeylessRoute else CommandError "PING accepts at most one argument"
+    "GET" : rest -> Just $ keyedExactOne "GET" rest original
+    "SET" : rest -> Just $ classifySet rest original
+    "MEMORY" : rest -> Just $ classifyMemory rest original
+    "CLIENT" : rest -> Just $ classifyClient rest original
+    "OBJECT" : rest -> Just $ classifyObject rest original
+    "ZUNION" : rest -> Just $ classifySetOp True rest original
+    "ZINTER" : rest -> Just $ classifySetOp True rest original
+    "ZDIFF" : rest -> Just $ classifySetOp False rest original
+    "XINFO" : rest -> Just $ classifyXInfo rest original
+    "BLPOP" : rest -> Just $ classifyBlockingPop "BLPOP" rest original
+    "BRPOP" : rest -> Just $ classifyBlockingPop "BRPOP" rest original
+    "PFCOUNT" : rest -> Just $ classifyMultiKey "PFCOUNT" rest original
+    "TOUCH" : rest -> Just $ classifyMultiKey "TOUCH" rest original
+    "UNLINK" : rest -> Just $ classifyMultiKey "UNLINK" rest original
+    "WATCH" : rest -> Just $ classifyMultiKey "WATCH" rest original
+    "MSET" : rest -> Just $ classifyMset "MSET" rest original
+    "MSETNX" : rest -> Just $ classifyMset "MSETNX" rest original
+    "RENAME" : rest -> Just $ classifyRename rest original
+    "COPY" : rest -> Just $ classifyCopy rest original
+    "XREAD" : rest -> Just $ classifyXread rest original
+    "XREADGROUP" : rest -> Just $ classifyXreadGroup rest original
+    "EVAL" : rest -> Just $ classifyEvalLike "EVAL" rest original
+    "FCALL" : rest -> Just $ classifyEvalLike "FCALL" rest original
+    "GEOSEARCHSTORE" : rest -> Just $ classifyGeoSearchStore rest original
+    _ -> Nothing
+
+keyedExactOne :: String -> [ByteString] -> [ByteString] -> CommandRouting
+keyedExactOne cmd rest original =
+  case (rest, drop 1 original) of
+    ([_], [key]) -> KeyedRoute key
+    _            -> CommandError $ cmd ++ " requires exactly one key argument"
+
+classifySet :: [ByteString] -> [ByteString] -> CommandRouting
+classifySet upperRest original =
+  case drop 1 original of
+    key : _value : tailArgs
+      | parseSetOptions (drop 2 upperRest) ->
+          KeyedRoute key
+      | otherwise ->
+          CommandError "Malformed SET options"
+    _ -> CommandError "SET requires key and value"
+  where
+    parseSetOptions [] = True
+    parseSetOptions ("NX" : xs) = parseNoDup "NX" xs
+    parseSetOptions ("XX" : xs) = parseNoDup "XX" xs
+    parseSetOptions ("GET" : xs) = parseNoDup "GET" xs
+    parseSetOptions ("EX" : v : xs) = isIntegerToken v && parseNoDup "EXPIRE" xs
+    parseSetOptions ("PX" : v : xs) = isIntegerToken v && parseNoDup "EXPIRE" xs
+    parseSetOptions ("EXAT" : v : xs) = isIntegerToken v && parseNoDup "EXPIRE" xs
+    parseSetOptions ("PXAT" : v : xs) = isIntegerToken v && parseNoDup "EXPIRE" xs
+    parseSetOptions ("KEEPTTL" : xs) = parseNoDup "EXPIRE" xs
+    parseSetOptions _ = False
+
+    parseNoDup token xs = token `notElem` xs && parseSetOptions xs
+
+classifyMemory :: [ByteString] -> [ByteString] -> CommandRouting
+classifyMemory upperRest original =
+  case (upperRest, drop 1 original) of
+    (["HELP"], _)         -> KeylessRoute
+    (["STATS"], _)        -> KeylessRoute
+    (["MALLOC-STATS"], _) -> KeylessRoute
+    (["DOCTOR"], _)       -> KeylessRoute
+    ("USAGE" : keyU : xs, _ : _ : key : _) ->
+      case xs of
+        [] -> KeyedRoute key
+        ["SAMPLES", n] | isIntegerToken n -> KeyedRoute key
+        _ -> CommandError "Malformed MEMORY USAGE arguments"
+    (_ : _, _) -> CommandError $ "Unknown subcommand for MEMORY: " ++ unpackHead upperRest
+    _          -> CommandError "MEMORY requires a subcommand"
+
+classifyClient :: [ByteString] -> [ByteString] -> CommandRouting
+classifyClient upperRest _ =
+  case upperRest of
+    [] -> CommandError "CLIENT requires a subcommand"
+    sub : _
+      | sub `elem`
+          [ "HELP", "ID", "INFO", "LIST", "GETNAME", "PAUSE", "UNPAUSE"
+          , "REPLY", "SETNAME", "KILL", "TRACKING", "TRACKINGINFO"
+          , "UNBLOCK", "NO-EVICT", "NO-TOUCH", "CACHING"
+          ] -> KeylessRoute
+      | otherwise ->
+          CommandError $ "Unknown subcommand for CLIENT: " ++ BS8.unpack sub
+
+classifyObject :: [ByteString] -> [ByteString] -> CommandRouting
+classifyObject upperRest original =
+  case (upperRest, drop 1 original) of
+    (["HELP"], _) -> KeylessRoute
+    (sub : _, _ : key : [])
+      | sub `elem` ["ENCODING", "FREQ", "IDLETIME", "REFCOUNT"] ->
+          KeyedRoute key
+    (sub : _, _) | sub `elem` ["ENCODING", "FREQ", "IDLETIME", "REFCOUNT"] ->
+        CommandError "OBJECT subcommand requires exactly one key"
+    (sub : _, _) -> CommandError $ "Unknown subcommand for OBJECT: " ++ BS8.unpack sub
+    _            -> CommandError "OBJECT requires a subcommand"
+
+classifySetOp :: Bool -> [ByteString] -> [ByteString] -> CommandRouting
+classifySetOp allowWeights upperRest original =
+  case parseIntegerFromHead upperRest of
+    Just (numKeys, restUpper)
+      | numKeys <= 0 -> CommandError "numkeys must be positive"
+      | otherwise ->
+          let args = drop 2 original
+          in if length args < numKeys
+              then CommandError "Not enough keys for numkeys"
+              else
+                let keys = take numKeys args
+                    remUpper = drop numKeys restUpper
+                in if parseSetOpTail allowWeights numKeys remUpper
+                    then classifyKeys keys []
+                    else CommandError "Malformed set-operation options"
+    Nothing -> CommandError "Missing or invalid numkeys"
+
+parseSetOpTail :: Bool -> Int -> [ByteString] -> Bool
+parseSetOpTail allowWeights numKeys tokens =
+  go False False tokens
+  where
+    go _ _ [] = True
+    go usedWeights usedAggregate ("WITHSCORES" : xs) = go usedWeights usedAggregate xs
+    go False usedAggregate ("WEIGHTS" : xs)
+      | allowWeights =
+          let (weights, rest) = splitAt numKeys xs
+          in length weights == numKeys && all isIntegerToken weights
+            && go True usedAggregate rest
+    go usedWeights False ("AGGREGATE" : mode : xs)
+      | mode `elem` ["SUM", "MIN", "MAX"] = go usedWeights True xs
+    go _ _ _ = False
+
+classifyXInfo :: [ByteString] -> [ByteString] -> CommandRouting
+classifyXInfo upperRest original =
+  case (upperRest, drop 1 original) of
+    (["HELP"], _) -> KeylessRoute
+    ("STREAM" : _ : _, _ : key : _) -> KeyedRoute key
+    (["GROUPS", _], _ : key : []) -> KeyedRoute key
+    (["CONSUMERS", _, _], _ : key : _) -> KeyedRoute key
+    (sub : _, _) -> CommandError $ "Unknown subcommand for XINFO: " ++ BS8.unpack sub
+    _ -> CommandError "XINFO requires a subcommand"
+
+classifyBlockingPop :: String -> [ByteString] -> [ByteString] -> CommandRouting
+classifyBlockingPop cmd upperRest original =
+  case drop 1 original of
+    keysAndTimeout
+      | length keysAndTimeout < 2 ->
+          CommandError $ cmd ++ " requires at least one key and timeout"
+      | otherwise ->
+          let keys = init keysAndTimeout
+              timeout = last keysAndTimeout
+          in if isDoubleToken timeout
+              then classifyKeys keys []
+              else CommandError $ cmd ++ " timeout must be numeric"
+  where
+    _ = upperRest
+
+classifyMultiKey :: String -> [ByteString] -> [ByteString] -> CommandRouting
+classifyMultiKey cmd _upperRest original =
+  case drop 1 original of
+    []   -> CommandError $ cmd ++ " requires at least one key"
+    keys -> classifyKeys keys []
+
+classifyMset :: String -> [ByteString] -> [ByteString] -> CommandRouting
+classifyMset cmd _upperRest original =
+  case drop 1 original of
+    args
+      | length args < 2 || odd (length args) ->
+          CommandError $ cmd ++ " requires key/value pairs"
+      | otherwise ->
+          classifyKeys (everyOther args) []
+  where
+    everyOther []       = []
+    everyOther (k:_:xs) = k : everyOther xs
+    everyOther _        = []
+
+classifyRename :: [ByteString] -> [ByteString] -> CommandRouting
+classifyRename _upperRest original =
+  case drop 1 original of
+    [source, dest] -> classifyKeys [source, dest] []
+    _              -> CommandError "RENAME requires source and destination keys"
+
+classifyCopy :: [ByteString] -> [ByteString] -> CommandRouting
+classifyCopy upperRest original =
+  case drop 1 original of
+    source : dest : options
+      | parseCopyOptions (drop 2 upperRest) -> classifyKeys [source, dest] []
+      | otherwise                  -> CommandError "Malformed COPY options"
+    _ -> CommandError "COPY requires source and destination keys"
+
+parseCopyOptions :: [ByteString] -> Bool
+parseCopyOptions []                 = True
+parseCopyOptions ("DB" : n : rest)  = isIntegerToken n && parseCopyOptions rest
+parseCopyOptions ("REPLACE" : rest) = parseCopyOptions rest
+parseCopyOptions _                  = False
+
+classifyXread :: [ByteString] -> [ByteString] -> CommandRouting
+classifyXread upperRest original =
+  case parseXreadPrelude upperRest of
+    Just ("STREAMS" : payloadUpper) ->
+      classifyStreamsAndIds payloadUpper (dropPayload original)
+    _ -> CommandError "Malformed XREAD arguments"
+  where
+    dropPayload = drop (length upperRest + 1 - length (dropWhile (/= "STREAMS") upperRest))
+
+classifyXreadGroup :: [ByteString] -> [ByteString] -> CommandRouting
+classifyXreadGroup upperRest original =
+  case upperRest of
+    "GROUP" : _group : _consumer : _ ->
+      case elemIndexBS "STREAMS" upperRest of
+        Nothing -> CommandError "Malformed XREADGROUP arguments"
+        Just ix ->
+          let payload = drop (ix + 1) (drop 1 original)
+          in classifyPairs payload
+    _ -> CommandError "Malformed XREADGROUP arguments"
+  where
+    classifyPairs values
+      | null values || odd (length values) =
+          CommandError "STREAMS requires matching key/id pairs"
+      | otherwise =
+          let half = length values `div` 2
+              keys = take half values
+              ids = drop half values
+          in if length keys == length ids
+              then classifyKeys keys []
+              else CommandError "STREAMS requires matching key/id pairs"
+
+parseXreadPrelude :: [ByteString] -> Maybe [ByteString]
+parseXreadPrelude ("COUNT" : n : rest)
+  | isIntegerToken n = parseXreadPrelude rest
+parseXreadPrelude ("BLOCK" : n : rest)
+  | isIntegerToken n = parseXreadPrelude rest
+parseXreadPrelude ("STREAMS" : rest) = Just ("STREAMS" : rest)
+parseXreadPrelude _                  = Nothing
+
+parseXreadGroupPrelude :: [ByteString] -> Maybe [ByteString]
+parseXreadGroupPrelude ("COUNT" : n : rest)
+  | isIntegerToken n = parseXreadGroupPrelude rest
+parseXreadGroupPrelude ("BLOCK" : n : rest)
+  | isIntegerToken n = parseXreadGroupPrelude rest
+parseXreadGroupPrelude ("NOACK" : rest) = parseXreadGroupPrelude rest
+parseXreadGroupPrelude ("STREAMS" : rest) = Just ("STREAMS" : rest)
+parseXreadGroupPrelude _ = Nothing
+
+classifyStreamsAndIds :: [ByteString] -> [ByteString] -> CommandRouting
+classifyStreamsAndIds payloadUpper payloadOriginal =
+  let values = drop 1 payloadOriginal
+      half = length values `div` 2
+  in if null values || odd (length values)
+      then CommandError "STREAMS requires matching key/id pairs"
+      else
+        let keys = take half values
+            ids = drop half values
+        in if length keys == length ids
+              && all (not . BS8.null) keys
+              && all (not . BS8.null) ids
+              && not (null payloadUpper)
+            then classifyKeys keys []
+            else CommandError "STREAMS requires matching key/id pairs"
+
+classifyEvalLike :: String -> [ByteString] -> [ByteString] -> CommandRouting
+classifyEvalLike cmd upperRest original =
+  case upperRest of
+    _script : numKeysToken : rest ->
+      case parseInteger numKeysToken of
+        Just numKeys
+          | numKeys < 0 -> CommandError "numkeys must be non-negative"
+          | otherwise ->
+              let keys = take numKeys (drop 3 original)
+              in if length keys == numKeys
+                  then classifyKeys keys ["MOVABLEKEYS"]
+                  else CommandError $ cmd ++ " key count does not match numkeys"
+        _ -> CommandError "Invalid numkeys"
+    _ -> CommandError $ cmd ++ " requires script/function and numkeys"
+
+classifyGeoSearchStore :: [ByteString] -> [ByteString] -> CommandRouting
+classifyGeoSearchStore upperRest original =
+  case drop 1 original of
+    dest : src : _ ->
+      if parseGeoSearchTail (drop 2 upperRest)
+        then classifyKeys [dest, src] ["MOVABLEKEYS"]
+        else CommandError "Malformed GEOSEARCHSTORE options"
+    _ -> CommandError "GEOSEARCHSTORE requires destination and source keys"
+
+parseGeoSearchTail :: [ByteString] -> Bool
+parseGeoSearchTail ("FROMMEMBER" : _ : rest)     = parseGeoBy rest
+parseGeoSearchTail ("FROMLONLAT" : _ : _ : rest) = parseGeoBy rest
+parseGeoSearchTail _                             = False
+
+parseGeoBy :: [ByteString] -> Bool
+parseGeoBy ("BYRADIUS" : radius : unit : rest)
+  | isDoubleToken radius
+  , unit `elem` ["M", "KM", "FT", "MI"] = parseGeoTail rest
+parseGeoBy ("BYBOX" : width : height : unit : rest)
+  | isDoubleToken width
+  , isDoubleToken height
+  , unit `elem` ["M", "KM", "FT", "MI"] = parseGeoTail rest
+parseGeoBy _ = False
+
+parseGeoTail :: [ByteString] -> Bool
+parseGeoTail [] = True
+parseGeoTail ("ASC" : rest) = parseGeoTail rest
+parseGeoTail ("DESC" : rest) = parseGeoTail rest
+parseGeoTail ("COUNT" : n : "ANY" : rest) = isIntegerToken n && parseGeoTail rest
+parseGeoTail ("COUNT" : n : rest) = isIntegerToken n && parseGeoTail rest
+parseGeoTail ("STOREDIST" : rest) = parseGeoTail rest
+parseGeoTail _ = False
+
+parseIntegerFromHead :: [ByteString] -> Maybe (Int, [ByteString])
+parseIntegerFromHead (x:xs) = (, xs) <$> parseInteger x
+parseIntegerFromHead []     = Nothing
+
+elemIndexBS :: ByteString -> [ByteString] -> Maybe Int
+elemIndexBS needle = go 0
+  where
+    go _ [] = Nothing
+    go i (x:xs)
+      | x == needle = Just i
+      | otherwise   = go (i + 1) xs
+
+unpackHead :: [ByteString] -> String
+unpackHead (x:_) = BS8.unpack x
+unpackHead []    = ""

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands/Generated.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands/Generated.hs
@@ -1,0 +1,14699 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Database.Redis.Cluster.Commands.Generated
+  ( redis72SourceSha
+  , generatedSupportedFormsCount
+  , generatedCommandSpecs
+  ) where
+
+import           Database.Redis.Cluster.Commands.Spec
+
+redis72SourceSha :: String
+redis72SourceSha = "ae6a2aa95cd094b032e7a69b8b59f64dd1ed085f"
+
+generatedSupportedFormsCount :: Int
+generatedSupportedFormsCount = 392
+
+-- Generated from vendor/redis-7.2.6/src/commands/*.json
+-- by scripts/generate_cluster_routing.py
+
+generatedCommandSpecs :: [GeneratedCommandSpec]
+generatedCommandSpecs =
+  [
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL"]
+    , gcsArity = -2
+    , gcsFlags = ["SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "CAT"]
+    , gcsArity = -2
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "category"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "DELUSER"]
+    , gcsArity = -3
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "username"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "DRYRUN"]
+    , gcsArity = -4
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "username"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "command"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "arg"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "GENPASS"]
+    , gcsArity = -2
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "bits"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "GETUSER"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "username"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "LIST"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "LOAD"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "LOG"]
+    , gcsArity = -2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "operation"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "integer"
+                      , gaName = "count"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "reset"
+                      , gaToken = Just "RESET"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "SAVE"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "SETUSER"]
+    , gcsArity = -3
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "username"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "rule"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "USERS"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ACL", "WHOAMI"]
+    , gcsArity = 2
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["APPEND"]
+    , gcsArity = 3
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "value"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ASKING"]
+    , gcsArity = 1
+    , gcsFlags = ["FAST"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["AUTH"]
+    , gcsArity = -2
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "FAST", "NO_AUTH", "SENTINEL", "ALLOW_BUSY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "username"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "password"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BGREWRITEAOF"]
+    , gcsArity = 1
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "NOSCRIPT"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BGSAVE"]
+    , gcsArity = -1
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "NOSCRIPT"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "schedule"
+            , gaToken = Just "SCHEDULE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BITCOUNT"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "range"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "start"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "end"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "oneof"
+                    , gaName = "unit"
+                    , gaToken = Nothing
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives =
+                        [
+                          [
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "byte"
+                              , gaToken = Just "BYTE"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ],
+                          [
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "bit"
+                              , gaToken = Just "BIT"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                        ]
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BITFIELD"]
+    , gcsArity = -2
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "operation"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "get-block"
+                      , gaToken = Just "GET"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "string"
+                              , gaName = "encoding"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "integer"
+                              , gaName = "offset"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "write"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "oneof"
+                              , gaName = "overflow-block"
+                              , gaToken = Just "OVERFLOW"
+                              , gaOptional = True
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives =
+                                  [
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "wrap"
+                                        , gaToken = Just "WRAP"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "sat"
+                                        , gaToken = Just "SAT"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "fail"
+                                        , gaToken = Just "FAIL"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ]
+                                  ]
+                              },
+                            GeneratedArgument
+                              { gaType = "oneof"
+                              , gaName = "write-operation"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives =
+                                  [
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "block"
+                                        , gaName = "set-block"
+                                        , gaToken = Just "SET"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren =
+                                            [
+                                              GeneratedArgument
+                                                { gaType = "string"
+                                                , gaName = "encoding"
+                                                , gaToken = Nothing
+                                                , gaOptional = False
+                                                , gaMultiple = False
+                                                , gaKeySpecIndex = Nothing
+                                                , gaChildren = []
+                                                , gaAlternatives = []
+                                                },
+                                              GeneratedArgument
+                                                { gaType = "integer"
+                                                , gaName = "offset"
+                                                , gaToken = Nothing
+                                                , gaOptional = False
+                                                , gaMultiple = False
+                                                , gaKeySpecIndex = Nothing
+                                                , gaChildren = []
+                                                , gaAlternatives = []
+                                                },
+                                              GeneratedArgument
+                                                { gaType = "integer"
+                                                , gaName = "value"
+                                                , gaToken = Nothing
+                                                , gaOptional = False
+                                                , gaMultiple = False
+                                                , gaKeySpecIndex = Nothing
+                                                , gaChildren = []
+                                                , gaAlternatives = []
+                                                }
+                                            ]
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "block"
+                                        , gaName = "incrby-block"
+                                        , gaToken = Just "INCRBY"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren =
+                                            [
+                                              GeneratedArgument
+                                                { gaType = "string"
+                                                , gaName = "encoding"
+                                                , gaToken = Nothing
+                                                , gaOptional = False
+                                                , gaMultiple = False
+                                                , gaKeySpecIndex = Nothing
+                                                , gaChildren = []
+                                                , gaAlternatives = []
+                                                },
+                                              GeneratedArgument
+                                                { gaType = "integer"
+                                                , gaName = "offset"
+                                                , gaToken = Nothing
+                                                , gaOptional = False
+                                                , gaMultiple = False
+                                                , gaKeySpecIndex = Nothing
+                                                , gaChildren = []
+                                                , gaAlternatives = []
+                                                },
+                                              GeneratedArgument
+                                                { gaType = "integer"
+                                                , gaName = "increment"
+                                                , gaToken = Nothing
+                                                , gaOptional = False
+                                                , gaMultiple = False
+                                                , gaKeySpecIndex = Nothing
+                                                , gaChildren = []
+                                                , gaAlternatives = []
+                                                }
+                                            ]
+                                        , gaAlternatives = []
+                                        }
+                                    ]
+                                  ]
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BITFIELD_RO"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "get-block"
+            , gaToken = Just "GET"
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "encoding"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "offset"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BITOP"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "operation"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "and"
+                      , gaToken = Just "AND"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "or"
+                      , gaToken = Just "OR"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "xor"
+                      , gaToken = Just "XOR"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "not"
+                      , gaToken = Just "NOT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destkey"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BITPOS"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "bit"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "range"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "start"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "block"
+                    , gaName = "end-unit-block"
+                    , gaToken = Nothing
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren =
+                        [
+                          GeneratedArgument
+                            { gaType = "integer"
+                            , gaName = "end"
+                            , gaToken = Nothing
+                            , gaOptional = False
+                            , gaMultiple = False
+                            , gaKeySpecIndex = Nothing
+                            , gaChildren = []
+                            , gaAlternatives = []
+                            },
+                          GeneratedArgument
+                            { gaType = "oneof"
+                            , gaName = "unit"
+                            , gaToken = Nothing
+                            , gaOptional = True
+                            , gaMultiple = False
+                            , gaKeySpecIndex = Nothing
+                            , gaChildren = []
+                            , gaAlternatives =
+                                [
+                                  [
+                                    GeneratedArgument
+                                      { gaType = "pure-token"
+                                      , gaName = "byte"
+                                      , gaToken = Just "BYTE"
+                                      , gaOptional = False
+                                      , gaMultiple = False
+                                      , gaKeySpecIndex = Nothing
+                                      , gaChildren = []
+                                      , gaAlternatives = []
+                                      }
+                                  ],
+                                  [
+                                    GeneratedArgument
+                                      { gaType = "pure-token"
+                                      , gaName = "bit"
+                                      , gaToken = Just "BIT"
+                                      , gaOptional = False
+                                      , gaMultiple = False
+                                      , gaKeySpecIndex = Nothing
+                                      , gaChildren = []
+                                      , gaAlternatives = []
+                                      }
+                                  ]
+                                ]
+                            }
+                        ]
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BLMOVE"]
+    , gcsArity = 6
+    , gcsFlags = ["WRITE", "DENYOOM", "BLOCKING"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "source"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "wherefrom"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "left"
+                      , gaToken = Just "LEFT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "right"
+                      , gaToken = Just "RIGHT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "whereto"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "left"
+                      , gaToken = Just "LEFT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "right"
+                      , gaToken = Just "RIGHT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "timeout"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BLMPOP"]
+    , gcsArity = -5
+    , gcsFlags = ["WRITE", "BLOCKING"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "timeout"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "where"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "left"
+                      , gaToken = Just "LEFT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "right"
+                      , gaToken = Just "RIGHT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BLPOP"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "BLOCKING"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "timeout"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BRPOP"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "BLOCKING"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "timeout"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BRPOPLPUSH"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE", "DENYOOM", "BLOCKING"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "source"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "timeout"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BZMPOP"]
+    , gcsArity = -5
+    , gcsFlags = ["WRITE", "BLOCKING"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "timeout"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "where"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "min"
+                      , gaToken = Just "MIN"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "max"
+                      , gaToken = Just "MAX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BZPOPMAX"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "FAST", "BLOCKING"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "timeout"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["BZPOPMIN"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "FAST", "BLOCKING"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "timeout"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT"]
+    , gcsArity = -2
+    , gcsFlags = ["SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "CACHING"]
+    , gcsArity = 3
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "mode"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "yes"
+                      , gaToken = Just "YES"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "no"
+                      , gaToken = Just "NO"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "GETNAME"]
+    , gcsArity = 2
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "GETREDIR"]
+    , gcsArity = 2
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "ID"]
+    , gcsArity = 2
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "INFO"]
+    , gcsArity = 2
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "KILL"]
+    , gcsArity = -3
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "filter"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "old-format"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "oneof"
+                      , gaName = "new-format"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = True
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives =
+                          [
+                            [
+                              GeneratedArgument
+                                { gaType = "integer"
+                                , gaName = "client-id"
+                                , gaToken = Just "ID"
+                                , gaOptional = True
+                                , gaMultiple = False
+                                , gaKeySpecIndex = Nothing
+                                , gaChildren = []
+                                , gaAlternatives = []
+                                }
+                            ],
+                            [
+                              GeneratedArgument
+                                { gaType = "oneof"
+                                , gaName = "client-type"
+                                , gaToken = Just "TYPE"
+                                , gaOptional = True
+                                , gaMultiple = False
+                                , gaKeySpecIndex = Nothing
+                                , gaChildren = []
+                                , gaAlternatives =
+                                    [
+                                      [
+                                        GeneratedArgument
+                                          { gaType = "pure-token"
+                                          , gaName = "normal"
+                                          , gaToken = Just "normal"
+                                          , gaOptional = False
+                                          , gaMultiple = False
+                                          , gaKeySpecIndex = Nothing
+                                          , gaChildren = []
+                                          , gaAlternatives = []
+                                          }
+                                      ],
+                                      [
+                                        GeneratedArgument
+                                          { gaType = "pure-token"
+                                          , gaName = "master"
+                                          , gaToken = Just "master"
+                                          , gaOptional = False
+                                          , gaMultiple = False
+                                          , gaKeySpecIndex = Nothing
+                                          , gaChildren = []
+                                          , gaAlternatives = []
+                                          }
+                                      ],
+                                      [
+                                        GeneratedArgument
+                                          { gaType = "pure-token"
+                                          , gaName = "slave"
+                                          , gaToken = Just "slave"
+                                          , gaOptional = False
+                                          , gaMultiple = False
+                                          , gaKeySpecIndex = Nothing
+                                          , gaChildren = []
+                                          , gaAlternatives = []
+                                          }
+                                      ],
+                                      [
+                                        GeneratedArgument
+                                          { gaType = "pure-token"
+                                          , gaName = "replica"
+                                          , gaToken = Just "replica"
+                                          , gaOptional = False
+                                          , gaMultiple = False
+                                          , gaKeySpecIndex = Nothing
+                                          , gaChildren = []
+                                          , gaAlternatives = []
+                                          }
+                                      ],
+                                      [
+                                        GeneratedArgument
+                                          { gaType = "pure-token"
+                                          , gaName = "pubsub"
+                                          , gaToken = Just "pubsub"
+                                          , gaOptional = False
+                                          , gaMultiple = False
+                                          , gaKeySpecIndex = Nothing
+                                          , gaChildren = []
+                                          , gaAlternatives = []
+                                          }
+                                      ]
+                                    ]
+                                }
+                            ],
+                            [
+                              GeneratedArgument
+                                { gaType = "string"
+                                , gaName = "username"
+                                , gaToken = Just "USER"
+                                , gaOptional = True
+                                , gaMultiple = False
+                                , gaKeySpecIndex = Nothing
+                                , gaChildren = []
+                                , gaAlternatives = []
+                                }
+                            ],
+                            [
+                              GeneratedArgument
+                                { gaType = "string"
+                                , gaName = "addr"
+                                , gaToken = Just "ADDR"
+                                , gaOptional = True
+                                , gaMultiple = False
+                                , gaKeySpecIndex = Nothing
+                                , gaChildren = []
+                                , gaAlternatives = []
+                                }
+                            ],
+                            [
+                              GeneratedArgument
+                                { gaType = "string"
+                                , gaName = "laddr"
+                                , gaToken = Just "LADDR"
+                                , gaOptional = True
+                                , gaMultiple = False
+                                , gaKeySpecIndex = Nothing
+                                , gaChildren = []
+                                , gaAlternatives = []
+                                }
+                            ],
+                            [
+                              GeneratedArgument
+                                { gaType = "oneof"
+                                , gaName = "skipme"
+                                , gaToken = Just "SKIPME"
+                                , gaOptional = True
+                                , gaMultiple = False
+                                , gaKeySpecIndex = Nothing
+                                , gaChildren = []
+                                , gaAlternatives =
+                                    [
+                                      [
+                                        GeneratedArgument
+                                          { gaType = "pure-token"
+                                          , gaName = "yes"
+                                          , gaToken = Just "YES"
+                                          , gaOptional = False
+                                          , gaMultiple = False
+                                          , gaKeySpecIndex = Nothing
+                                          , gaChildren = []
+                                          , gaAlternatives = []
+                                          }
+                                      ],
+                                      [
+                                        GeneratedArgument
+                                          { gaType = "pure-token"
+                                          , gaName = "no"
+                                          , gaToken = Just "NO"
+                                          , gaOptional = False
+                                          , gaMultiple = False
+                                          , gaKeySpecIndex = Nothing
+                                          , gaChildren = []
+                                          , gaAlternatives = []
+                                          }
+                                      ]
+                                    ]
+                                }
+                            ]
+                          ]
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "LIST"]
+    , gcsArity = -2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "client-type"
+            , gaToken = Just "TYPE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "normal"
+                      , gaToken = Just "normal"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "master"
+                      , gaToken = Just "master"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "replica"
+                      , gaToken = Just "replica"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "pubsub"
+                      , gaToken = Just "pubsub"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "client-id"
+            , gaToken = Just "ID"
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "NO-EVICT"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "enabled"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "on"
+                      , gaToken = Just "ON"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "off"
+                      , gaToken = Just "OFF"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "NO-TOUCH"]
+    , gcsArity = 3
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "enabled"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "on"
+                      , gaToken = Just "ON"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "off"
+                      , gaToken = Just "OFF"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "PAUSE"]
+    , gcsArity = -3
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "timeout"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "mode"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "write"
+                      , gaToken = Just "WRITE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "all"
+                      , gaToken = Just "ALL"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "REPLY"]
+    , gcsArity = 3
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "action"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "on"
+                      , gaToken = Just "ON"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "off"
+                      , gaToken = Just "OFF"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "skip"
+                      , gaToken = Just "SKIP"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "SETINFO"]
+    , gcsArity = 4
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "attr"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "libname"
+                      , gaToken = Just "lib-name"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "libver"
+                      , gaToken = Just "lib-ver"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "SETNAME"]
+    , gcsArity = 3
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "connection-name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "TRACKING"]
+    , gcsArity = -3
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "status"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "on"
+                      , gaToken = Just "ON"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "off"
+                      , gaToken = Just "OFF"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "client-id"
+            , gaToken = Just "REDIRECT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "prefix"
+            , gaToken = Just "PREFIX"
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "BCAST"
+            , gaToken = Just "BCAST"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "OPTIN"
+            , gaToken = Just "OPTIN"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "OPTOUT"
+            , gaToken = Just "OPTOUT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "NOLOOP"
+            , gaToken = Just "NOLOOP"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "TRACKINGINFO"]
+    , gcsArity = 2
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "UNBLOCK"]
+    , gcsArity = -3
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "client-id"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "unblock-type"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "timeout"
+                      , gaToken = Just "TIMEOUT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "error"
+                      , gaToken = Just "ERROR"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLIENT", "UNPAUSE"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER"]
+    , gcsArity = -2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "ADDSLOTS"]
+    , gcsArity = -3
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "slot"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "ADDSLOTSRANGE"]
+    , gcsArity = -4
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "range"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "start-slot"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "end-slot"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "BUMPEPOCH"]
+    , gcsArity = 2
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "COUNT-FAILURE-REPORTS"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "node-id"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "COUNTKEYSINSLOT"]
+    , gcsArity = 3
+    , gcsFlags = ["STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "slot"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "DELSLOTS"]
+    , gcsArity = -3
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "slot"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "DELSLOTSRANGE"]
+    , gcsArity = -4
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "range"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "start-slot"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "end-slot"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "FAILOVER"]
+    , gcsArity = -2
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "options"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "force"
+                      , gaToken = Just "FORCE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "takeover"
+                      , gaToken = Just "TAKEOVER"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "FLUSHSLOTS"]
+    , gcsArity = 2
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "FORGET"]
+    , gcsArity = 3
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "node-id"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "GETKEYSINSLOT"]
+    , gcsArity = 4
+    , gcsFlags = ["STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "slot"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "INFO"]
+    , gcsArity = 2
+    , gcsFlags = ["STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "KEYSLOT"]
+    , gcsArity = 3
+    , gcsFlags = ["STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "LINKS"]
+    , gcsArity = 2
+    , gcsFlags = ["STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "MEET"]
+    , gcsArity = -4
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "ip"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "port"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "cluster-bus-port"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "MYID"]
+    , gcsArity = 2
+    , gcsFlags = ["STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "MYSHARDID"]
+    , gcsArity = 2
+    , gcsFlags = ["STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "NODES"]
+    , gcsArity = 2
+    , gcsFlags = ["STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "REPLICAS"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "node-id"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "REPLICATE"]
+    , gcsArity = 3
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "node-id"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "RESET"]
+    , gcsArity = -2
+    , gcsFlags = ["ADMIN", "STALE", "NOSCRIPT"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "reset-type"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "hard"
+                      , gaToken = Just "HARD"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "soft"
+                      , gaToken = Just "SOFT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "SAVECONFIG"]
+    , gcsArity = 2
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "SET-CONFIG-EPOCH"]
+    , gcsArity = 3
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "config-epoch"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "SETSLOT"]
+    , gcsArity = -4
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "slot"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "subcommand"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "importing"
+                      , gaToken = Just "IMPORTING"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "migrating"
+                      , gaToken = Just "MIGRATING"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "node"
+                      , gaToken = Just "NODE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "stable"
+                      , gaToken = Just "STABLE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "SHARDS"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "SLAVES"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "node-id"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CLUSTER", "SLOTS"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["COMMAND"]
+    , gcsArity = -1
+    , gcsFlags = ["LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["COMMAND", "COUNT"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["COMMAND", "DOCS"]
+    , gcsArity = -2
+    , gcsFlags = ["LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "command-name"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["COMMAND", "GETKEYS"]
+    , gcsArity = -3
+    , gcsFlags = ["LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "command"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "arg"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["COMMAND", "GETKEYSANDFLAGS"]
+    , gcsArity = -3
+    , gcsFlags = ["LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "command"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "arg"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["COMMAND", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["COMMAND", "INFO"]
+    , gcsArity = -2
+    , gcsFlags = ["LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "command-name"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["COMMAND", "LIST"]
+    , gcsArity = -2
+    , gcsFlags = ["LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "filterby"
+            , gaToken = Just "FILTERBY"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "module-name"
+                      , gaToken = Just "MODULE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "category"
+                      , gaToken = Just "ACLCAT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pattern"
+                      , gaName = "pattern"
+                      , gaToken = Just "PATTERN"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CONFIG"]
+    , gcsArity = -2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CONFIG", "GET"]
+    , gcsArity = -3
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "parameter"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CONFIG", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CONFIG", "RESETSTAT"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CONFIG", "REWRITE"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["CONFIG", "SET"]
+    , gcsArity = -4
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "data"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "parameter"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "value"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["COPY"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "source"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "destination-db"
+            , gaToken = Just "DB"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "replace"
+            , gaToken = Just "REPLACE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["DBSIZE"]
+    , gcsArity = 1
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["DEBUG"]
+    , gcsArity = -2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "PROTECTED"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["DECR"]
+    , gcsArity = 2
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["DECRBY"]
+    , gcsArity = 3
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "decrement"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["DEL"]
+    , gcsArity = -2
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["DISCARD"]
+    , gcsArity = 1
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "FAST", "ALLOW_BUSY"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["DUMP"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ECHO"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "message"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["EVAL"]
+    , gcsArity = -3
+    , gcsFlags = ["NOSCRIPT", "SKIP_MONITOR", "MAY_REPLICATE", "NO_MANDATORY_KEYS", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "script"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "arg"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["EVALSHA"]
+    , gcsArity = -3
+    , gcsFlags = ["NOSCRIPT", "SKIP_MONITOR", "MAY_REPLICATE", "NO_MANDATORY_KEYS", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "sha1"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "arg"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["EVALSHA_RO"]
+    , gcsArity = -3
+    , gcsFlags = ["NOSCRIPT", "SKIP_MONITOR", "NO_MANDATORY_KEYS", "STALE", "READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "sha1"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "arg"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["EVAL_RO"]
+    , gcsArity = -3
+    , gcsFlags = ["NOSCRIPT", "SKIP_MONITOR", "NO_MANDATORY_KEYS", "STALE", "READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "script"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "arg"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["EXEC"]
+    , gcsArity = 1
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "SKIP_SLOWLOG"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["EXISTS"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["EXPIRE"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "seconds"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "condition"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "nx"
+                      , gaToken = Just "NX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "xx"
+                      , gaToken = Just "XX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "gt"
+                      , gaToken = Just "GT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "lt"
+                      , gaToken = Just "LT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["EXPIREAT"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "unix-time"
+            , gaName = "unix-time-seconds"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "condition"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "nx"
+                      , gaToken = Just "NX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "xx"
+                      , gaToken = Just "XX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "gt"
+                      , gaToken = Just "GT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "lt"
+                      , gaToken = Just "LT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["EXPIRETIME"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FAILOVER"]
+    , gcsArity = -1
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "target"
+            , gaToken = Just "TO"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "host"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "port"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "pure-token"
+                    , gaName = "force"
+                    , gaToken = Just "FORCE"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "abort"
+            , gaToken = Just "ABORT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "milliseconds"
+            , gaToken = Just "TIMEOUT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FCALL"]
+    , gcsArity = -3
+    , gcsFlags = ["NOSCRIPT", "SKIP_MONITOR", "MAY_REPLICATE", "NO_MANDATORY_KEYS", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "function"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "arg"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FCALL_RO"]
+    , gcsArity = -3
+    , gcsFlags = ["NOSCRIPT", "SKIP_MONITOR", "NO_MANDATORY_KEYS", "STALE", "READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "function"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "arg"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FLUSHALL"]
+    , gcsArity = -1
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "flush-type"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "async"
+                      , gaToken = Just "ASYNC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "sync"
+                      , gaToken = Just "SYNC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FLUSHDB"]
+    , gcsArity = -1
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "flush-type"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "async"
+                      , gaToken = Just "ASYNC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "sync"
+                      , gaToken = Just "SYNC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FUNCTION"]
+    , gcsArity = -2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FUNCTION", "DELETE"]
+    , gcsArity = 3
+    , gcsFlags = ["NOSCRIPT", "WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "library-name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FUNCTION", "DUMP"]
+    , gcsArity = 2
+    , gcsFlags = ["NOSCRIPT"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FUNCTION", "FLUSH"]
+    , gcsArity = -2
+    , gcsFlags = ["NOSCRIPT", "WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "flush-type"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "async"
+                      , gaToken = Just "ASYNC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "sync"
+                      , gaToken = Just "SYNC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FUNCTION", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FUNCTION", "KILL"]
+    , gcsArity = 2
+    , gcsFlags = ["NOSCRIPT", "ALLOW_BUSY"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FUNCTION", "LIST"]
+    , gcsArity = -2
+    , gcsFlags = ["NOSCRIPT"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "library-name-pattern"
+            , gaToken = Just "LIBRARYNAME"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withcode"
+            , gaToken = Just "WITHCODE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FUNCTION", "LOAD"]
+    , gcsArity = -3
+    , gcsFlags = ["NOSCRIPT", "WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "replace"
+            , gaToken = Just "REPLACE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "function-code"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FUNCTION", "RESTORE"]
+    , gcsArity = -3
+    , gcsFlags = ["NOSCRIPT", "WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "serialized-value"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "policy"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "flush"
+                      , gaToken = Just "FLUSH"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "append"
+                      , gaToken = Just "APPEND"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "replace"
+                      , gaToken = Just "REPLACE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["FUNCTION", "STATS"]
+    , gcsArity = 2
+    , gcsFlags = ["NOSCRIPT", "ALLOW_BUSY"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GEOADD"]
+    , gcsArity = -5
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "condition"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "nx"
+                      , gaToken = Just "NX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "xx"
+                      , gaToken = Just "XX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "change"
+            , gaToken = Just "CH"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "data"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "double"
+                    , gaName = "longitude"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "double"
+                    , gaName = "latitude"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "member"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GEODIST"]
+    , gcsArity = -4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member1"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member2"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "unit"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "m"
+                      , gaToken = Just "m"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "km"
+                      , gaToken = Just "km"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "ft"
+                      , gaToken = Just "ft"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "mi"
+                      , gaToken = Just "mi"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GEOHASH"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GEOPOS"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GEORADIUS"]
+    , gcsArity = -6
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "longitude"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "latitude"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "radius"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "unit"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "m"
+                      , gaToken = Just "m"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "km"
+                      , gaToken = Just "km"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "ft"
+                      , gaToken = Just "ft"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "mi"
+                      , gaToken = Just "mi"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withcoord"
+            , gaToken = Just "WITHCOORD"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withdist"
+            , gaToken = Just "WITHDIST"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withhash"
+            , gaToken = Just "WITHHASH"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "count-block"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Just "COUNT"
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "pure-token"
+                    , gaName = "any"
+                    , gaToken = Just "ANY"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "order"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "asc"
+                      , gaToken = Just "ASC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "desc"
+                      , gaToken = Just "DESC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "store"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "key"
+                      , gaName = "storekey"
+                      , gaToken = Just "STORE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Just 1
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "key"
+                      , gaName = "storedistkey"
+                      , gaToken = Just "STOREDIST"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Just 2
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GEORADIUSBYMEMBER"]
+    , gcsArity = -5
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "radius"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "unit"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "m"
+                      , gaToken = Just "m"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "km"
+                      , gaToken = Just "km"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "ft"
+                      , gaToken = Just "ft"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "mi"
+                      , gaToken = Just "mi"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withcoord"
+            , gaToken = Just "WITHCOORD"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withdist"
+            , gaToken = Just "WITHDIST"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withhash"
+            , gaToken = Just "WITHHASH"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "count-block"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Just "COUNT"
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "pure-token"
+                    , gaName = "any"
+                    , gaToken = Just "ANY"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "order"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "asc"
+                      , gaToken = Just "ASC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "desc"
+                      , gaToken = Just "DESC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "store"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "key"
+                      , gaName = "storekey"
+                      , gaToken = Just "STORE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Just 1
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "key"
+                      , gaName = "storedistkey"
+                      , gaToken = Just "STOREDIST"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Just 2
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GEORADIUSBYMEMBER_RO"]
+    , gcsArity = -5
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "radius"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "unit"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "m"
+                      , gaToken = Just "m"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "km"
+                      , gaToken = Just "km"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "ft"
+                      , gaToken = Just "ft"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "mi"
+                      , gaToken = Just "mi"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withcoord"
+            , gaToken = Just "WITHCOORD"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withdist"
+            , gaToken = Just "WITHDIST"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withhash"
+            , gaToken = Just "WITHHASH"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "count-block"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Just "COUNT"
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "pure-token"
+                    , gaName = "any"
+                    , gaToken = Just "ANY"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "order"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "asc"
+                      , gaToken = Just "ASC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "desc"
+                      , gaToken = Just "DESC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GEORADIUS_RO"]
+    , gcsArity = -6
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "longitude"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "latitude"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "radius"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "unit"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "m"
+                      , gaToken = Just "m"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "km"
+                      , gaToken = Just "km"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "ft"
+                      , gaToken = Just "ft"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "mi"
+                      , gaToken = Just "mi"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withcoord"
+            , gaToken = Just "WITHCOORD"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withdist"
+            , gaToken = Just "WITHDIST"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withhash"
+            , gaToken = Just "WITHHASH"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "count-block"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Just "COUNT"
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "pure-token"
+                    , gaName = "any"
+                    , gaToken = Just "ANY"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "order"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "asc"
+                      , gaToken = Just "ASC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "desc"
+                      , gaToken = Just "DESC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GEOSEARCH"]
+    , gcsArity = -7
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "from"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "member"
+                      , gaToken = Just "FROMMEMBER"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "fromlonlat"
+                      , gaToken = Just "FROMLONLAT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "double"
+                              , gaName = "longitude"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "double"
+                              , gaName = "latitude"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "by"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "circle"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "double"
+                              , gaName = "radius"
+                              , gaToken = Just "BYRADIUS"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "oneof"
+                              , gaName = "unit"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives =
+                                  [
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "m"
+                                        , gaToken = Just "m"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "km"
+                                        , gaToken = Just "km"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "ft"
+                                        , gaToken = Just "ft"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "mi"
+                                        , gaToken = Just "mi"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ]
+                                  ]
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "box"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "double"
+                              , gaName = "width"
+                              , gaToken = Just "BYBOX"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "double"
+                              , gaName = "height"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "oneof"
+                              , gaName = "unit"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives =
+                                  [
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "m"
+                                        , gaToken = Just "m"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "km"
+                                        , gaToken = Just "km"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "ft"
+                                        , gaToken = Just "ft"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "mi"
+                                        , gaToken = Just "mi"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ]
+                                  ]
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "order"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "asc"
+                      , gaToken = Just "ASC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "desc"
+                      , gaToken = Just "DESC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "count-block"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Just "COUNT"
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "pure-token"
+                    , gaName = "any"
+                    , gaToken = Just "ANY"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withcoord"
+            , gaToken = Just "WITHCOORD"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withdist"
+            , gaToken = Just "WITHDIST"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withhash"
+            , gaToken = Just "WITHHASH"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GEOSEARCHSTORE"]
+    , gcsArity = -8
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "source"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "from"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "member"
+                      , gaToken = Just "FROMMEMBER"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "fromlonlat"
+                      , gaToken = Just "FROMLONLAT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "double"
+                              , gaName = "longitude"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "double"
+                              , gaName = "latitude"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "by"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "circle"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "double"
+                              , gaName = "radius"
+                              , gaToken = Just "BYRADIUS"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "oneof"
+                              , gaName = "unit"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives =
+                                  [
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "m"
+                                        , gaToken = Just "m"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "km"
+                                        , gaToken = Just "km"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "ft"
+                                        , gaToken = Just "ft"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "mi"
+                                        , gaToken = Just "mi"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ]
+                                  ]
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "box"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "double"
+                              , gaName = "width"
+                              , gaToken = Just "BYBOX"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "double"
+                              , gaName = "height"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "oneof"
+                              , gaName = "unit"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives =
+                                  [
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "m"
+                                        , gaToken = Just "m"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "km"
+                                        , gaToken = Just "km"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "ft"
+                                        , gaToken = Just "ft"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ],
+                                    [
+                                      GeneratedArgument
+                                        { gaType = "pure-token"
+                                        , gaName = "mi"
+                                        , gaToken = Just "mi"
+                                        , gaOptional = False
+                                        , gaMultiple = False
+                                        , gaKeySpecIndex = Nothing
+                                        , gaChildren = []
+                                        , gaAlternatives = []
+                                        }
+                                    ]
+                                  ]
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "order"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "asc"
+                      , gaToken = Just "ASC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "desc"
+                      , gaToken = Just "DESC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "count-block"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Just "COUNT"
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "pure-token"
+                    , gaName = "any"
+                    , gaToken = Just "ANY"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "storedist"
+            , gaToken = Just "STOREDIST"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GET"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GETBIT"]
+    , gcsArity = 3
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "offset"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GETDEL"]
+    , gcsArity = 2
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GETEX"]
+    , gcsArity = -2
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "expiration"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "integer"
+                      , gaName = "seconds"
+                      , gaToken = Just "EX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "integer"
+                      , gaName = "milliseconds"
+                      , gaToken = Just "PX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "unix-time"
+                      , gaName = "unix-time-seconds"
+                      , gaToken = Just "EXAT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "unix-time"
+                      , gaName = "unix-time-milliseconds"
+                      , gaToken = Just "PXAT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "persist"
+                      , gaToken = Just "PERSIST"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GETRANGE"]
+    , gcsArity = 4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "start"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "end"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["GETSET"]
+    , gcsArity = 3
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "value"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HDEL"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "field"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HELLO"]
+    , gcsArity = -1
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "FAST", "NO_AUTH", "SENTINEL", "ALLOW_BUSY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "arguments"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "protover"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "block"
+                    , gaName = "auth"
+                    , gaToken = Just "AUTH"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren =
+                        [
+                          GeneratedArgument
+                            { gaType = "string"
+                            , gaName = "username"
+                            , gaToken = Nothing
+                            , gaOptional = False
+                            , gaMultiple = False
+                            , gaKeySpecIndex = Nothing
+                            , gaChildren = []
+                            , gaAlternatives = []
+                            },
+                          GeneratedArgument
+                            { gaType = "string"
+                            , gaName = "password"
+                            , gaToken = Nothing
+                            , gaOptional = False
+                            , gaMultiple = False
+                            , gaKeySpecIndex = Nothing
+                            , gaChildren = []
+                            , gaAlternatives = []
+                            }
+                        ]
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "clientname"
+                    , gaToken = Just "SETNAME"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HEXISTS"]
+    , gcsArity = 3
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "field"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HGET"]
+    , gcsArity = 3
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "field"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HGETALL"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HINCRBY"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "field"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "increment"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HINCRBYFLOAT"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "field"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "increment"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HKEYS"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HLEN"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HMGET"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "field"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HMSET"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "data"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "field"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "value"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HRANDFIELD"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "options"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "pure-token"
+                    , gaName = "withvalues"
+                    , gaToken = Just "WITHVALUES"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HSCAN"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "cursor"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "pattern"
+            , gaToken = Just "MATCH"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HSET"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "data"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "field"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "value"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HSETNX"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "field"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "value"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HSTRLEN"]
+    , gcsArity = 3
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "field"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["HVALS"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["INCR"]
+    , gcsArity = 2
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["INCRBY"]
+    , gcsArity = 3
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "increment"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["INCRBYFLOAT"]
+    , gcsArity = 3
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "increment"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["INFO"]
+    , gcsArity = -1
+    , gcsFlags = ["LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "section"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["KEYS"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "pattern"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LASTSAVE"]
+    , gcsArity = 1
+    , gcsFlags = ["LOADING", "STALE", "FAST"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LATENCY"]
+    , gcsArity = -2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LATENCY", "DOCTOR"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LATENCY", "GRAPH"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "event"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LATENCY", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LATENCY", "HISTOGRAM"]
+    , gcsArity = -2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "COMMAND"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LATENCY", "HISTORY"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "event"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LATENCY", "LATEST"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LATENCY", "RESET"]
+    , gcsArity = -2
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "event"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LCS"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key1"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key2"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "len"
+            , gaToken = Just "LEN"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "idx"
+            , gaToken = Just "IDX"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "min-match-len"
+            , gaToken = Just "MINMATCHLEN"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withmatchlen"
+            , gaToken = Just "WITHMATCHLEN"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LINDEX"]
+    , gcsArity = 3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "index"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LINSERT"]
+    , gcsArity = 5
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "where"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "before"
+                      , gaToken = Just "BEFORE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "after"
+                      , gaToken = Just "AFTER"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "pivot"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "element"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LLEN"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LMOVE"]
+    , gcsArity = 5
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "source"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "wherefrom"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "left"
+                      , gaToken = Just "LEFT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "right"
+                      , gaToken = Just "RIGHT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "whereto"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "left"
+                      , gaToken = Just "LEFT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "right"
+                      , gaToken = Just "RIGHT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LMPOP"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "where"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "left"
+                      , gaToken = Just "LEFT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "right"
+                      , gaToken = Just "RIGHT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LOLWUT"]
+    , gcsArity = -1
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "version"
+            , gaToken = Just "VERSION"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LPOP"]
+    , gcsArity = -2
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LPOS"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "element"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "rank"
+            , gaToken = Just "RANK"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "num-matches"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "len"
+            , gaToken = Just "MAXLEN"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LPUSH"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "element"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LPUSHX"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "element"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LRANGE"]
+    , gcsArity = 4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "start"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "stop"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LREM"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "element"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LSET"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "index"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "element"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["LTRIM"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "start"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "stop"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MEMORY"]
+    , gcsArity = -2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MEMORY", "DOCTOR"]
+    , gcsArity = 2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MEMORY", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MEMORY", "MALLOC-STATS"]
+    , gcsArity = 2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MEMORY", "PURGE"]
+    , gcsArity = 2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MEMORY", "STATS"]
+    , gcsArity = 2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MEMORY", "USAGE"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "SAMPLES"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MGET"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MIGRATE"]
+    , gcsArity = -6
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "host"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "port"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "key-selector"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "key"
+                      , gaName = "key"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Just 0
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "empty-string"
+                      , gaToken = Just "\"\""
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "destination-db"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "timeout"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "copy"
+            , gaToken = Just "COPY"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "replace"
+            , gaToken = Just "REPLACE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "authentication"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "auth"
+                      , gaToken = Just "AUTH"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "auth2"
+                      , gaToken = Just "AUTH2"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "string"
+                              , gaName = "username"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "string"
+                              , gaName = "password"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "keys"
+            , gaToken = Just "KEYS"
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MODULE"]
+    , gcsArity = -2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MODULE", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MODULE", "LIST"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "NOSCRIPT"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MODULE", "LOAD"]
+    , gcsArity = -3
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "NOSCRIPT", "PROTECTED"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "path"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "arg"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MODULE", "LOADEX"]
+    , gcsArity = -3
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "NOSCRIPT", "PROTECTED"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "path"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "configs"
+            , gaToken = Just "CONFIG"
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "name"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "value"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "args"
+            , gaToken = Just "ARGS"
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MODULE", "UNLOAD"]
+    , gcsArity = 3
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "NOSCRIPT", "PROTECTED"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MONITOR"]
+    , gcsArity = 1
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MOVE"]
+    , gcsArity = 3
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "db"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MSET"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "data"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "key"
+                    , gaName = "key"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Just 0
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "value"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MSETNX"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "data"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "key"
+                    , gaName = "key"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Just 0
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "value"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["MULTI"]
+    , gcsArity = 1
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "FAST", "ALLOW_BUSY"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["OBJECT"]
+    , gcsArity = -2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["OBJECT", "ENCODING"]
+    , gcsArity = 3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["OBJECT", "FREQ"]
+    , gcsArity = 3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["OBJECT", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["OBJECT", "IDLETIME"]
+    , gcsArity = 3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["OBJECT", "REFCOUNT"]
+    , gcsArity = 3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PERSIST"]
+    , gcsArity = 2
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PEXPIRE"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "milliseconds"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "condition"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "nx"
+                      , gaToken = Just "NX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "xx"
+                      , gaToken = Just "XX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "gt"
+                      , gaToken = Just "GT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "lt"
+                      , gaToken = Just "LT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PEXPIREAT"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "unix-time"
+            , gaName = "unix-time-milliseconds"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "condition"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "nx"
+                      , gaToken = Just "NX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "xx"
+                      , gaToken = Just "XX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "gt"
+                      , gaToken = Just "GT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "lt"
+                      , gaToken = Just "LT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PEXPIRETIME"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PFADD"]
+    , gcsArity = -2
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "element"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PFCOUNT"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY", "MAY_REPLICATE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PFDEBUG"]
+    , gcsArity = 3
+    , gcsFlags = ["WRITE", "DENYOOM", "ADMIN"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "subcommand"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PFMERGE"]
+    , gcsArity = -2
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destkey"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "sourcekey"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PFSELFTEST"]
+    , gcsArity = 1
+    , gcsFlags = ["ADMIN"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PING"]
+    , gcsArity = -1
+    , gcsFlags = ["FAST", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "message"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PSETEX"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "milliseconds"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "value"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PSUBSCRIBE"]
+    , gcsArity = -2
+    , gcsFlags = ["PUBSUB", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "pattern"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PSYNC"]
+    , gcsArity = -3
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "NO_MULTI", "NOSCRIPT"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "replicationid"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "offset"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PTTL"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PUBLISH"]
+    , gcsArity = 3
+    , gcsFlags = ["PUBSUB", "LOADING", "STALE", "FAST", "MAY_REPLICATE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "channel"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "message"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PUBSUB"]
+    , gcsArity = -2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PUBSUB", "CHANNELS"]
+    , gcsArity = -2
+    , gcsFlags = ["PUBSUB", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "pattern"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PUBSUB", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PUBSUB", "NUMPAT"]
+    , gcsArity = 2
+    , gcsFlags = ["PUBSUB", "LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PUBSUB", "NUMSUB"]
+    , gcsArity = -2
+    , gcsFlags = ["PUBSUB", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "channel"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PUBSUB", "SHARDCHANNELS"]
+    , gcsArity = -2
+    , gcsFlags = ["PUBSUB", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "pattern"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PUBSUB", "SHARDNUMSUB"]
+    , gcsArity = -2
+    , gcsFlags = ["PUBSUB", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "shardchannel"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["PUNSUBSCRIBE"]
+    , gcsArity = -1
+    , gcsFlags = ["PUBSUB", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "pattern"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["QUIT"]
+    , gcsArity = -1
+    , gcsFlags = ["ALLOW_BUSY", "NOSCRIPT", "LOADING", "STALE", "FAST", "NO_AUTH"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["RANDOMKEY"]
+    , gcsArity = 1
+    , gcsFlags = ["READONLY", "TOUCHES_ARBITRARY_KEYS"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["READONLY"]
+    , gcsArity = 1
+    , gcsFlags = ["FAST", "LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["READWRITE"]
+    , gcsArity = 1
+    , gcsFlags = ["FAST", "LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["RENAME"]
+    , gcsArity = 3
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "newkey"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["RENAMENX"]
+    , gcsArity = 3
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "newkey"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["REPLCONF"]
+    , gcsArity = -1
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "ALLOW_BUSY"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["REPLICAOF"]
+    , gcsArity = 3
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "NOSCRIPT", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "args"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "host-port"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "string"
+                              , gaName = "host"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "integer"
+                              , gaName = "port"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "no-one"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "no"
+                              , gaToken = Just "NO"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "one"
+                              , gaToken = Just "ONE"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["RESET"]
+    , gcsArity = 1
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "FAST", "NO_AUTH", "ALLOW_BUSY"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["RESTORE"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "ttl"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "serialized-value"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "replace"
+            , gaToken = Just "REPLACE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "absttl"
+            , gaToken = Just "ABSTTL"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "seconds"
+            , gaToken = Just "IDLETIME"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "frequency"
+            , gaToken = Just "FREQ"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["RESTORE-ASKING"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE", "DENYOOM", "ASKING"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "ttl"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "serialized-value"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "replace"
+            , gaToken = Just "REPLACE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "absttl"
+            , gaToken = Just "ABSTTL"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "seconds"
+            , gaToken = Just "IDLETIME"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "frequency"
+            , gaToken = Just "FREQ"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ROLE"]
+    , gcsArity = 1
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "FAST", "SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["RPOP"]
+    , gcsArity = -2
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["RPOPLPUSH"]
+    , gcsArity = 3
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "source"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["RPUSH"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "element"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["RPUSHX"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "element"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SADD"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SAVE"]
+    , gcsArity = 1
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "NOSCRIPT", "NO_MULTI"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SCAN"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY", "TOUCHES_ARBITRARY_KEYS"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "cursor"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "pattern"
+            , gaToken = Just "MATCH"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "type"
+            , gaToken = Just "TYPE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SCARD"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SCRIPT"]
+    , gcsArity = -2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SCRIPT", "DEBUG"]
+    , gcsArity = 3
+    , gcsFlags = ["NOSCRIPT"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "mode"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "yes"
+                      , gaToken = Just "YES"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "sync"
+                      , gaToken = Just "SYNC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "no"
+                      , gaToken = Just "NO"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SCRIPT", "EXISTS"]
+    , gcsArity = -3
+    , gcsFlags = ["NOSCRIPT"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "sha1"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SCRIPT", "FLUSH"]
+    , gcsArity = -2
+    , gcsFlags = ["NOSCRIPT"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "flush-type"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "async"
+                      , gaToken = Just "ASYNC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "sync"
+                      , gaToken = Just "SYNC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SCRIPT", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SCRIPT", "KILL"]
+    , gcsArity = 2
+    , gcsFlags = ["NOSCRIPT", "ALLOW_BUSY"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SCRIPT", "LOAD"]
+    , gcsArity = 3
+    , gcsFlags = ["NOSCRIPT", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "script"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SDIFF"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SDIFFSTORE"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SELECT"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "index"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL"]
+    , gcsArity = -2
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "CKQUORUM"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "master-name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "CONFIG"]
+    , gcsArity = -4
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "action"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "set"
+                      , gaToken = Just "SET"
+                      , gaOptional = False
+                      , gaMultiple = True
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "string"
+                              , gaName = "parameter"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "string"
+                              , gaName = "value"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "parameter"
+                      , gaToken = Just "GET"
+                      , gaOptional = False
+                      , gaMultiple = True
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "DEBUG"]
+    , gcsArity = -2
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "data"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "parameter"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "value"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "FAILOVER"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "master-name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "FLUSHCONFIG"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "GET-MASTER-ADDR-BY-NAME"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "master-name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "INFO-CACHE"]
+    , gcsArity = -3
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "nodename"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "IS-MASTER-DOWN-BY-ADDR"]
+    , gcsArity = 6
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "ip"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "port"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "current-epoch"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "runid"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "MASTER"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "master-name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "MASTERS"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "MONITOR"]
+    , gcsArity = 6
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "ip"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "port"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "quorum"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "MYID"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "PENDING-SCRIPTS"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "REMOVE"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "master-name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "REPLICAS"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "master-name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "RESET"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "pattern"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "SENTINELS"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "master-name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "SET"]
+    , gcsArity = -5
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "master-name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "data"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "option"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "value"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "SIMULATE-FAILURE"]
+    , gcsArity = -3
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "mode"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "crash-after-election"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "crash-after-promotion"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "help"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SENTINEL", "SLAVES"]
+    , gcsArity = 3
+    , gcsFlags = ["ADMIN", "SENTINEL", "ONLY_SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "master-name"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SET"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "value"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "condition"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "nx"
+                      , gaToken = Just "NX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "xx"
+                      , gaToken = Just "XX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "get"
+            , gaToken = Just "GET"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "expiration"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "integer"
+                      , gaName = "seconds"
+                      , gaToken = Just "EX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "integer"
+                      , gaName = "milliseconds"
+                      , gaToken = Just "PX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "unix-time"
+                      , gaName = "unix-time-seconds"
+                      , gaToken = Just "EXAT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "unix-time"
+                      , gaName = "unix-time-milliseconds"
+                      , gaToken = Just "PXAT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "keepttl"
+                      , gaToken = Just "KEEPTTL"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SETBIT"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "offset"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "value"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SETEX"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "seconds"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "value"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SETNX"]
+    , gcsArity = 3
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "value"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SETRANGE"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "offset"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "value"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SHUTDOWN"]
+    , gcsArity = -1
+    , gcsFlags = ["ADMIN", "NOSCRIPT", "LOADING", "STALE", "NO_MULTI", "SENTINEL", "ALLOW_BUSY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "save-selector"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "nosave"
+                      , gaToken = Just "NOSAVE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "save"
+                      , gaToken = Just "SAVE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "now"
+            , gaToken = Just "NOW"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "force"
+            , gaToken = Just "FORCE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "abort"
+            , gaToken = Just "ABORT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SINTER"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SINTERCARD"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "limit"
+            , gaToken = Just "LIMIT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SINTERSTORE"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SISMEMBER"]
+    , gcsArity = 3
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SLAVEOF"]
+    , gcsArity = 3
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "NOSCRIPT", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "args"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "host-port"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "string"
+                              , gaName = "host"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "integer"
+                              , gaName = "port"
+                              , gaToken = Nothing
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "block"
+                      , gaName = "no-one"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren =
+                          [
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "no"
+                              , gaToken = Just "NO"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              },
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "one"
+                              , gaToken = Just "ONE"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SLOWLOG"]
+    , gcsArity = -2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SLOWLOG", "GET"]
+    , gcsArity = -2
+    , gcsFlags = ["ADMIN", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SLOWLOG", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SLOWLOG", "LEN"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SLOWLOG", "RESET"]
+    , gcsArity = 2
+    , gcsFlags = ["ADMIN", "LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SMEMBERS"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SMISMEMBER"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SMOVE"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "source"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SORT"]
+    , gcsArity = -2
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "by-pattern"
+            , gaToken = Just "BY"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "limit"
+            , gaToken = Just "LIMIT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "offset"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "get-pattern"
+            , gaToken = Just "GET"
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "order"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "asc"
+                      , gaToken = Just "ASC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "desc"
+                      , gaToken = Just "DESC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "sorting"
+            , gaToken = Just "ALPHA"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Just "STORE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 2
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SORT_RO"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "by-pattern"
+            , gaToken = Just "BY"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "limit"
+            , gaToken = Just "LIMIT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "offset"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "get-pattern"
+            , gaToken = Just "GET"
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "order"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "asc"
+                      , gaToken = Just "ASC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "desc"
+                      , gaToken = Just "DESC"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "sorting"
+            , gaToken = Just "ALPHA"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SPOP"]
+    , gcsArity = -2
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SPUBLISH"]
+    , gcsArity = 3
+    , gcsFlags = ["PUBSUB", "LOADING", "STALE", "FAST", "MAY_REPLICATE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "shardchannel"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "message"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SRANDMEMBER"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SREM"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SSCAN"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "cursor"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "pattern"
+            , gaToken = Just "MATCH"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SSUBSCRIBE"]
+    , gcsArity = -2
+    , gcsFlags = ["PUBSUB", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "shardchannel"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["STRLEN"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SUBSCRIBE"]
+    , gcsArity = -2
+    , gcsFlags = ["PUBSUB", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "channel"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SUBSTR"]
+    , gcsArity = 4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "start"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "end"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SUNION"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SUNIONSTORE"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SUNSUBSCRIBE"]
+    , gcsArity = -1
+    , gcsFlags = ["PUBSUB", "NOSCRIPT", "LOADING", "STALE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "shardchannel"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SWAPDB"]
+    , gcsArity = 3
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "index1"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "index2"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["SYNC"]
+    , gcsArity = 1
+    , gcsFlags = ["NO_ASYNC_LOADING", "ADMIN", "NO_MULTI", "NOSCRIPT"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["TIME"]
+    , gcsArity = 1
+    , gcsFlags = ["LOADING", "STALE", "FAST"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["TOUCH"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["TTL"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["TYPE"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["UNLINK"]
+    , gcsArity = -2
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["UNSUBSCRIBE"]
+    , gcsArity = -1
+    , gcsFlags = ["PUBSUB", "NOSCRIPT", "LOADING", "STALE", "SENTINEL"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "channel"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["UNWATCH"]
+    , gcsArity = 1
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "FAST", "ALLOW_BUSY"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["WAIT"]
+    , gcsArity = 3
+    , gcsFlags = []
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numreplicas"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "timeout"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["WAITAOF"]
+    , gcsArity = 4
+    , gcsFlags = ["NOSCRIPT"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numlocal"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numreplicas"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "timeout"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["WATCH"]
+    , gcsArity = -2
+    , gcsFlags = ["NOSCRIPT", "LOADING", "STALE", "FAST", "ALLOW_BUSY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XACK"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "group"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "ID"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XADD"]
+    , gcsArity = -5
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "nomkstream"
+            , gaToken = Just "NOMKSTREAM"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "trim"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "oneof"
+                    , gaName = "strategy"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives =
+                        [
+                          [
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "maxlen"
+                              , gaToken = Just "MAXLEN"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ],
+                          [
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "minid"
+                              , gaToken = Just "MINID"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                        ]
+                    },
+                  GeneratedArgument
+                    { gaType = "oneof"
+                    , gaName = "operator"
+                    , gaToken = Nothing
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives =
+                        [
+                          [
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "equal"
+                              , gaToken = Just "="
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ],
+                          [
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "approximately"
+                              , gaToken = Just "~"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                        ]
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "threshold"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Just "LIMIT"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "id-selector"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "auto-id"
+                      , gaToken = Just "*"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "id"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "data"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "field"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "value"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XAUTOCLAIM"]
+    , gcsArity = -6
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "group"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "consumer"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "min-idle-time"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "start"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "justid"
+            , gaToken = Just "JUSTID"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XCLAIM"]
+    , gcsArity = -6
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "group"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "consumer"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "min-idle-time"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "ID"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "ms"
+            , gaToken = Just "IDLE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "unix-time"
+            , gaName = "unix-time-milliseconds"
+            , gaToken = Just "TIME"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "RETRYCOUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "force"
+            , gaToken = Just "FORCE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "justid"
+            , gaToken = Just "JUSTID"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "lastid"
+            , gaToken = Just "LASTID"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XDEL"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "ID"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XGROUP"]
+    , gcsArity = -2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XGROUP", "CREATE"]
+    , gcsArity = -5
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "group"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "id-selector"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "id"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "new-id"
+                      , gaToken = Just "$"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "mkstream"
+            , gaToken = Just "MKSTREAM"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "entries-read"
+            , gaToken = Just "ENTRIESREAD"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XGROUP", "CREATECONSUMER"]
+    , gcsArity = 5
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "group"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "consumer"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XGROUP", "DELCONSUMER"]
+    , gcsArity = 5
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "group"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "consumer"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XGROUP", "DESTROY"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "group"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XGROUP", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XGROUP", "SETID"]
+    , gcsArity = -5
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "group"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "id-selector"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "string"
+                      , gaName = "id"
+                      , gaToken = Nothing
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "new-id"
+                      , gaToken = Just "$"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "entriesread"
+            , gaToken = Just "ENTRIESREAD"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XINFO"]
+    , gcsArity = -2
+    , gcsFlags = []
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XINFO", "CONSUMERS"]
+    , gcsArity = 4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "group"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XINFO", "GROUPS"]
+    , gcsArity = 3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XINFO", "HELP"]
+    , gcsArity = 2
+    , gcsFlags = ["LOADING", "STALE"]
+    , gcsArguments = []
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XINFO", "STREAM"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "full-block"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "pure-token"
+                    , gaName = "full"
+                    , gaToken = Just "FULL"
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Just "COUNT"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XLEN"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XPENDING"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "group"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "filters"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "min-idle-time"
+                    , gaToken = Just "IDLE"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "start"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "end"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "consumer"
+                    , gaToken = Nothing
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XRANGE"]
+    , gcsArity = -4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "start"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "end"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XREAD"]
+    , gcsArity = -4
+    , gcsFlags = ["BLOCKING", "READONLY", "BLOCKING"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "milliseconds"
+            , gaToken = Just "BLOCK"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "streams"
+            , gaToken = Just "STREAMS"
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "key"
+                    , gaName = "key"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = True
+                    , gaKeySpecIndex = Just 0
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "ID"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = True
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XREADGROUP"]
+    , gcsArity = -7
+    , gcsFlags = ["BLOCKING", "WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "group-block"
+            , gaToken = Just "GROUP"
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "group"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "consumer"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "milliseconds"
+            , gaToken = Just "BLOCK"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "noack"
+            , gaToken = Just "NOACK"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "streams"
+            , gaToken = Just "STREAMS"
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "key"
+                    , gaName = "key"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = True
+                    , gaKeySpecIndex = Just 0
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "ID"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = True
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XREVRANGE"]
+    , gcsArity = -4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "end"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "start"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XSETID"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "last-id"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "entries-added"
+            , gaToken = Just "ENTRIESADDED"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "max-deleted-id"
+            , gaToken = Just "MAXDELETEDID"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["XTRIM"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "trim"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "oneof"
+                    , gaName = "strategy"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives =
+                        [
+                          [
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "maxlen"
+                              , gaToken = Just "MAXLEN"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ],
+                          [
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "minid"
+                              , gaToken = Just "MINID"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                        ]
+                    },
+                  GeneratedArgument
+                    { gaType = "oneof"
+                    , gaName = "operator"
+                    , gaToken = Nothing
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives =
+                        [
+                          [
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "equal"
+                              , gaToken = Just "="
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ],
+                          [
+                            GeneratedArgument
+                              { gaType = "pure-token"
+                              , gaName = "approximately"
+                              , gaToken = Just "~"
+                              , gaOptional = False
+                              , gaMultiple = False
+                              , gaKeySpecIndex = Nothing
+                              , gaChildren = []
+                              , gaAlternatives = []
+                              }
+                          ]
+                        ]
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "threshold"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Just "LIMIT"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZADD"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "condition"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "nx"
+                      , gaToken = Just "NX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "xx"
+                      , gaToken = Just "XX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "comparison"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "gt"
+                      , gaToken = Just "GT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "lt"
+                      , gaToken = Just "LT"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "change"
+            , gaToken = Just "CH"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "increment"
+            , gaToken = Just "INCR"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "data"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "double"
+                    , gaName = "score"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "string"
+                    , gaName = "member"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZCARD"]
+    , gcsArity = 2
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZCOUNT"]
+    , gcsArity = 4
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "min"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "max"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZDIFF"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withscores"
+            , gaToken = Just "WITHSCORES"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZDIFFSTORE"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZINCRBY"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE", "DENYOOM", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "increment"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZINTER"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "weight"
+            , gaToken = Just "WEIGHTS"
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "aggregate"
+            , gaToken = Just "AGGREGATE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "sum"
+                      , gaToken = Just "SUM"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "min"
+                      , gaToken = Just "MIN"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "max"
+                      , gaToken = Just "MAX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withscores"
+            , gaToken = Just "WITHSCORES"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZINTERCARD"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "limit"
+            , gaToken = Just "LIMIT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZINTERSTORE"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "weight"
+            , gaToken = Just "WEIGHTS"
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "aggregate"
+            , gaToken = Just "AGGREGATE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "sum"
+                      , gaToken = Just "SUM"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "min"
+                      , gaToken = Just "MIN"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "max"
+                      , gaToken = Just "MAX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZLEXCOUNT"]
+    , gcsArity = 4
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "min"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "max"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZMPOP"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "where"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "min"
+                      , gaToken = Just "MIN"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "max"
+                      , gaToken = Just "MAX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZMSCORE"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZPOPMAX"]
+    , gcsArity = -2
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZPOPMIN"]
+    , gcsArity = -2
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZRANDMEMBER"]
+    , gcsArity = -2
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "options"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "pure-token"
+                    , gaName = "withscores"
+                    , gaToken = Just "WITHSCORES"
+                    , gaOptional = True
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZRANGE"]
+    , gcsArity = -4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "start"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "stop"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "sortby"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "byscore"
+                      , gaToken = Just "BYSCORE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "bylex"
+                      , gaToken = Just "BYLEX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "rev"
+            , gaToken = Just "REV"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "limit"
+            , gaToken = Just "LIMIT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "offset"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withscores"
+            , gaToken = Just "WITHSCORES"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZRANGEBYLEX"]
+    , gcsArity = -4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "min"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "max"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "limit"
+            , gaToken = Just "LIMIT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "offset"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZRANGEBYSCORE"]
+    , gcsArity = -4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "min"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "max"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withscores"
+            , gaToken = Just "WITHSCORES"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "limit"
+            , gaToken = Just "LIMIT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "offset"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZRANGESTORE"]
+    , gcsArity = -5
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "dst"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "src"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "min"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "max"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "sortby"
+            , gaToken = Nothing
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "byscore"
+                      , gaToken = Just "BYSCORE"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "bylex"
+                      , gaToken = Just "BYLEX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "rev"
+            , gaToken = Just "REV"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "limit"
+            , gaToken = Just "LIMIT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "offset"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZRANK"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withscore"
+            , gaToken = Just "WITHSCORE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZREM"]
+    , gcsArity = -3
+    , gcsFlags = ["WRITE", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZREMRANGEBYLEX"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "min"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "max"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZREMRANGEBYRANK"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "start"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "stop"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZREMRANGEBYSCORE"]
+    , gcsArity = 4
+    , gcsFlags = ["WRITE"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "min"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "max"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZREVRANGE"]
+    , gcsArity = -4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "start"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "stop"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withscores"
+            , gaToken = Just "WITHSCORES"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZREVRANGEBYLEX"]
+    , gcsArity = -4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "max"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "min"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "limit"
+            , gaToken = Just "LIMIT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "offset"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZREVRANGEBYSCORE"]
+    , gcsArity = -4
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "max"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "double"
+            , gaName = "min"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withscores"
+            , gaToken = Just "WITHSCORES"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "block"
+            , gaName = "limit"
+            , gaToken = Just "LIMIT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren =
+                [
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "offset"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    },
+                  GeneratedArgument
+                    { gaType = "integer"
+                    , gaName = "count"
+                    , gaToken = Nothing
+                    , gaOptional = False
+                    , gaMultiple = False
+                    , gaKeySpecIndex = Nothing
+                    , gaChildren = []
+                    , gaAlternatives = []
+                    }
+                ]
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZREVRANK"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withscore"
+            , gaToken = Just "WITHSCORE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZSCAN"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "cursor"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "pattern"
+            , gaName = "pattern"
+            , gaToken = Just "MATCH"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "count"
+            , gaToken = Just "COUNT"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZSCORE"]
+    , gcsArity = 3
+    , gcsFlags = ["READONLY", "FAST"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "string"
+            , gaName = "member"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZUNION"]
+    , gcsArity = -3
+    , gcsFlags = ["READONLY"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "weight"
+            , gaToken = Just "WEIGHTS"
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "aggregate"
+            , gaToken = Just "AGGREGATE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "sum"
+                      , gaToken = Just "SUM"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "min"
+                      , gaToken = Just "MIN"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "max"
+                      , gaToken = Just "MAX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            },
+          GeneratedArgument
+            { gaType = "pure-token"
+            , gaName = "withscores"
+            , gaToken = Just "WITHSCORES"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            }
+        ]
+    },
+  GeneratedCommandSpec
+    { gcsTokens = ["ZUNIONSTORE"]
+    , gcsArity = -4
+    , gcsFlags = ["WRITE", "DENYOOM"]
+    , gcsArguments =
+        [
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "destination"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Just 0
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "numkeys"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "key"
+            , gaName = "key"
+            , gaToken = Nothing
+            , gaOptional = False
+            , gaMultiple = True
+            , gaKeySpecIndex = Just 1
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "integer"
+            , gaName = "weight"
+            , gaToken = Just "WEIGHTS"
+            , gaOptional = True
+            , gaMultiple = True
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives = []
+            },
+          GeneratedArgument
+            { gaType = "oneof"
+            , gaName = "aggregate"
+            , gaToken = Just "AGGREGATE"
+            , gaOptional = True
+            , gaMultiple = False
+            , gaKeySpecIndex = Nothing
+            , gaChildren = []
+            , gaAlternatives =
+                [
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "sum"
+                      , gaToken = Just "SUM"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "min"
+                      , gaToken = Just "MIN"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ],
+                  [
+                    GeneratedArgument
+                      { gaType = "pure-token"
+                      , gaName = "max"
+                      , gaToken = Just "MAX"
+                      , gaOptional = False
+                      , gaMultiple = False
+                      , gaKeySpecIndex = Nothing
+                      , gaChildren = []
+                      , gaAlternatives = []
+                      }
+                  ]
+                ]
+            }
+        ]
+    }
+  ]

--- a/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands/Spec.hs
+++ b/hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands/Spec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Database.Redis.Cluster.Commands.Spec
+  ( GeneratedCommandSpec(..)
+  , GeneratedArgument(..)
+  ) where
+
+import           Data.ByteString (ByteString)
+
+data GeneratedCommandSpec = GeneratedCommandSpec
+  { gcsTokens    :: [ByteString]
+  , gcsArity     :: Int
+  , gcsFlags     :: [ByteString]
+  , gcsArguments :: [GeneratedArgument]
+  }
+  deriving (Eq, Show)
+
+data GeneratedArgument = GeneratedArgument
+  { gaType         :: ByteString
+  , gaName         :: ByteString
+  , gaToken        :: Maybe ByteString
+  , gaOptional     :: Bool
+  , gaMultiple     :: Bool
+  , gaKeySpecIndex :: Maybe Int
+  , gaChildren     :: [GeneratedArgument]
+  , gaAlternatives :: [[GeneratedArgument]]
+  }
+  deriving (Eq, Show)

--- a/hask-redis-mux/test/ClusterRoutingSpec.hs
+++ b/hask-redis-mux/test/ClusterRoutingSpec.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import           Data.ByteString                 (ByteString)
+import           Database.Redis.Cluster.Commands
+import           Test.Hspec
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "subcommand validation" $ do
+    assertError "MEMORY" ["BOGUS"]
+    assertError "CLIENT" ["BOGUS"]
+    assertError "XINFO" ["BOGUS"]
+
+  describe "grammar validation" $ do
+    assertError "XREAD" ["NOACK"]
+    assertError "MSETNX" ["k1", "v1", "k2"]
+    assertError "MSET" ["k1", "v1", "k2"]
+    assertError "SET" ["k", "v", "GET", "GET"]
+    assertError "GET" ["k", "extra"]
+    assertError "ZUNION" ["2", "{h}a", "{h}b", "WEIGHTS", "1"]
+    assertError "EVAL" ["return 1", "2", "k1"]
+    assertError "FCALL" ["f", "2", "k1"]
+
+  describe "valid command routing" $ do
+    assertKeyed "SET" ["{h}key", "value"] "{h}key"
+    assertKeyed "OBJECT" ["ENCODING", "{h}key"] "{h}key"
+    assertKeyed "ZUNION" ["2", "{h}a", "{h}b", "WEIGHTS", "1", "2", "AGGREGATE", "MAX", "WITHSCORES"] "{h}a"
+    assertKeyed "ZINTER" ["2", "{h}a", "{h}b", "WEIGHTS", "1", "2", "AGGREGATE", "SUM", "WITHSCORES"] "{h}a"
+    assertKeyed "ZDIFF" ["2", "{h}a", "{h}b", "WITHSCORES"] "{h}a"
+    assertKeyed "XINFO" ["STREAM", "{h}stream"] "{h}stream"
+    assertKeyed "BLPOP" ["{h}list", "0.25"] "{h}list"
+    assertKeyed "BRPOP" ["{h}list", "0.5"] "{h}list"
+    assertKeyed "PFCOUNT" ["{h}a", "{h}b"] "{h}a"
+    assertKeyed "TOUCH" ["{h}a", "{h}b"] "{h}a"
+    assertKeyed "UNLINK" ["{h}a", "{h}b"] "{h}a"
+    assertKeyed "WATCH" ["{h}a", "{h}b"] "{h}a"
+    assertKeyed "MSET" ["{h}a", "1", "{h}b", "2"] "{h}a"
+    assertKeyed "MSETNX" ["{h}a", "1", "{h}b", "2"] "{h}a"
+    assertKeyed "RENAME" ["{h}a", "{h}b"] "{h}a"
+    assertKeyed "COPY" ["{h}a", "{h}b", "REPLACE"] "{h}a"
+    assertKeyed "XREAD" ["COUNT", "2", "BLOCK", "10", "STREAMS", "{h}s1", "{h}s2", "0-0", "0-1"] "{h}s1"
+    assertKeyed "XREADGROUP" ["GROUP", "g", "c", "COUNT", "2", "BLOCK", "10", "STREAMS", "{h}s1", "{h}s2", ">", ">"] "{h}s1"
+    assertKeyed "EVAL" ["return ARGV[1]", "2", "{h}k1", "{h}k2", "arg"] "{h}k1"
+    assertKeyed "FCALL" ["myf", "2", "{h}k1", "{h}k2", "arg"] "{h}k1"
+    assertKeyed "GEOSEARCHSTORE" ["{h}dst", "{h}src", "FROMMEMBER", "m", "BYRADIUS", "1.2", "km", "COUNT", "1", "ANY", "STOREDIST"] "{h}dst"
+
+    it "accepts OBJECT HELP as keyless" $ do
+      classifyCommand "OBJECT" ["HELP"] `shouldBe` KeylessRoute
+
+assertError :: ByteString -> [ByteString] -> Spec
+assertError cmd args =
+  it (show cmd ++ " rejects malformed input") $ do
+    classifyCommand cmd args `shouldSatisfy` isCommandError
+
+assertKeyed :: ByteString -> [ByteString] -> ByteString -> Spec
+assertKeyed cmd args expectedKey =
+  it (show cmd ++ " routes by key") $ do
+    classifyCommand cmd args `shouldBe` KeyedRoute expectedKey
+
+isCommandError :: CommandRouting -> Bool
+isCommandError routing =
+  case routing of
+    CommandError _ -> True
+    _              -> False

--- a/scripts/audit_cluster_routing.sh
+++ b/scripts/audit_cluster_routing.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+cd "$REPO_ROOT"
+
+scripts/generate_cluster_routing.py --check
+
+SOURCE_SHA=$(grep -E '^redis72SourceSha = ' hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands/Generated.hs | sed -E 's/.*"([0-9a-f]+)"/\1/')
+FORM_COUNT=$(grep -E '^generatedSupportedFormsCount = ' hask-redis-mux/lib/cluster/Database/Redis/Cluster/Commands/Generated.hs | awk '{print $3}')
+
+printf 'Redis command source SHA: %s\n' "$SOURCE_SHA"
+printf 'Generated command forms: %s\n' "$FORM_COUNT"

--- a/scripts/generate_cluster_routing.py
+++ b/scripts/generate_cluster_routing.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from dataclasses import dataclass
+from typing import Any
+
+REDIS_SOURCE_SHA = "ae6a2aa95cd094b032e7a69b8b59f64dd1ed085f"  # redis 7.2.6
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+COMMANDS_DIR = ROOT / "vendor" / "redis-7.2.6-commands"
+OUT_PATH = ROOT / "hask-redis-mux" / "lib" / "cluster" / "Database" / "Redis" / "Cluster" / "Commands" / "Generated.hs"
+
+
+def hs_bs(value: str) -> str:
+    escaped = value.replace('\\', '\\\\').replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def bool_lit(v: bool) -> str:
+    return "True" if v else "False"
+
+
+@dataclass(frozen=True)
+class Arg:
+    type: str
+    name: str
+    token: str | None
+    optional: bool
+    multiple: bool
+    key_spec_index: int | None
+    children: tuple["Arg", ...]
+    alternatives: tuple[tuple["Arg", ...], ...]
+
+
+@dataclass(frozen=True)
+class Spec:
+    tokens: tuple[str, ...]
+    arity: int
+    flags: tuple[str, ...]
+    args: tuple[Arg, ...]
+
+
+def normalize_arg(raw: dict[str, Any]) -> Arg:
+    alternatives: list[tuple[Arg, ...]] = []
+    if raw.get("type") == "oneof":
+        for option in raw.get("arguments", []):
+            option_type = option.get("type")
+            if option_type in ("block", "oneof"):
+                option_nodes = (normalize_arg(option),)
+            else:
+                option_nodes = (normalize_arg(option),)
+            alternatives.append(option_nodes)
+    return Arg(
+        type=raw.get("type", "string"),
+        name=raw.get("name", ""),
+        token=raw.get("token"),
+        optional=bool(raw.get("optional", False)),
+        multiple=bool(raw.get("multiple", False)),
+        key_spec_index=raw.get("key_spec_index"),
+        children=tuple(normalize_arg(x) for x in raw.get("arguments", []) if raw.get("type") != "oneof"),
+        alternatives=tuple(alternatives),
+    )
+
+
+def normalize_spec(name: str, raw: dict[str, Any]) -> Spec:
+    tokens_parts: list[str] = []
+    container = raw.get("container")
+    if container:
+        tokens_parts.extend(container.split("|"))
+    tokens_parts.extend(name.split("|"))
+    tokens = tuple(token.upper() for token in tokens_parts)
+    flags = tuple(flag.upper() for flag in raw.get("command_flags", []))
+    args = tuple(normalize_arg(arg) for arg in raw.get("arguments", []))
+    return Spec(tokens=tokens, arity=int(raw.get("arity", 0)), flags=flags, args=args)
+
+
+def load_specs() -> list[Spec]:
+    specs: list[Spec] = []
+    for path in sorted(COMMANDS_DIR.glob("*.json")):
+        data = json.loads(path.read_text())
+        for name, raw in data.items():
+            specs.append(normalize_spec(name, raw))
+    specs.sort(key=lambda spec: spec.tokens)
+    return specs
+
+
+def emit_arg(arg: Arg, indent: str) -> list[str]:
+    lines = [f"{indent}GeneratedArgument"]
+    lines.append(f"{indent}  {{ gaType = {hs_bs(arg.type)}")
+    lines.append(f"{indent}  , gaName = {hs_bs(arg.name)}")
+    token = "Nothing" if arg.token is None else f"Just {hs_bs(arg.token)}"
+    lines.append(f"{indent}  , gaToken = {token}")
+    lines.append(f"{indent}  , gaOptional = {bool_lit(arg.optional)}")
+    lines.append(f"{indent}  , gaMultiple = {bool_lit(arg.multiple)}")
+    key_idx = "Nothing" if arg.key_spec_index is None else f"Just {arg.key_spec_index}"
+    lines.append(f"{indent}  , gaKeySpecIndex = {key_idx}")
+    if arg.children:
+        lines.append(f"{indent}  , gaChildren =")
+        lines.append(f"{indent}      [")
+        child_lines: list[str] = []
+        for idx, child in enumerate(arg.children):
+            emitted = emit_arg(child, indent + "        ")
+            if idx + 1 < len(arg.children):
+                emitted[-1] = emitted[-1] + ","
+            child_lines.extend(emitted)
+        lines.extend(child_lines)
+        lines.append(f"{indent}      ]")
+    else:
+        lines.append(f"{indent}  , gaChildren = []")
+
+    if arg.alternatives:
+        lines.append(f"{indent}  , gaAlternatives =")
+        lines.append(f"{indent}      [")
+        alt_blocks: list[str] = []
+        for alt_idx, alt in enumerate(arg.alternatives):
+            alt_blocks.append(f"{indent}        [")
+            for arg_idx, alt_arg in enumerate(alt):
+                emitted = emit_arg(alt_arg, indent + "          ")
+                if arg_idx + 1 < len(alt):
+                    emitted[-1] = emitted[-1] + ","
+                alt_blocks.extend(emitted)
+            suffix = "]" + ("," if alt_idx + 1 < len(arg.alternatives) else "")
+            alt_blocks.append(f"{indent}        {suffix}")
+        lines.extend(alt_blocks)
+        lines.append(f"{indent}      ]")
+    else:
+        lines.append(f"{indent}  , gaAlternatives = []")
+
+    lines.append(f"{indent}  }}")
+    return lines
+
+
+def emit_spec(spec: Spec, indent: str = "  ") -> list[str]:
+    lines = [f"{indent}GeneratedCommandSpec"]
+    tokens = ", ".join(hs_bs(token) for token in spec.tokens)
+    lines.append(f"{indent}  {{ gcsTokens = [{tokens}]")
+    lines.append(f"{indent}  , gcsArity = {spec.arity}")
+    flags = ", ".join(hs_bs(flag) for flag in spec.flags)
+    lines.append(f"{indent}  , gcsFlags = [{flags}]")
+    if spec.args:
+        lines.append(f"{indent}  , gcsArguments =")
+        lines.append(f"{indent}      [")
+        arg_lines: list[str] = []
+        for idx, arg in enumerate(spec.args):
+            emitted = emit_arg(arg, indent + "        ")
+            if idx + 1 < len(spec.args):
+                emitted[-1] = emitted[-1] + ","
+            arg_lines.extend(emitted)
+        lines.extend(arg_lines)
+        lines.append(f"{indent}      ]")
+    else:
+        lines.append(f"{indent}  , gcsArguments = []")
+    lines.append(f"{indent}  }}")
+    return lines
+
+
+def generate_haskell(specs: list[Spec]) -> str:
+    lines: list[str] = []
+    lines.append("{-# LANGUAGE OverloadedStrings #-}")
+    lines.append("")
+    lines.append("module Database.Redis.Cluster.Commands.Generated")
+    lines.append("  ( redis72SourceSha")
+    lines.append("  , generatedSupportedFormsCount")
+    lines.append("  , generatedCommandSpecs")
+    lines.append("  ) where")
+    lines.append("")
+    lines.append("import Database.Redis.Cluster.Commands.Spec")
+    lines.append("")
+    lines.append(f"redis72SourceSha :: String")
+    lines.append(f"redis72SourceSha = \"{REDIS_SOURCE_SHA}\"")
+    lines.append("")
+    lines.append("generatedSupportedFormsCount :: Int")
+    lines.append(f"generatedSupportedFormsCount = {len(specs)}")
+    lines.append("")
+    lines.append("-- Generated from vendor/redis-7.2.6/src/commands/*.json")
+    lines.append("-- by scripts/generate_cluster_routing.py")
+    lines.append("")
+    lines.append("generatedCommandSpecs :: [GeneratedCommandSpec]")
+    lines.append("generatedCommandSpecs =")
+    lines.append("  [")
+    for idx, spec in enumerate(specs):
+        emitted = emit_spec(spec)
+        if idx + 1 < len(specs):
+            emitted[-1] = emitted[-1] + ","
+        lines.extend(emitted)
+    lines.append("  ]")
+    lines.append("")
+    return "\n".join(lines)
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    if not COMMANDS_DIR.exists():
+        raise SystemExit(f"Missing Redis metadata directory: {COMMANDS_DIR}")
+
+    specs = load_specs()
+    generated = generate_haskell(specs)
+
+    if args.check:
+        current = OUT_PATH.read_text() if OUT_PATH.exists() else ""
+        if normalize_for_semantic_compare(current) != normalize_for_semantic_compare(generated):
+            raise SystemExit("Generated routing artifact is stale: run scripts/generate_cluster_routing.py")
+        print("Generated routing artifact is up-to-date")
+        return
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(generated)
+    print(f"Wrote {OUT_PATH}")
+
+
+def normalize_for_semantic_compare(text: str) -> str:
+    keep: list[str] = []
+    for line in text.splitlines():
+      stripped = line.strip()
+      if stripped.startswith("--"):
+        continue
+      if stripped == "":
+        continue
+      keep.append(stripped)
+    return "\n".join(keep)
+
+
+if __name__ == "__main__":
+    main()

--- a/vendor/redis-7.2.6-commands/acl-cat.json
+++ b/vendor/redis-7.2.6-commands/acl-cat.json
@@ -1,0 +1,42 @@
+{
+    "CAT": {
+        "summary": "Lists the ACL categories, or the commands inside a category.",
+        "complexity": "O(1) since the categories and commands are a fixed set.",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": -2,
+        "container": "ACL",
+        "function": "aclCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "description": "In case `category` was not given, a list of existing ACL categories",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "type": "array",
+                    "description": "In case `category` was given, list of commands that fall under the provided ACL category",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "category",
+                "type": "string",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl-deluser.json
+++ b/vendor/redis-7.2.6-commands/acl-deluser.json
@@ -1,0 +1,33 @@
+{
+    "DELUSER": {
+        "summary": "Deletes ACL users, and terminates their connections.",
+        "complexity": "O(1) amortized time considering the typical user.",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": -3,
+        "container": "ACL",
+        "function": "aclCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "command_tips": [
+          "REQUEST_POLICY:ALL_NODES",
+          "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],        
+        "reply_schema": {
+            "type": "integer",
+            "description": "The number of users that were deleted"
+        },
+        "arguments": [
+            {
+                "name": "username",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl-dryrun.json
+++ b/vendor/redis-7.2.6-commands/acl-dryrun.json
@@ -1,0 +1,47 @@
+{
+    "DRYRUN": {
+        "summary": "Simulates the execution of a command by a user, without executing the command.",
+        "complexity": "O(1).",
+        "group": "server",
+        "since": "7.0.0",
+        "arity": -4,
+        "container": "ACL",
+        "function": "aclCommand",
+        "history": [],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "const": "OK",
+                    "description": "The given user may successfully execute the given command."
+                },
+                {
+                    "type": "string",
+                    "description": "The description of the problem, in case the user is not allowed to run the given command."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "username",
+                "type": "string"
+            },
+            {
+                "name": "command",
+                "type": "string"
+            },
+            {
+                "name": "arg",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl-genpass.json
+++ b/vendor/redis-7.2.6-commands/acl-genpass.json
@@ -1,0 +1,28 @@
+{
+    "GENPASS": {
+        "summary": "Generates a pseudorandom, secure password that can be used to identify ACL users.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": -2,
+        "container": "ACL",
+        "function": "aclCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "string",
+            "description": "Pseudorandom data. By default it contains 64 bytes, representing 256 bits of data. If `bits` was given, the output string length is the number of specified bits (rounded to the next multiple of 4) divided by 4."
+        },
+        "arguments": [
+            {
+                "name": "bits",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl-getuser.json
+++ b/vendor/redis-7.2.6-commands/acl-getuser.json
@@ -1,0 +1,91 @@
+{
+    "GETUSER": {
+        "summary": "Lists the ACL rules of a user.",
+        "complexity": "O(N). Where N is the number of password, command and pattern rules that the user has.",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": 3,
+        "container": "ACL",
+        "function": "aclCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added Pub/Sub channel patterns."
+            ],
+            [
+                "7.0.0",
+                "Added selectors and changed the format of key and channel patterns from a list to their rule representation."
+            ]
+        ],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "arguments": [
+            {
+                "name": "username",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "a set of ACL rule definitions for the user",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "flags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "passwords": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "commands": {
+                            "description": "root selector's commands",
+                            "type": "string"
+                        },
+                        "keys": {
+                            "description": "root selector's keys",
+                            "type": "string"
+                        },
+                        "channels": {
+                            "description": "root selector's channels",
+                            "type": "string"
+                        },
+                        "selectors": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "commands": {
+                                        "type": "string"
+                                    },
+                                    "keys": {
+                                        "type": "string"
+                                    },
+                                    "channels": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "description": "If user does not exist",
+                    "type": "null"
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl-help.json
+++ b/vendor/redis-7.2.6-commands/acl-help.json
@@ -1,0 +1,23 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": 2,
+        "container": "ACL",
+        "function": "aclCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "A list of subcommands and their description",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl-list.json
+++ b/vendor/redis-7.2.6-commands/acl-list.json
@@ -1,0 +1,25 @@
+{
+    "LIST": {
+        "summary": "Dumps the effective rules in ACL file format.",
+        "complexity": "O(N). Where N is the number of configured users.",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": 2,
+        "container": "ACL",
+        "function": "aclCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "A list of currently active ACL rules",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl-load.json
+++ b/vendor/redis-7.2.6-commands/acl-load.json
@@ -1,0 +1,21 @@
+{
+    "LOAD": {
+        "summary": "Reloads the rules from the configured ACL file.",
+        "complexity": "O(N). Where N is the number of configured users.",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": 2,
+        "container": "ACL",
+        "function": "aclCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl-log.json
+++ b/vendor/redis-7.2.6-commands/acl-log.json
@@ -1,0 +1,90 @@
+{
+    "LOG": {
+        "summary": "Lists recent security events generated due to ACL rules.",
+        "complexity": "O(N) with N being the number of entries shown.",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": -2,
+        "container": "ACL",
+        "function": "aclCommand",
+        "history": [
+            [
+                "7.2.0",
+                "Added entry ID, timestamp created, and timestamp last updated."
+            ]
+        ],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "In case `RESET` was not given, a list of recent ACL security events.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "count": {
+                                "type": "integer"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "context": {
+                                "type": "string"
+                            },
+                            "object": {
+                                "type": "string"
+                            },
+                            "username": {
+                                "type": "string"
+                            },
+                            "age-seconds": {
+                                "type": "number"
+                            },
+                            "client-info": {
+                                "type": "string"
+                            },
+                            "entry-id": {
+                                "type": "integer"
+                            },
+                            "timestamp-created": {
+                                "type": "integer"
+                            },
+                            "timestamp-last-updated": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                },
+                {
+                    "const": "OK",
+                    "description": "In case `RESET` was given, OK indicates ACL log was cleared."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "operation",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "reset",
+                        "type": "pure-token",
+                        "token": "RESET"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl-save.json
+++ b/vendor/redis-7.2.6-commands/acl-save.json
@@ -1,0 +1,25 @@
+{
+    "SAVE": {
+        "summary": "Saves the effective ACL rules in the configured ACL file.",
+        "complexity": "O(N). Where N is the number of configured users.",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": 2,
+        "container": "ACL",
+        "function": "aclCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "command_tips": [
+          "REQUEST_POLICY:ALL_NODES",
+          "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl-setuser.json
+++ b/vendor/redis-7.2.6-commands/acl-setuser.json
@@ -1,0 +1,47 @@
+{
+    "SETUSER": {
+        "summary": "Creates and modifies an ACL user and its rules.",
+        "complexity": "O(N). Where N is the number of rules provided.",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": -3,
+        "container": "ACL",
+        "function": "aclCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added Pub/Sub channel patterns."
+            ],
+            [
+                "7.0.0",
+                "Added selectors and key based permissions."
+            ]
+        ],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "command_tips": [
+          "REQUEST_POLICY:ALL_NODES",
+          "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],        
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "username",
+                "type": "string"
+            },
+            {
+                "name": "rule",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl-users.json
+++ b/vendor/redis-7.2.6-commands/acl-users.json
@@ -1,0 +1,25 @@
+{
+    "USERS": {
+        "summary": "Lists all ACL users.",
+        "complexity": "O(N). Where N is the number of configured users.",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": 2,
+        "container": "ACL",
+        "function": "aclCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List of existing ACL users",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl-whoami.json
+++ b/vendor/redis-7.2.6-commands/acl-whoami.json
@@ -1,0 +1,21 @@
+{
+    "WHOAMI": {
+        "summary": "Returns the authenticated username of the current connection.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": 2,
+        "container": "ACL",
+        "function": "aclCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "string",
+            "description": "The username of the current connection."
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/acl.json
+++ b/vendor/redis-7.2.6-commands/acl.json
@@ -1,0 +1,12 @@
+{
+    "ACL": {
+        "summary": "A container for Access List Control commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "server",
+        "since": "6.0.0",
+        "arity": -2,
+        "command_flags": [
+            "SENTINEL"
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/append.json
+++ b/vendor/redis-7.2.6-commands/append.json
@@ -1,0 +1,53 @@
+{
+    "APPEND": {
+        "summary": "Appends a string to the value of a key. Creates the key if it doesn't exist.",
+        "complexity": "O(1). The amortized time complexity is O(1) assuming the appended value is small and the already present value is of any size, since the dynamic string library used by Redis will double the free space available on every reallocation.",
+        "group": "string",
+        "since": "2.0.0",
+        "arity": 3,
+        "function": "appendCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "The length of the string after the append operation."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/asking.json
+++ b/vendor/redis-7.2.6-commands/asking.json
@@ -1,0 +1,19 @@
+{
+    "ASKING": {
+        "summary": "Signals that a cluster client is following an -ASK redirect.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 1,
+        "function": "askingCommand",
+        "command_flags": [
+            "FAST"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/auth.json
+++ b/vendor/redis-7.2.6-commands/auth.json
@@ -1,0 +1,43 @@
+{
+    "AUTH": {
+        "summary": "Authenticates the connection.",
+        "complexity": "O(N) where N is the number of passwords defined for the user",
+        "group": "connection",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "authCommand",
+        "history": [
+            [
+                "6.0.0",
+                "Added ACL style (username and password)."
+            ]
+        ],
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "FAST",
+            "NO_AUTH",
+            "SENTINEL",
+            "ALLOW_BUSY"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "username",
+                "type": "string",
+                "optional": true,
+                "since": "6.0.0"
+            },
+            {
+                "name": "password",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/bgrewriteaof.json
+++ b/vendor/redis-7.2.6-commands/bgrewriteaof.json
@@ -1,0 +1,19 @@
+{
+    "BGREWRITEAOF": {
+        "summary": "Asynchronously rewrites the append-only file to disk.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": 1,
+        "function": "bgrewriteaofCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "NOSCRIPT"
+        ],
+        "reply_schema": {
+            "description": "A simple string reply indicating that the rewriting started or is about to start ASAP",
+            "type": "string"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/bgsave.json
+++ b/vendor/redis-7.2.6-commands/bgsave.json
@@ -1,0 +1,40 @@
+{
+    "BGSAVE": {
+        "summary": "Asynchronously saves the database(s) to disk.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": -1,
+        "function": "bgsaveCommand",
+        "history": [
+            [
+                "3.2.2",
+                "Added the `SCHEDULE` option."
+            ]
+        ],
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "NOSCRIPT"
+        ],
+        "arguments": [
+            {
+                "name": "schedule",
+                "token": "SCHEDULE",
+                "type": "pure-token",
+                "optional": true,
+                "since": "3.2.2"
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "const": "Background saving started"
+                },
+                {
+                    "const": "Background saving scheduled"
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/bitcount.json
+++ b/vendor/redis-7.2.6-commands/bitcount.json
@@ -1,0 +1,87 @@
+{
+    "BITCOUNT": {
+        "summary": "Counts the number of set bits (population counting) in a string.",
+        "complexity": "O(N)",
+        "group": "bitmap",
+        "since": "2.6.0",
+        "arity": -2,
+        "function": "bitcountCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added the `BYTE|BIT` option."
+            ]
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "BITMAP"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "range",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "start",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "end",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "unit",
+                        "type": "oneof",
+                        "optional": true,
+                        "since": "7.0.0",
+                        "arguments": [
+                            {
+                                "name": "byte",
+                                "type": "pure-token",
+                                "token": "BYTE"
+                            },
+                            {
+                                "name": "bit",
+                                "type": "pure-token",
+                                "token": "BIT"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of bits set to 1.",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/bitfield.json
+++ b/vendor/redis-7.2.6-commands/bitfield.json
@@ -1,0 +1,159 @@
+{
+    "BITFIELD": {
+        "summary": "Performs arbitrary bitfield integer operations on strings.",
+        "complexity": "O(1) for each subcommand specified",
+        "group": "bitmap",
+        "since": "3.2.0",
+        "arity": -2,
+        "function": "bitfieldCommand",
+        "get_keys_function": "bitfieldGetKeys",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "BITMAP"
+        ],
+        "key_specs": [
+            {
+                "notes": "This command allows both access and modification of the key",
+                "flags": [
+                    "RW",
+                    "UPDATE",
+                    "ACCESS",
+                    "VARIABLE_FLAGS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "operation",
+                "type": "oneof",
+                "multiple": true,
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "GET",
+                        "name": "get-block",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "encoding",
+                                "type": "string"
+                            },
+                            {
+                                "name": "offset",
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "write",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "token": "OVERFLOW",
+                                "name": "overflow-block",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                    {
+                                        "name": "wrap",
+                                        "type": "pure-token",
+                                        "token": "WRAP"
+                                    },
+                                    {
+                                        "name": "sat",
+                                        "type": "pure-token",
+                                        "token": "SAT"
+                                    },
+                                    {
+                                        "name": "fail",
+                                        "type": "pure-token",
+                                        "token": "FAIL"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "write-operation",
+                                "type": "oneof",
+                                "arguments": [
+                                    {
+                                        "token": "SET",
+                                        "name": "set-block",
+                                        "type": "block",
+                                        "arguments": [
+                                            {
+                                                "name": "encoding",
+                                                "type": "string"
+                                            },
+                                            {
+                                                "name": "offset",
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "name": "value",
+                                                "type": "integer"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "token": "INCRBY",
+                                        "name": "incrby-block",
+                                        "type": "block",
+                                        "arguments": [
+                                            {
+                                                "name": "encoding",
+                                                "type": "string"
+                                            },
+                                            {
+                                                "name": "offset",
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "name": "increment",
+                                                "type": "integer"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "The result of the subcommand at the same position",
+                        "type": "integer"
+                    },
+                    {
+                        "description": "In case OVERFLOW FAIL was given and overflows or underflows detected",
+                        "type": "null"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/bitfield_ro.json
+++ b/vendor/redis-7.2.6-commands/bitfield_ro.json
@@ -1,0 +1,69 @@
+{
+    "BITFIELD_RO": {
+        "summary": "Performs arbitrary read-only bitfield integer operations on strings.",
+        "complexity": "O(1) for each subcommand specified",
+        "group": "bitmap",
+        "since": "6.0.0",
+        "arity": -2,
+        "function": "bitfieldroCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "BITMAP"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "token": "GET",
+                "name": "get-block",
+                "type": "block",
+                "optional": true,
+                "multiple": true,
+                "multiple_token": true,
+                "arguments": [
+                    {
+                        "name": "encoding",
+                        "type": "string"
+                    },
+                    {
+                        "name": "offset",
+                        "type": "integer"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "items": {
+                "description": "The result of the subcommand at the same position",
+                "type": "integer"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/bitop.json
+++ b/vendor/redis-7.2.6-commands/bitop.json
@@ -1,0 +1,99 @@
+{
+    "BITOP": {
+        "summary": "Performs bitwise operations on multiple strings, and stores the result.",
+        "complexity": "O(N)",
+        "group": "bitmap",
+        "since": "2.6.0",
+        "arity": -4,
+        "function": "bitopCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "BITMAP"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 3
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "operation",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "and",
+                        "type": "pure-token",
+                        "token": "AND"
+                    },
+                    {
+                        "name": "or",
+                        "type": "pure-token",
+                        "token": "OR"
+                    },
+                    {
+                        "name": "xor",
+                        "type": "pure-token",
+                        "token": "XOR"
+                    },
+                    {
+                        "name": "not",
+                        "type": "pure-token",
+                        "token": "NOT"
+                    }
+                ]
+            },
+            {
+                "name": "destkey",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 1,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "the size of the string stored in the destination key, that is equal to the size of the longest input string",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/bitpos.json
+++ b/vendor/redis-7.2.6-commands/bitpos.json
@@ -1,0 +1,106 @@
+{
+    "BITPOS": {
+        "summary": "Finds the first set (1) or clear (0) bit in a string.",
+        "complexity": "O(N)",
+        "group": "bitmap",
+        "since": "2.8.7",
+        "arity": -3,
+        "function": "bitposCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added the `BYTE|BIT` option."
+            ]
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "BITMAP"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "bit",
+                "type": "integer"
+            },
+            {
+                "name": "range",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "start",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "end-unit-block",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                            {
+                                "name": "end",
+                                "type": "integer"
+                            },
+                            {
+                                "name": "unit",
+                                "type": "oneof",
+                                "optional": true,
+                                "since": "7.0.0",
+                                "arguments": [
+                                    {
+                                        "name": "byte",
+                                        "type": "pure-token",
+                                        "token": "BYTE"
+                                    },
+                                    {
+                                        "name": "bit",
+                                        "type": "pure-token",
+                                        "token": "BIT"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "the position of the first bit set to 1 or 0 according to the request",
+                    "type": "integer",
+                    "minimum": 0
+                },
+                {
+                    "description": "In case the `bit` argument is 1 and the string is empty or composed of just zero bytes",
+                    "const": -1
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/blmove.json
+++ b/vendor/redis-7.2.6-commands/blmove.json
@@ -1,0 +1,117 @@
+{
+    "BLMOVE": {
+        "summary": "Pops an element from a list, pushes it to another list and returns it. Blocks until an element is available otherwise. Deletes the list if the last element was moved.",
+        "complexity": "O(1)",
+        "group": "list",
+        "since": "6.2.0",
+        "arity": 6,
+        "function": "blmoveCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "BLOCKING"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The popped element.",
+                    "type": "string"
+                },
+                {
+                    "description": "Operation timed-out",
+                    "type": "null"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "source",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 1
+            },
+            {
+                "name": "wherefrom",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "left",
+                        "type": "pure-token",
+                        "token": "LEFT"
+                    },
+                    {
+                        "name": "right",
+                        "type": "pure-token",
+                        "token": "RIGHT"
+                    }
+                ]
+            },
+            {
+                "name": "whereto",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "left",
+                        "type": "pure-token",
+                        "token": "LEFT"
+                    },
+                    {
+                        "name": "right",
+                        "type": "pure-token",
+                        "token": "RIGHT"
+                    }
+                ]
+            },
+            {
+                "name": "timeout",
+                "type": "double"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/blmpop.json
+++ b/vendor/redis-7.2.6-commands/blmpop.json
@@ -1,0 +1,105 @@
+{
+    "BLMPOP": {
+        "summary": "Pops the first element from one of multiple lists. Blocks until an element is available otherwise. Deletes the list if the last element was popped.",
+        "complexity": "O(N+M) where N is the number of provided keys and M is the number of elements returned.",
+        "group": "list",
+        "since": "7.0.0",
+        "arity": -5,
+        "function": "blmpopCommand",
+        "get_keys_function": "blmpopGetKeys",
+        "command_flags": [
+            "WRITE",
+            "BLOCKING"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Operation timed-out",
+                    "type": "null"
+                },
+                {
+                    "description": "The key from which elements were popped and the popped elements",
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "description": "List key from which elements were popped.",
+                            "type": "string"
+                        },
+                        {
+                            "description": "Array of popped elements.",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "timeout",
+                "type": "double"
+            },
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "name": "where",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "left",
+                        "type": "pure-token",
+                        "token": "LEFT"
+                    },
+                    {
+                        "name": "right",
+                        "type": "pure-token",
+                        "token": "RIGHT"
+                    }
+                ]
+            },
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/blpop.json
+++ b/vendor/redis-7.2.6-commands/blpop.json
@@ -1,0 +1,80 @@
+{
+    "BLPOP": {
+        "summary": "Removes and returns the first element in a list. Blocks until an element is available otherwise. Deletes the list if the last element was popped.",
+        "complexity": "O(N) where N is the number of provided keys.",
+        "group": "list",
+        "since": "2.0.0",
+        "arity": -3,
+        "function": "blpopCommand",
+        "history": [
+            [
+                "6.0.0",
+                "`timeout` is interpreted as a double instead of an integer."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "BLOCKING"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -2,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "null",
+                    "description": "No element could be popped and timeout expired"
+                },
+                {
+                    "description": "The key from which the element was popped and the value of the popped element",
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "description": "List key from which the element was popped.",
+                            "type": "string"
+                        },
+                        {
+                            "description": "Value of the popped element.",
+                            "type": "string"
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "name": "timeout",
+                "type": "double"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/brpop.json
+++ b/vendor/redis-7.2.6-commands/brpop.json
@@ -1,0 +1,79 @@
+{
+    "BRPOP": {
+        "summary": "Removes and returns the last element in a list. Blocks until an element is available otherwise. Deletes the list if the last element was popped.",
+        "complexity": "O(N) where N is the number of provided keys.",
+        "group": "list",
+        "since": "2.0.0",
+        "arity": -3,
+        "function": "brpopCommand",
+        "history": [
+            [
+                "6.0.0",
+                "`timeout` is interpreted as a double instead of an integer."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "BLOCKING"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -2,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "name": "timeout",
+                "type": "double"
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "No element could be popped and the timeout expired.",
+                    "type": "null"
+                },
+                {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "description": "The name of the key where an element was popped ",
+                            "type": "string"
+                        },
+                        {
+                            "description": "The value of the popped element",
+                            "type": "string"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/brpoplpush.json
+++ b/vendor/redis-7.2.6-commands/brpoplpush.json
@@ -1,0 +1,96 @@
+{
+    "BRPOPLPUSH": {
+        "summary": "Pops an element from a list, pushes it to another list and returns it. Block until an element is available otherwise. Deletes the list if the last element was popped.",
+        "complexity": "O(1)",
+        "group": "list",
+        "since": "2.2.0",
+        "arity": 4,
+        "function": "brpoplpushCommand",
+        "history": [
+            [
+                "6.0.0",
+                "`timeout` is interpreted as a double instead of an integer."
+            ]
+        ],
+        "deprecated_since": "6.2.0",
+        "replaced_by": "`BLMOVE` with the `RIGHT` and `LEFT` arguments",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "BLOCKING"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "description": "The element being popped from source and pushed to destination."
+                },
+                {
+                    "type": "null",
+                    "description": "Timeout is reached."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "source",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 1
+            },
+            {
+                "name": "timeout",
+                "type": "double"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/bzmpop.json
+++ b/vendor/redis-7.2.6-commands/bzmpop.json
@@ -1,0 +1,117 @@
+{
+    "BZMPOP": {
+        "summary": "Removes and returns a member by score from one or more sorted sets. Blocks until a member is available otherwise. Deletes the sorted set if the last element was popped.",
+        "complexity": "O(K) + O(M*log(N)) where K is the number of provided keys, N being the number of elements in the sorted set, and M being the number of elements popped.",
+        "group": "sorted_set",
+        "since": "7.0.0",
+        "arity": -5,
+        "function": "bzmpopCommand",
+        "get_keys_function": "blmpopGetKeys",
+        "command_flags": [
+            "WRITE",
+            "BLOCKING"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Timeout reached and no elements were popped.",
+                    "type": "null"
+                },
+                {
+                    "description": "The keyname and the popped members.",
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "description": "Keyname",
+                            "type": "string"
+                        },
+                        {
+                            "description": "Popped members and their scores.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": [
+                                    {
+                                        "description": "Member",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "description": "Score",
+                                        "type": "number"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "timeout",
+                "type": "double"
+            },
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "name": "where",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                    },
+                    {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                    }
+                ]
+            },
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/bzpopmax.json
+++ b/vendor/redis-7.2.6-commands/bzpopmax.json
@@ -1,0 +1,85 @@
+{
+    "BZPOPMAX": {
+        "summary": "Removes and returns the member with the highest score from one or more sorted sets. Blocks until a member available otherwise.  Deletes the sorted set if the last element was popped.",
+        "complexity": "O(log(N)) with N being the number of elements in the sorted set.",
+        "group": "sorted_set",
+        "since": "5.0.0",
+        "arity": -3,
+        "function": "bzpopmaxCommand",
+        "history": [
+            [
+                "6.0.0",
+                "`timeout` is interpreted as a double instead of an integer."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST",
+            "BLOCKING"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -2,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Timeout reached and no elements were popped.",
+                    "type": "null"
+                },
+                {
+                    "description": "The keyname, popped member, and its score.",
+                    "type": "array",
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "items": [
+                        {
+                            "description": "Keyname",
+                            "type": "string"
+                        },
+                        {
+                            "description": "Member",
+                            "type": "string"
+                        },
+                        {
+                            "description": "Score",
+                            "type": "number"
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "name": "timeout",
+                "type": "double"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/bzpopmin.json
+++ b/vendor/redis-7.2.6-commands/bzpopmin.json
@@ -1,0 +1,85 @@
+{
+    "BZPOPMIN": {
+        "summary": "Removes and returns the member with the lowest score from one or more sorted sets. Blocks until a member is available otherwise. Deletes the sorted set if the last element was popped.",
+        "complexity": "O(log(N)) with N being the number of elements in the sorted set.",
+        "group": "sorted_set",
+        "since": "5.0.0",
+        "arity": -3,
+        "function": "bzpopminCommand",
+        "history": [
+            [
+                "6.0.0",
+                "`timeout` is interpreted as a double instead of an integer."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST",
+            "BLOCKING"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -2,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Timeout reached and no elements were popped.",
+                    "type": "null"
+                },
+                {
+                    "description": "The keyname, popped member, and its score.",
+                    "type": "array",
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "items": [
+                        {
+                            "description": "Keyname",
+                            "type": "string"
+                        },
+                        {
+                            "description": "Member",
+                            "type": "string"
+                        },
+                        {
+                            "description": "Score",
+                            "type": "number"
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "name": "timeout",
+                "type": "double"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-caching.json
+++ b/vendor/redis-7.2.6-commands/client-caching.json
@@ -1,0 +1,41 @@
+{
+    "CACHING": {
+        "summary": "Instructs the server whether to track the keys in the next request.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "6.0.0",
+        "arity": 3,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "mode",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "yes",
+                        "type": "pure-token",
+                        "token": "YES"
+                    },
+                    {
+                        "name": "no",
+                        "type": "pure-token",
+                        "token": "NO"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-getname.json
+++ b/vendor/redis-7.2.6-commands/client-getname.json
@@ -1,0 +1,32 @@
+{
+    "GETNAME": {
+        "summary": "Returns the name of the connection.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "2.6.9",
+        "arity": 2,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "description": "The connection name of the current connection"
+                },
+                {
+                    "type": "null",
+                    "description": "Connection name was not set"
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-getredir.json
+++ b/vendor/redis-7.2.6-commands/client-getredir.json
@@ -1,0 +1,37 @@
+{
+    "GETREDIR": {
+        "summary": "Returns the client ID to which the connection's tracking notifications are redirected.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "6.0.0",
+        "arity": 2,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "const": 0,
+                    "description": "Not redirecting notifications to any client."
+                },
+                {
+                    "const": -1,
+                    "description": "Client tracking is not enabled."
+                },
+                {
+                    "type": "integer",
+                    "description": "ID of the client we are redirecting the notifications to.",
+                    "minimum": 1
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-help.json
+++ b/vendor/redis-7.2.6-commands/client-help.json
@@ -1,0 +1,26 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "5.0.0",
+        "arity": 2,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-id.json
+++ b/vendor/redis-7.2.6-commands/client-id.json
@@ -1,0 +1,24 @@
+{
+    "ID": {
+        "summary": "Returns the unique client ID of the connection.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "5.0.0",
+        "arity": 2,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "The id of the client"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-info.json
+++ b/vendor/redis-7.2.6-commands/client-info.json
@@ -1,0 +1,27 @@
+{
+    "INFO": {
+        "summary": "Returns information about the connection.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "6.2.0",
+        "arity": 2,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "description": "a unique string, as described at the CLIENT LIST page, for the current client",
+            "type": "string"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-kill.json
+++ b/vendor/redis-7.2.6-commands/client-kill.json
@@ -1,0 +1,159 @@
+{
+    "KILL": {
+        "summary": "Terminates open connections.",
+        "complexity": "O(N) where N is the number of client connections",
+        "group": "connection",
+        "since": "2.4.0",
+        "arity": -3,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "history": [
+            [
+                "2.8.12",
+                "Added new filter format."
+            ],
+            [
+                "2.8.12",
+                "`ID` option."
+            ],
+            [
+                "3.2.0",
+                "Added `master` type in for `TYPE` option."
+            ],
+            [
+                "5.0.0",
+                "Replaced `slave` `TYPE` with `replica`. `slave` still supported for backward compatibility."
+            ],
+            [
+                "6.2.0",
+                "`LADDR` option."
+            ]
+        ],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "arguments": [
+            {
+                "name": "filter",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "old-format",
+                        "display": "ip:port",
+                        "type": "string",
+                        "deprecated_since": "2.8.12"
+                    },
+                    {
+                        "name": "new-format",
+                        "type": "oneof",
+                        "multiple": true,
+                        "arguments": [
+                            {
+                                "token": "ID",
+                                "name": "client-id",
+                                "type": "integer",
+                                "optional": true,
+                                "since": "2.8.12"
+                            },
+                            {
+                                "token": "TYPE",
+                                "name": "client-type",
+                                "type": "oneof",
+                                "optional": true,
+                                "since": "2.8.12",
+                                "arguments": [
+                                    {
+                                        "name": "normal",
+                                        "type": "pure-token",
+                                        "token": "normal"
+                                    },
+                                    {
+                                        "name": "master",
+                                        "type": "pure-token",
+                                        "token": "master",
+                                        "since": "3.2.0"
+                                    },
+                                    {
+                                        "name": "slave",
+                                        "type": "pure-token",
+                                        "token": "slave"
+                                    },
+                                    {
+                                        "name": "replica",
+                                        "type": "pure-token",
+                                        "token": "replica",
+                                        "since": "5.0.0"
+                                    },
+                                    {
+                                        "name": "pubsub",
+                                        "type": "pure-token",
+                                        "token": "pubsub"
+                                    }
+                                ]
+                            },
+                            {
+                                "token": "USER",
+                                "name": "username",
+                                "type": "string",
+                                "optional": true
+                            },
+                            {
+                                "token": "ADDR",
+                                "name": "addr",
+                                "display": "ip:port",
+                                "type": "string",
+                                "optional": true
+                            },
+                            {
+                                "token": "LADDR",
+                                "name": "laddr",
+                                "display": "ip:port",
+                                "type": "string",
+                                "optional": true,
+                                "since": "6.2.0"
+                            },
+                            {
+                                "token": "SKIPME",
+                                "name": "skipme",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                    {
+                                        "name": "yes",
+                                        "type": "pure-token",
+                                        "token": "YES"
+                                    },
+                                    {
+                                        "name": "no",
+                                        "type": "pure-token",
+                                        "token": "NO"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "when called in 3 argument format",
+                    "const": "OK"
+                },
+                {
+                    "description": "when called in filter/value format, the number of clients killed",
+                    "type": "integer",
+                    "minimum": 0
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-list.json
+++ b/vendor/redis-7.2.6-commands/client-list.json
@@ -1,0 +1,93 @@
+{
+    "LIST": {
+        "summary": "Lists open connections.",
+        "complexity": "O(N) where N is the number of client connections",
+        "group": "connection",
+        "since": "2.4.0",
+        "arity": -2,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "history": [
+            [
+                "2.8.12",
+                "Added unique client `id` field."
+            ],
+            [
+                "5.0.0",
+                "Added optional `TYPE` filter."
+            ],
+            [
+                "6.0.0",
+                "Added `user` field."
+            ],
+            [
+                "6.2.0",
+                "Added `argv-mem`, `tot-mem`, `laddr` and `redir` fields and the optional `ID` filter."
+            ],
+            [
+                "7.0.0",
+                "Added `resp`, `multi-mem`, `rbs` and `rbp` fields."
+            ],
+            [
+                "7.0.3",
+                "Added `ssub` field."
+            ]
+        ],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "type": "string",
+            "description": "Information and statistics about client connections"
+        },
+        "arguments": [
+            {
+                "token": "TYPE",
+                "name": "client-type",
+                "type": "oneof",
+                "optional": true,
+                "since": "5.0.0",
+                "arguments": [
+                    {
+                        "name": "normal",
+                        "type": "pure-token",
+                        "token": "normal"
+                    },
+                    {
+                        "name": "master",
+                        "type": "pure-token",
+                        "token": "master"
+                    },
+                    {
+                        "name": "replica",
+                        "type": "pure-token",
+                        "token": "replica"
+                    },
+                    {
+                        "name": "pubsub",
+                        "type": "pure-token",
+                        "token": "pubsub"
+                    }
+                ]
+            },
+            {
+                "name": "client-id",
+                "token": "ID",
+                "type": "integer",
+                "optional": true,
+                "multiple": true,
+                "since": "6.2.0"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-no-evict.json
+++ b/vendor/redis-7.2.6-commands/client-no-evict.json
@@ -1,0 +1,42 @@
+{
+    "NO-EVICT": {
+        "summary": "Sets the client eviction mode of the connection.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "7.0.0",
+        "arity": 3,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "arguments": [
+            {
+                "name": "enabled",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "on",
+                        "type": "pure-token",
+                        "token": "ON"
+                    },
+                    {
+                        "name": "off",
+                        "type": "pure-token",
+                        "token": "OFF"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-no-touch.json
+++ b/vendor/redis-7.2.6-commands/client-no-touch.json
@@ -1,0 +1,40 @@
+{
+    "NO-TOUCH": {
+        "summary": "Controls whether commands sent by the client affect the LRU/LFU of accessed keys.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "7.2.0",
+        "arity": 3,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "enabled",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "on",
+                        "type": "pure-token",
+                        "token": "ON"
+                    },
+                    {
+                        "name": "off",
+                        "type": "pure-token",
+                        "token": "OFF"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-pause.json
+++ b/vendor/redis-7.2.6-commands/client-pause.json
@@ -1,0 +1,54 @@
+{
+    "PAUSE": {
+        "summary": "Suspends commands processing.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "3.0.0",
+        "arity": -3,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "history": [
+            [
+                "6.2.0",
+                "`CLIENT PAUSE WRITE` mode added along with the `mode` option."
+            ]
+        ],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "arguments": [
+            {
+                "name": "timeout",
+                "type": "integer"
+            },
+            {
+                "name": "mode",
+                "type": "oneof",
+                "optional": true,
+                "since": "6.2.0",
+                "arguments": [
+                    {
+                        "name": "write",
+                        "type": "pure-token",
+                        "token": "WRITE"
+                    },
+                    {
+                        "name": "all",
+                        "type": "pure-token",
+                        "token": "ALL"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-reply.json
+++ b/vendor/redis-7.2.6-commands/client-reply.json
@@ -1,0 +1,47 @@
+{
+    "REPLY": {
+        "summary": "Instructs the server whether to reply to commands.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "3.2.0",
+        "arity": 3,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK",
+            "description": "When called with either OFF or SKIP subcommands, no reply is made. When called with ON, reply is OK."
+        },
+        "arguments": [
+            {
+                "name": "action",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "on",
+                        "type": "pure-token",
+                        "token": "ON"
+                    },
+                    {
+                        "name": "off",
+                        "type": "pure-token",
+                        "token": "OFF"
+                    },
+                    {
+                        "name": "skip",
+                        "type": "pure-token",
+                        "token": "SKIP"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-setinfo.json
+++ b/vendor/redis-7.2.6-commands/client-setinfo.json
@@ -1,0 +1,45 @@
+{
+    "SETINFO": {
+        "summary": "Sets information specific to the client or connection.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "7.2.0",
+        "arity": 4,
+        "container": "CLIENT",
+        "function": "clientSetinfoCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "command_tips": [
+          "REQUEST_POLICY:ALL_NODES",
+          "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],        
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "attr",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "token": "lib-name",
+                        "name": "libname",
+                        "type": "string"
+                    },
+                    {
+                        "token": "lib-ver",
+                        "name": "libver",
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-setname.json
+++ b/vendor/redis-7.2.6-commands/client-setname.json
@@ -1,0 +1,33 @@
+{
+    "SETNAME": {
+        "summary": "Sets the connection name.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "2.6.9",
+        "arity": 3,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "command_tips": [
+          "REQUEST_POLICY:ALL_NODES",
+          "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],        
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "arguments": [
+            {
+                "name": "connection-name",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-tracking.json
+++ b/vendor/redis-7.2.6-commands/client-tracking.json
@@ -1,0 +1,80 @@
+{
+    "TRACKING": {
+        "summary": "Controls server-assisted client-side caching for the connection.",
+        "complexity": "O(1). Some options may introduce additional complexity.",
+        "group": "connection",
+        "since": "6.0.0",
+        "arity": -3,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "arguments": [
+            {
+                "name": "status",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "on",
+                        "type": "pure-token",
+                        "token": "ON"
+                    },
+                    {
+                        "name": "off",
+                        "type": "pure-token",
+                        "token": "OFF"
+                    }
+                ]
+            },
+            {
+                "token": "REDIRECT",
+                "name": "client-id",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "token": "PREFIX",
+                "name": "prefix",
+                "type": "string",
+                "optional": true,
+                "multiple": true,
+                "multiple_token": true
+            },
+            {
+                "name": "BCAST",
+                "token": "BCAST",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "OPTIN",
+                "token": "OPTIN",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "OPTOUT",
+                "token": "OPTOUT",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "NOLOOP",
+                "token": "NOLOOP",
+                "type": "pure-token",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "if the client was successfully put into or taken out of tracking mode",
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-trackinginfo.json
+++ b/vendor/redis-7.2.6-commands/client-trackinginfo.json
@@ -1,0 +1,80 @@
+{
+    "TRACKINGINFO": {
+        "summary": "Returns information about server-assisted client-side caching for the connection.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "6.2.0",
+        "arity": 2,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "flags": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "const": "off",
+                                "description": "The connection isn't using server assisted client side caching."
+                            },
+                            {
+                                "const": "on",
+                                "description": "Server assisted client side caching is enabled for the connection."
+                            },
+                            {
+                                "const": "bcast",
+                                "description": "The client uses broadcasting mode."
+                            },
+                            {
+                                "const": "optin",
+                                "description": "The client does not cache keys by default."
+                            },
+                            {
+                                "const": "optout",
+                                "description": "The client caches keys by default."
+                            },
+                            {
+                                "const": "caching-yes",
+                                "description": "The next command will cache keys (exists only together with optin)."
+                            },
+                            {
+                                "const": "caching-no",
+                                "description": "The next command won't cache keys (exists only together with optout)."
+                            },
+                            {
+                                "const": "noloop",
+                                "description": "The client isn't notified about keys modified by itself."
+                            },
+                            {
+                                "const": "broken_redirect",
+                                "description": "The client ID used for redirection isn't valid anymore."
+                            }
+                        ]
+                    }
+                },
+                "redirect": {
+                    "type": "integer",
+                    "description": "The client ID used for notifications redirection, or -1 when none."
+                },
+                "prefixes": {
+                    "type": "array",
+                    "description": "List of key prefixes for which notifications are sent to the client.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-unblock.json
+++ b/vendor/redis-7.2.6-commands/client-unblock.json
@@ -1,0 +1,56 @@
+{
+    "UNBLOCK": {
+        "summary": "Unblocks a client blocked by a blocking command from a different connection.",
+        "complexity": "O(log N) where N is the number of client connections",
+        "group": "connection",
+        "since": "5.0.0",
+        "arity": -3,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "const": 0,
+                    "description": "if the client was unblocked successfully"
+                },
+                {
+                    "const": 1,
+                    "description": "if the client wasn't unblocked"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "client-id",
+                "type": "integer"
+            },
+            {
+                "name": "unblock-type",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "timeout",
+                        "type": "pure-token",
+                        "token": "TIMEOUT"
+                    },
+                    {
+                        "name": "error",
+                        "type": "pure-token",
+                        "token": "ERROR"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/client-unpause.json
+++ b/vendor/redis-7.2.6-commands/client-unpause.json
@@ -1,0 +1,24 @@
+{
+    "UNPAUSE": {
+        "summary": "Resumes processing commands from paused clients.",
+        "complexity": "O(N) Where N is the number of paused clients",
+        "group": "connection",
+        "since": "6.2.0",
+        "arity": 2,
+        "container": "CLIENT",
+        "function": "clientCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/client.json
+++ b/vendor/redis-7.2.6-commands/client.json
@@ -1,0 +1,12 @@
+{
+    "CLIENT": {
+        "summary": "A container for client connection commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "connection",
+        "since": "2.4.0",
+        "arity": -2,
+        "command_flags": [
+            "SENTINEL"
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-addslots.json
+++ b/vendor/redis-7.2.6-commands/cluster-addslots.json
@@ -1,0 +1,26 @@
+{
+    "ADDSLOTS": {
+        "summary": "Assigns new hash slots to a node.",
+        "complexity": "O(N) where N is the total number of hash slot arguments",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": -3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "slot",
+                "type": "integer",
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-addslotsrange.json
+++ b/vendor/redis-7.2.6-commands/cluster-addslotsrange.json
@@ -1,0 +1,36 @@
+{
+    "ADDSLOTSRANGE": {
+        "summary": "Assigns new hash slot ranges to a node.",
+        "complexity": "O(N) where N is the total number of the slots between the start slot and end slot arguments.",
+        "group": "cluster",
+        "since": "7.0.0",
+        "arity": -4,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "range",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "start-slot",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "end-slot",
+                        "type": "integer"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-bumpepoch.json
+++ b/vendor/redis-7.2.6-commands/cluster-bumpepoch.json
@@ -1,0 +1,33 @@
+{
+    "BUMPEPOCH": {
+        "summary": "Advances the cluster config epoch.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "if the epoch was incremented",
+                    "type": "string",
+                    "pattern": "^BUMPED [0-9]*$"
+                },
+                {
+                    "description": "if the node already has the greatest config epoch in the cluster",
+                    "type": "string",
+                    "pattern": "^STILL [0-9]*$"
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-count-failure-reports.json
+++ b/vendor/redis-7.2.6-commands/cluster-count-failure-reports.json
@@ -1,0 +1,29 @@
+{
+    "COUNT-FAILURE-REPORTS": {
+        "summary": "Returns the number of active failure reports active for a node.",
+        "complexity": "O(N) where N is the number of failure reports",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "ADMIN",
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "arguments": [
+            {
+                "name": "node-id",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "description": "the number of active failure reports for the node",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-countkeysinslot.json
+++ b/vendor/redis-7.2.6-commands/cluster-countkeysinslot.json
@@ -1,0 +1,25 @@
+{
+    "COUNTKEYSINSLOT": {
+        "summary": "Returns the number of keys in a hash slot.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "slot",
+                "type": "integer"
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of keys in the specified hash slot",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-delslots.json
+++ b/vendor/redis-7.2.6-commands/cluster-delslots.json
@@ -1,0 +1,26 @@
+{
+    "DELSLOTS": {
+        "summary": "Sets hash slots as unbound for a node.",
+        "complexity": "O(N) where N is the total number of hash slot arguments",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": -3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "slot",
+                "type": "integer",
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-delslotsrange.json
+++ b/vendor/redis-7.2.6-commands/cluster-delslotsrange.json
@@ -1,0 +1,36 @@
+{
+    "DELSLOTSRANGE": {
+        "summary": "Sets hash slot ranges as unbound for a node.",
+        "complexity": "O(N) where N is the total number of the slots between the start slot and end slot arguments.",
+        "group": "cluster",
+        "since": "7.0.0",
+        "arity": -4,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "range",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "start-slot",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "end-slot",
+                        "type": "integer"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-failover.json
+++ b/vendor/redis-7.2.6-commands/cluster-failover.json
@@ -1,0 +1,38 @@
+{
+    "FAILOVER": {
+        "summary": "Forces a replica to perform a manual failover of its master.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": -2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "options",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "force",
+                        "type": "pure-token",
+                        "token": "FORCE"
+                    },
+                    {
+                        "name": "takeover",
+                        "type": "pure-token",
+                        "token": "TAKEOVER"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-flushslots.json
+++ b/vendor/redis-7.2.6-commands/cluster-flushslots.json
@@ -1,0 +1,19 @@
+{
+    "FLUSHSLOTS": {
+        "summary": "Deletes all slots information from a node.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-forget.json
+++ b/vendor/redis-7.2.6-commands/cluster-forget.json
@@ -1,0 +1,25 @@
+{
+    "FORGET": {
+        "summary": "Removes a node from the nodes table.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "node-id",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-getkeysinslot.json
+++ b/vendor/redis-7.2.6-commands/cluster-getkeysinslot.json
@@ -1,0 +1,35 @@
+{
+    "GETKEYSINSLOT": {
+        "summary": "Returns the key names in a hash slot.",
+        "complexity": "O(N) where N is the number of requested keys",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 4,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "arguments": [
+            {
+                "name": "slot",
+                "type": "integer"
+            },
+            {
+                "name": "count",
+                "type": "integer"
+            }
+        ],
+        "reply_schema": {
+            "description": "an array with up to count elements",
+            "type": "array",
+            "items": {
+                "description": "key name",
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-help.json
+++ b/vendor/redis-7.2.6-commands/cluster-help.json
@@ -1,0 +1,22 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "5.0.0",
+        "arity": 2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-info.json
+++ b/vendor/redis-7.2.6-commands/cluster-info.json
@@ -1,0 +1,21 @@
+{
+    "INFO": {
+        "summary": "Returns information about the state of a node.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "description": "A map between named fields and values in the form of <field>:<value> lines separated by newlines composed by the two bytes CRLF",
+            "type": "string"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-keyslot.json
+++ b/vendor/redis-7.2.6-commands/cluster-keyslot.json
@@ -1,0 +1,25 @@
+{
+    "KEYSLOT": {
+        "summary": "Returns the hash slot for a key.",
+        "complexity": "O(N) where N is the number of bytes in the key",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "description": "The hash slot number for the specified key",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-links.json
+++ b/vendor/redis-7.2.6-commands/cluster-links.json
@@ -1,0 +1,60 @@
+{
+    "LINKS": {
+        "summary": "Returns a list of all TCP links to and from peer nodes.",
+        "complexity": "O(N) where N is the total number of Cluster nodes",
+        "group": "cluster",
+        "since": "7.0.0",
+        "arity": 2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "description": "an array of cluster links and their attributes",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "direction": {
+                        "description": "This link is established by the local node _to_ the peer, or accepted by the local node _from_ the peer.",
+                        "oneOf": [
+                            {
+                                "description": "connection initiated from peer",
+                                "const": "from"
+                            },
+                            {
+                                "description": "connection initiated to peer",
+                                "const": "to"
+                            }
+                        ]
+                    },
+                    "node": {
+                        "description": "the node id of the peer",
+                        "type": "string"
+                    },
+                    "create-time": {
+                        "description": "unix time creation time of the link. (In the case of a _to_ link, this is the time when the TCP link is created by the local node, not the time when it is actually established.)",
+                        "type": "integer"
+                    },
+                    "events": {
+                        "description": "events currently registered for the link. r means readable event, w means writable event",
+                        "type": "string"
+                    },
+                    "send-buffer-allocated": {
+                        "description": "allocated size of the link's send buffer, which is used to buffer outgoing messages toward the peer",
+                        "type": "integer"
+                    },
+                    "send-buffer-used": {
+                        "description": "size of the portion of the link's send buffer that is currently holding data(messages)",
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-meet.json
+++ b/vendor/redis-7.2.6-commands/cluster-meet.json
@@ -1,0 +1,41 @@
+{
+    "MEET": {
+        "summary": "Forces a node to handshake with another node.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": -4,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "history": [
+            [
+                "4.0.0",
+                "Added the optional `cluster_bus_port` argument."
+            ]
+        ],
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "ip",
+                "type": "string"
+            },
+            {
+                "name": "port",
+                "type": "integer"
+            },
+            {
+                "name": "cluster-bus-port",
+                "type": "integer",
+                "optional": true,
+                "since": "4.0.0"
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-myid.json
+++ b/vendor/redis-7.2.6-commands/cluster-myid.json
@@ -1,0 +1,18 @@
+{
+    "MYID": {
+        "summary": "Returns the ID of a node.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "STALE"
+        ],
+        "reply_schema": {
+            "description": "the node id",
+            "type": "string"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-myshardid.json
+++ b/vendor/redis-7.2.6-commands/cluster-myshardid.json
@@ -1,0 +1,22 @@
+{
+    "MYSHARDID": {
+        "summary": "Returns the shard ID of a node.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "7.2.0",
+        "arity": 2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "history": [],
+        "command_flags": [
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "description": "the node's shard id",
+            "type": "string"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-nodes.json
+++ b/vendor/redis-7.2.6-commands/cluster-nodes.json
@@ -1,0 +1,21 @@
+{
+    "NODES": {
+        "summary": "Returns the cluster configuration for a node.",
+        "complexity": "O(N) where N is the total number of Cluster nodes",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "description": "the serialized cluster configuration",
+            "type": "string"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-replicas.json
+++ b/vendor/redis-7.2.6-commands/cluster-replicas.json
@@ -1,0 +1,32 @@
+{
+    "REPLICAS": {
+        "summary": "Lists the replica nodes of a master node.",
+        "complexity": "O(N) where N is the number of replicas.",
+        "group": "cluster",
+        "since": "5.0.0",
+        "arity": 3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "ADMIN",
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "arguments": [
+            {
+                "name": "node-id",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "description": "a list of replica nodes replicating from the specified master node provided in the same format used by CLUSTER NODES",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "description": "the serialized cluster configuration"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-replicate.json
+++ b/vendor/redis-7.2.6-commands/cluster-replicate.json
@@ -1,0 +1,25 @@
+{
+    "REPLICATE": {
+        "summary": "Configure a node as replica of a master node.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "node-id",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-reset.json
+++ b/vendor/redis-7.2.6-commands/cluster-reset.json
@@ -1,0 +1,38 @@
+{
+    "RESET": {
+        "summary": "Resets a node.",
+        "complexity": "O(N) where N is the number of known nodes. The command may execute a FLUSHALL as a side effect.",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": -2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "ADMIN",
+            "STALE",
+            "NOSCRIPT"
+        ],
+        "arguments": [
+            {
+                "name": "reset-type",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "hard",
+                        "type": "pure-token",
+                        "token": "HARD"
+                    },
+                    {
+                        "name": "soft",
+                        "type": "pure-token",
+                        "token": "SOFT"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-saveconfig.json
+++ b/vendor/redis-7.2.6-commands/cluster-saveconfig.json
@@ -1,0 +1,19 @@
+{
+    "SAVECONFIG": {
+        "summary": "Forces a node to save the cluster configuration to disk.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-set-config-epoch.json
+++ b/vendor/redis-7.2.6-commands/cluster-set-config-epoch.json
@@ -1,0 +1,25 @@
+{
+    "SET-CONFIG-EPOCH": {
+        "summary": "Sets the configuration epoch for a new node.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "config-epoch",
+                "type": "integer"
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-setslot.json
+++ b/vendor/redis-7.2.6-commands/cluster-setslot.json
@@ -1,0 +1,54 @@
+{
+    "SETSLOT": {
+        "summary": "Binds a hash slot to a node.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": -4,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "slot",
+                "type": "integer"
+            },
+            {
+                "name": "subcommand",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "importing",
+                        "display": "node-id",
+                        "type": "string",
+                        "token": "IMPORTING"
+                    },
+                    {
+                        "name": "migrating",
+                        "display": "node-id",
+                        "type": "string",
+                        "token": "MIGRATING"
+                    },
+                    {
+                        "name": "node",
+                        "display": "node-id",
+                        "type": "string",
+                        "token": "NODE"
+                    },
+                    {
+                        "name": "stable",
+                        "type": "pure-token",
+                        "token": "STABLE"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-shards.json
+++ b/vendor/redis-7.2.6-commands/cluster-shards.json
@@ -1,0 +1,90 @@
+{
+    "SHARDS": {
+        "summary": "Returns the mapping of cluster slots to shards.",
+        "complexity": "O(N) where N is the total number of cluster nodes",
+        "group": "cluster",
+        "since": "7.0.0",
+        "arity": 2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "history": [],
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "description": "a nested list of a map of hash ranges and shard nodes describing individual shards",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "slots": {
+                        "description": "an even number element array specifying the start and end slot numbers for slot ranges owned by this shard",
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "nodes": {
+                        "description": "nodes that handle these slot ranges",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "tls-port": {
+                                    "type": "integer"
+                                },
+                                "ip": {
+                                    "type": "string"
+                                },
+                                "endpoint": {
+                                    "type": "string"
+                                },
+                                "hostname": {
+                                    "type": "string"
+                                },
+                                "role": {
+                                    "oneOf": [
+                                        {
+                                            "const": "master"
+                                        },
+                                        {
+                                            "const": "replica"
+                                        }
+                                    ]
+                                },
+                                "replication-offset": {
+                                    "type": "integer"
+                                },
+                                "health": {
+                                    "oneOf": [
+                                        {
+                                            "const": "fail"
+                                        },
+                                        {
+                                            "const": "loading"
+                                        },
+                                        {
+                                            "const": "online"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-slaves.json
+++ b/vendor/redis-7.2.6-commands/cluster-slaves.json
@@ -1,0 +1,37 @@
+{
+    "SLAVES": {
+        "summary": "Lists the replica nodes of a master node.",
+        "complexity": "O(N) where N is the number of replicas.",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "deprecated_since": "5.0.0",
+        "replaced_by": "`CLUSTER REPLICAS`",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "ADMIN",
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "arguments": [
+            {
+                "name": "node-id",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "description": "a list of replica nodes replicating from the specified master node provided in the same format used by CLUSTER NODES",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "description": "the serialized cluster configuration"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster-slots.json
+++ b/vendor/redis-7.2.6-commands/cluster-slots.json
@@ -1,0 +1,136 @@
+{
+    "SLOTS": {
+        "summary": "Returns the mapping of cluster slots to nodes.",
+        "complexity": "O(N) where N is the total number of Cluster nodes",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 2,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "deprecated_since": "7.0.0",
+        "replaced_by": "`CLUSTER SHARDS`",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "history": [
+            [
+                "4.0.0",
+                "Added node IDs."
+            ],
+            [
+                "7.0.0",
+                "Added additional networking metadata field."
+            ]
+        ],
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "description": "nested list of slot ranges with networking information",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 4294967295,
+                "items": [
+                    {
+                        "description": "start slot number",
+                        "type": "integer"
+                    },
+                    {
+                        "description": "end slot number",
+                        "type": "integer"
+                    },
+                    {
+                        "type": "array",
+                        "description": "Master node for the slot range",
+                        "minItems": 4,
+                        "maxItems": 4,
+                        "items": [
+                            {
+                                "description": "endpoint description",
+                                "oneOf": [
+                                    {
+                                        "description": "hostname or ip",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "description": "unknown type",
+                                        "type": "null"
+                                    }
+                                ]
+                            },
+                            {
+                                "description": "port",
+                                "type": "integer"
+                            },
+                            {
+                                "description": "node name",
+                                "type": "string"
+                            },
+                            {
+                                "description": "array of node descriptions",
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "hostname": {
+                                        "type": "string"
+                                    },
+                                    "ip": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "additionalItems": {
+                    "type": "array",
+                    "description": "Replica node for the slot range",
+                    "minItems": 4,
+                    "maxItems": 4,
+                    "items": [
+                        {
+                            "description": "endpoint description",
+                            "oneOf": [
+                                {
+                                    "description": "hostname or ip",
+                                    "type": "string"
+                                },
+                                {
+                                    "description": "unknown type",
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        {
+                            "description": "port",
+                            "type": "integer"
+                        },
+                        {
+                            "description": "node name",
+                            "type": "string"
+                        },
+                        {
+                            "description": "array of node descriptions",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "hostname": {
+                                    "type": "string"
+                                },
+                                "ip": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/cluster.json
+++ b/vendor/redis-7.2.6-commands/cluster.json
@@ -1,0 +1,9 @@
+{
+    "CLUSTER": {
+        "summary": "A container for Redis Cluster commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": -2
+    }
+}

--- a/vendor/redis-7.2.6-commands/command-count.json
+++ b/vendor/redis-7.2.6-commands/command-count.json
@@ -1,0 +1,23 @@
+{
+    "COUNT": {
+        "summary": "Returns a count of commands.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "2.8.13",
+        "arity": 2,
+        "container": "COMMAND",
+        "function": "commandCountCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "description": "Number of total commands in this Redis server.",
+            "type": "integer"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/command-docs.json
+++ b/vendor/redis-7.2.6-commands/command-docs.json
@@ -1,0 +1,211 @@
+{
+    "DOCS": {
+        "summary": "Returns documentary information about one, multiple or all commands.",
+        "complexity": "O(N) where N is the number of commands to look up",
+        "group": "server",
+        "since": "7.0.0",
+        "arity": -2,
+        "container": "COMMAND",
+        "function": "commandDocsCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "reply_schema": {
+            "description": "A map where each key is a command name, and each value is the documentary information",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^.*$": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "summary": {
+                            "description": "short command description",
+                            "type": "string"
+                        },
+                        "since": {
+                            "description": "the Redis version that added the command (or for module commands, the module version).",
+                            "type": "string"
+                        },
+                        "group": {
+                            "description": "the functional group to which the command belongs",
+                            "oneOf": [
+                                {
+                                    "const": "bitmap"
+                                },
+                                {
+                                    "const": "cluster"
+                                },
+                                {
+                                    "const": "connection"
+                                },
+                                {
+                                    "const": "generic"
+                                },
+                                {
+                                    "const": "geo"
+                                },
+                                {
+                                    "const": "hash"
+                                },
+                                {
+                                    "const": "hyperloglog"
+                                },
+                                {
+                                    "const": "list"
+                                },
+                                {
+                                    "const": "module"
+                                },
+                                {
+                                    "const": "pubsub"
+                                },
+                                {
+                                    "const": "scripting"
+                                },
+                                {
+                                    "const": "sentinel"
+                                },
+                                {
+                                    "const": "server"
+                                },
+                                {
+                                    "const": "set"
+                                },
+                                {
+                                    "const": "sorted-set"
+                                },
+                                {
+                                    "const": "stream"
+                                },
+                                {
+                                    "const": "string"
+                                },
+                                {
+                                    "const": "transactions"
+                                }
+                            ]
+                        },
+                        "complexity": {
+                            "description": "a short explanation about the command's time complexity.",
+                            "type": "string"
+                        },
+                        "module": {
+                            "type": "string"
+                        },
+                        "doc_flags": {
+                            "description": "an array of documentation flags",
+                            "type": "array",
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "description": "the command is deprecated.",
+                                        "const": "deprecated"
+                                    },
+                                    {
+                                        "description": "a system command that isn't meant to be called by users.",
+                                        "const": "syscmd"
+                                    }
+                                ]
+                            }
+                        },
+                        "deprecated_since": {
+                            "description": "the Redis version that deprecated the command (or for module commands, the module version)",
+                            "type": "string"
+                        },
+                        "replaced_by": {
+                            "description": "the alternative for a deprecated command.",
+                            "type": "string"
+                        },
+                        "history": {
+                            "description": "an array of historical notes describing changes to the command's behavior or arguments.",
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": [
+                                    {
+                                        "type": "string",
+                                        "description": "The Redis version that the entry applies to."
+                                    },
+                                    {
+                                        "type": "string",
+                                        "description": "The description of the change."
+                                    }
+                                ]
+                            }
+                        },
+                        "arguments": {
+                            "description": "an array of maps that describe the command's arguments.",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string"
+                                    },
+                                    "display_text": {
+                                        "type": "string"
+                                    },
+                                    "key_spec_index": {
+                                        "type": "integer"
+                                    },
+                                    "token": {
+                                        "type": "string"
+                                    },
+                                    "summary": {
+                                        "type": "string"
+                                    },
+                                    "since": {
+                                        "type": "string"
+                                    },
+                                    "deprecated_since": {
+                                        "type": "string"
+                                    },
+                                    "flags": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "arguments": {
+                                        "type": "array"
+                                    }
+                                }
+                            }
+                        },
+                        "reply_schema": {
+                            "description": "command reply schema",
+                            "type": "object"
+                        },
+                        "subcommands": {
+                            "description": "A map where each key is a subcommand, and each value is the documentary information",
+                            "$ref": "#"
+                        }
+                    }
+                }
+            }
+        },
+        "arguments": [
+            {
+                "name": "command-name",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/command-getkeys.json
+++ b/vendor/redis-7.2.6-commands/command-getkeys.json
@@ -1,0 +1,39 @@
+{
+    "GETKEYS": {
+        "summary": "Extracts the key names from an arbitrary command.",
+        "complexity": "O(N) where N is the number of arguments to the command",
+        "group": "server",
+        "since": "2.8.13",
+        "arity": -3,
+        "container": "COMMAND",
+        "function": "commandGetKeysCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "description": "List of keys from the given Redis command.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "arguments": [
+            {
+                "name": "command",
+                "type": "string"
+            },
+            {
+                "name": "arg",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/command-getkeysandflags.json
+++ b/vendor/redis-7.2.6-commands/command-getkeysandflags.json
@@ -1,0 +1,55 @@
+{
+    "GETKEYSANDFLAGS": {
+        "summary": "Extracts the key names and access flags for an arbitrary command.",
+        "complexity": "O(N) where N is the number of arguments to the command",
+        "group": "server",
+        "since": "7.0.0",
+        "arity": -3,
+        "container": "COMMAND",
+        "function": "commandGetKeysAndFlagsCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "description": "List of keys from the given Redis command and their usage flags.",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "items": [
+                    {
+                        "description": "Key name",
+                        "type": "string"
+                    },
+                    {
+                        "description": "Set of key flags",
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "command",
+                "type": "string"
+            },
+            {
+                "name": "arg",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/command-help.json
+++ b/vendor/redis-7.2.6-commands/command-help.json
@@ -1,0 +1,26 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "5.0.0",
+        "arity": 2,
+        "container": "COMMAND",
+        "function": "commandHelpCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/command-info.json
+++ b/vendor/redis-7.2.6-commands/command-info.json
@@ -1,0 +1,213 @@
+{
+    "INFO": {
+        "summary": "Returns information about one, multiple or all commands.",
+        "complexity": "O(N) where N is the number of commands to look up",
+        "group": "server",
+        "since": "2.8.13",
+        "arity": -2,
+        "container": "COMMAND",
+        "function": "commandInfoCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Allowed to be called with no argument to get info on all commands."
+            ]
+        ],
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "arguments": [
+            {
+                "name": "command-name",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "command does not exist",
+                        "type": "null"
+                    },
+                    {
+                        "description": "command info array output",
+                        "type": "array",
+                        "minItems": 10,
+                        "maxItems": 10,
+                        "items": [
+                            {
+                                "description": "command name",
+                                "type": "string"
+                            },
+                            {
+                                "description": "command arity",
+                                "type": "integer"
+                            },
+                            {
+                                "description": "command flags",
+                                "type": "array",
+                                "items": {
+                                    "description": "command flag",
+                                    "type": "string"
+                                }
+                            },
+                            {
+                                "description": "command first key index",
+                                "type": "integer"
+                            },
+                            {
+                                "description": "command last key index",
+                                "type": "integer"
+                            },
+                            {
+                                "description": "command key step index",
+                                "type": "integer"
+                            },
+                            {
+                                "description": "command categories",
+                                "type": "array",
+                                "items": {
+                                    "description": "command category",
+                                    "type": "string"
+                                }
+                            },
+                            {
+                                "description": "command tips",
+                                "type": "array",
+                                "items": {
+                                    "description": "command tip",
+                                    "type": "string"
+                                }
+                            },
+                            {
+                                "description": "command key specs",
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "notes": {
+                                            "type": "string"
+                                        },
+                                        "flags": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "begin_search": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string"
+                                                },
+                                                "spec": {
+                                                    "anyOf": [
+                                                        {
+                                                            "description": "unknown type, empty map",
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        {
+                                                            "description": "index type",
+                                                            "type": "object",
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "index": {
+                                                                    "type": "integer"
+                                                                }
+                                                            }
+                                                        },
+                                                        {
+                                                            "description": "keyword type",
+                                                            "type": "object",
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "keyword": {
+                                                                    "type": "string"
+                                                                },
+                                                                "startfrom": {
+                                                                    "type": "integer"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "find_keys": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string"
+                                                },
+                                                "spec": {
+                                                    "anyOf": [
+                                                        {
+                                                            "description": "unknown type",
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        {
+                                                            "description": "range type",
+                                                            "type": "object",
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lastkey": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "keystep": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "limit": {
+                                                                    "type": "integer"
+                                                                }
+                                                            }
+                                                        },
+                                                        {
+                                                            "description": "keynum type",
+                                                            "type": "object",
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "keynumidx": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "firstkey": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "keystep": {
+                                                                    "type": "integer"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "type": "array",
+                                "description": "subcommands"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/command-list.json
+++ b/vendor/redis-7.2.6-commands/command-list.json
@@ -1,0 +1,55 @@
+{
+    "LIST": {
+        "summary": "Returns a list of command names.",
+        "complexity": "O(N) where N is the total number of Redis commands",
+        "group": "server",
+        "since": "7.0.0",
+        "arity": -2,
+        "container": "COMMAND",
+        "function": "commandListCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "arguments": [
+            {
+                "name": "filterby",
+                "token": "FILTERBY",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "module-name",
+                        "type": "string",
+                        "token": "MODULE"
+                    },
+                    {
+                        "name": "category",
+                        "type": "string",
+                        "token": "ACLCAT"
+                    },
+                    {
+                        "name": "pattern",
+                        "type": "pattern",
+                        "token": "PATTERN"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "items": {
+                "description": "command name",
+                "type": "string"
+            },
+            "uniqueItems": true
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/command.json
+++ b/vendor/redis-7.2.6-commands/command.json
@@ -1,0 +1,21 @@
+{
+    "COMMAND": {
+        "summary": "Returns detailed information about all commands.",
+        "complexity": "O(N) where N is the total number of Redis commands",
+        "group": "server",
+        "since": "2.8.13",
+        "arity": -1,
+        "function": "commandCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/config-get.json
+++ b/vendor/redis-7.2.6-commands/config-get.json
@@ -1,0 +1,36 @@
+{
+    "GET": {
+        "summary": "Returns the effective values of configuration parameters.",
+        "complexity": "O(N) when N is the number of configuration parameters provided",
+        "group": "server",
+        "since": "2.0.0",
+        "arity": -3,
+        "container": "CONFIG",
+        "function": "configGetCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added the ability to pass multiple pattern parameters in one call"
+            ]
+        ],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "reply_schema": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "arguments": [
+            {
+                "name": "parameter",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/config-help.json
+++ b/vendor/redis-7.2.6-commands/config-help.json
@@ -1,0 +1,22 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "5.0.0",
+        "arity": 2,
+        "container": "CONFIG",
+        "function": "configHelpCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/config-resetstat.json
+++ b/vendor/redis-7.2.6-commands/config-resetstat.json
@@ -1,0 +1,24 @@
+{
+    "RESETSTAT": {
+        "summary": "Resets the server's statistics.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "2.0.0",
+        "arity": 2,
+        "container": "CONFIG",
+        "function": "configResetStatCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+          "REQUEST_POLICY:ALL_NODES",
+          "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/config-rewrite.json
+++ b/vendor/redis-7.2.6-commands/config-rewrite.json
@@ -1,0 +1,24 @@
+{
+    "REWRITE": {
+        "summary": "Persists the effective configuration to file.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "2.8.0",
+        "arity": 2,
+        "container": "CONFIG",
+        "function": "configRewriteCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+          "REQUEST_POLICY:ALL_NODES",
+          "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/config-set.json
+++ b/vendor/redis-7.2.6-commands/config-set.json
@@ -1,0 +1,47 @@
+{
+    "SET": {
+        "summary": "Sets configuration parameters in-flight.",
+        "complexity": "O(N) when N is the number of configuration parameters provided",
+        "group": "server",
+        "since": "2.0.0",
+        "arity": -4,
+        "container": "CONFIG",
+        "function": "configSetCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added the ability to set multiple parameters in one call."
+            ]
+        ],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "parameter",
+                        "type": "string"
+                    },
+                    {
+                        "name": "value",
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/config.json
+++ b/vendor/redis-7.2.6-commands/config.json
@@ -1,0 +1,9 @@
+{
+    "CONFIG": {
+        "summary": "A container for server configuration commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "server",
+        "since": "2.0.0",
+        "arity": -2
+    }
+}

--- a/vendor/redis-7.2.6-commands/copy.json
+++ b/vendor/redis-7.2.6-commands/copy.json
@@ -1,0 +1,91 @@
+{
+    "COPY": {
+        "summary": "Copies the value of a key to a new key.",
+        "complexity": "O(N) worst case for collections, where N is the number of nested items. O(1) for string values.",
+        "group": "generic",
+        "since": "6.2.0",
+        "arity": -3,
+        "function": "copyCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "source",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 1
+            },
+            {
+                "token": "DB",
+                "name": "destination-db",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "name": "replace",
+                "token": "REPLACE",
+                "type": "pure-token",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "source was copied",
+                    "const": 1
+                },
+                {
+                    "description": "source was not copied",
+                    "const": 0
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/dbsize.json
+++ b/vendor/redis-7.2.6-commands/dbsize.json
@@ -1,0 +1,25 @@
+{
+    "DBSIZE": {
+        "summary": "Returns the number of keys in the database.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": 1,
+        "function": "dbsizeCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:AGG_SUM"
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "The number of keys in the currently-selected database."
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/debug.json
+++ b/vendor/redis-7.2.6-commands/debug.json
@@ -1,0 +1,20 @@
+{
+    "DEBUG": {
+        "summary": "A container for debugging commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "debugCommand",
+        "doc_flags": [
+            "SYSCMD"
+        ],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "PROTECTED"
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/decr.json
+++ b/vendor/redis-7.2.6-commands/decr.json
@@ -1,0 +1,50 @@
+{
+    "DECR": {
+        "summary": "Decrements the integer value of a key by one. Uses 0 as initial value if the key doesn't exist.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "1.0.0",
+        "arity": 2,
+        "function": "decrCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "The value of the key after decrementing it."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/decrby.json
+++ b/vendor/redis-7.2.6-commands/decrby.json
@@ -1,0 +1,54 @@
+{
+    "DECRBY": {
+        "summary": "Decrements a number from the integer value of a key. Uses 0 as initial value if the key doesn't exist.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "1.0.0",
+        "arity": 3,
+        "function": "decrbyCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "The value of the key after decrementing it."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "decrement",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/del.json
+++ b/vendor/redis-7.2.6-commands/del.json
@@ -1,0 +1,53 @@
+{
+    "DEL": {
+        "summary": "Deletes one or more keys.",
+        "complexity": "O(N) where N is the number of keys that will be removed. When a key to remove holds a value other than a string, the individual complexity for this key is O(M) where M is the number of elements in the list, set, sorted set or hash. Removing a single key that holds a string value is O(1).",
+        "group": "generic",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "delCommand",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:MULTI_SHARD",
+            "RESPONSE_POLICY:AGG_SUM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RM",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "the number of keys that were removed",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/discard.json
+++ b/vendor/redis-7.2.6-commands/discard.json
@@ -1,0 +1,23 @@
+{
+    "DISCARD": {
+        "summary": "Discards a transaction.",
+        "complexity": "O(N), when N is the number of queued commands",
+        "group": "transactions",
+        "since": "2.0.0",
+        "arity": 1,
+        "function": "discardCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "FAST",
+            "ALLOW_BUSY"
+        ],
+        "acl_categories": [
+            "TRANSACTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/dump.json
+++ b/vendor/redis-7.2.6-commands/dump.json
@@ -1,0 +1,58 @@
+{
+    "DUMP": {
+        "summary": "Returns a serialized representation of the value stored at a key.",
+        "complexity": "O(1) to access the key and additional O(N*M) to serialize it, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1).",
+        "group": "generic",
+        "since": "2.6.0",
+        "arity": 2,
+        "function": "dumpCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The serialized value.",
+                    "type": "string"
+                },
+                {
+                    "description": "Key does not exist.",
+                    "type": "null"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/echo.json
+++ b/vendor/redis-7.2.6-commands/echo.json
@@ -1,0 +1,28 @@
+{
+    "ECHO": {
+        "summary": "Returns the given string.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "1.0.0",
+        "arity": 2,
+        "function": "echoCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "description": "The given string",
+            "type": "string"
+        },
+        "arguments": [
+            {
+                "name": "message",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/eval.json
+++ b/vendor/redis-7.2.6-commands/eval.json
@@ -1,0 +1,69 @@
+{
+    "EVAL": {
+        "summary": "Executes a server-side Lua script.",
+        "complexity": "Depends on the script that is executed.",
+        "group": "scripting",
+        "since": "2.6.0",
+        "arity": -3,
+        "function": "evalCommand",
+        "get_keys_function": "evalGetKeys",
+        "command_flags": [
+            "NOSCRIPT",
+            "SKIP_MONITOR",
+            "MAY_REPLICATE",
+            "NO_MANDATORY_KEYS",
+            "STALE"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "key_specs": [
+            {
+                "notes": "We cannot tell how the keys will be used so we assume the worst, RW and UPDATE",
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "script",
+                "type": "string"
+            },
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "optional": true,
+                "multiple": true
+            },
+            {
+                "name": "arg",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "Return value depends on the script that is executed"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/eval_ro.json
+++ b/vendor/redis-7.2.6-commands/eval_ro.json
@@ -1,0 +1,68 @@
+{
+    "EVAL_RO": {
+        "summary": "Executes a read-only server-side Lua script.",
+        "complexity": "Depends on the script that is executed.",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": -3,
+        "function": "evalRoCommand",
+        "get_keys_function": "evalGetKeys",
+        "command_flags": [
+            "NOSCRIPT",
+            "SKIP_MONITOR",
+            "NO_MANDATORY_KEYS",
+            "STALE",
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "key_specs": [
+            {
+                "notes": "We cannot tell how the keys will be used so we assume the worst, RO and ACCESS",
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "script",
+                "type": "string"
+            },
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "optional":true,
+                "multiple": true
+            },
+            {
+                "name": "arg",
+                "type": "string",
+                "optional":true,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "Return value depends on the script that is executed"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/evalsha.json
+++ b/vendor/redis-7.2.6-commands/evalsha.json
@@ -1,0 +1,68 @@
+{
+    "EVALSHA": {
+        "summary": "Executes a server-side Lua script by SHA1 digest.",
+        "complexity": "Depends on the script that is executed.",
+        "group": "scripting",
+        "since": "2.6.0",
+        "arity": -3,
+        "function": "evalShaCommand",
+        "get_keys_function": "evalGetKeys",
+        "command_flags": [
+            "NOSCRIPT",
+            "SKIP_MONITOR",
+            "MAY_REPLICATE",
+            "NO_MANDATORY_KEYS",
+            "STALE"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "sha1",
+                "type": "string"
+            },
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "optional": true,
+                "multiple": true
+            },
+            {
+                "name": "arg",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "Return value depends on the script that is executed"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/evalsha_ro.json
+++ b/vendor/redis-7.2.6-commands/evalsha_ro.json
@@ -1,0 +1,67 @@
+{
+    "EVALSHA_RO": {
+        "summary": "Executes a read-only server-side Lua script by SHA1 digest.",
+        "complexity": "Depends on the script that is executed.",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": -3,
+        "function": "evalShaRoCommand",
+        "get_keys_function": "evalGetKeys",
+        "command_flags": [
+            "NOSCRIPT",
+            "SKIP_MONITOR",
+            "NO_MANDATORY_KEYS",
+            "STALE",
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "sha1",
+                "type": "string"
+            },
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "optional":true,
+                "multiple": true
+            },
+            {
+                "name": "arg",
+                "type": "string",
+                "optional":true,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "Return value depends on the script that is executed"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/exec.json
+++ b/vendor/redis-7.2.6-commands/exec.json
@@ -1,0 +1,31 @@
+{
+    "EXEC": {
+        "summary": "Executes all commands in a transaction.",
+        "complexity": "Depends on commands in the transaction",
+        "group": "transactions",
+        "since": "1.2.0",
+        "arity": 1,
+        "function": "execCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SKIP_SLOWLOG"
+        ],
+        "acl_categories": [
+            "TRANSACTION"
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Each element being the reply to each of the commands in the atomic transaction.",
+                    "type": "array"
+                },
+                {
+                    "description": "The transaction was aborted because a `WATCH`ed key was touched",
+                    "type": "null"
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/exists.json
+++ b/vendor/redis-7.2.6-commands/exists.json
@@ -1,0 +1,58 @@
+{
+    "EXISTS": {
+        "summary": "Determines whether one or more keys exist.",
+        "complexity": "O(N) where N is the number of keys to check.",
+        "group": "generic",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "existsCommand",
+        "history": [
+            [
+                "3.0.3",
+                "Accepts multiple `key` arguments."
+            ]
+        ],
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:MULTI_SHARD",
+            "RESPONSE_POLICY:AGG_SUM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of keys that exist from those specified as arguments.",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/expire.json
+++ b/vendor/redis-7.2.6-commands/expire.json
@@ -1,0 +1,94 @@
+{
+    "EXPIRE": {
+        "summary": "Sets the expiration time of a key in seconds.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "1.0.0",
+        "arity": -3,
+        "function": "expireCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added options: `NX`, `XX`, `GT` and `LT`."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.",
+                    "const": 0
+                },
+                {
+                    "description": "The timeout was set.",
+                    "const": 1
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "seconds",
+                "type": "integer"
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "since": "7.0.0",
+                "arguments": [
+                    {
+                        "name": "nx",
+                        "type": "pure-token",
+                        "token": "NX"
+                    },
+                    {
+                        "name": "xx",
+                        "type": "pure-token",
+                        "token": "XX"
+                    },
+                    {
+                        "name": "gt",
+                        "type": "pure-token",
+                        "token": "GT"
+                    },
+                    {
+                        "name": "lt",
+                        "type": "pure-token",
+                        "token": "LT"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/expireat.json
+++ b/vendor/redis-7.2.6-commands/expireat.json
@@ -1,0 +1,94 @@
+{
+    "EXPIREAT": {
+        "summary": "Sets the expiration time of a key to a Unix timestamp.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "1.2.0",
+        "arity": -3,
+        "function": "expireatCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added options: `NX`, `XX`, `GT` and `LT`."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "const": 1,
+                    "description": "The timeout was set."
+                },
+                {
+                    "const": 0,
+                    "description": "The timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "unix-time-seconds",
+                "type": "unix-time"
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "since": "7.0.0",
+                "arguments": [
+                    {
+                        "name": "nx",
+                        "type": "pure-token",
+                        "token": "NX"
+                    },
+                    {
+                        "name": "xx",
+                        "type": "pure-token",
+                        "token": "XX"
+                    },
+                    {
+                        "name": "gt",
+                        "type": "pure-token",
+                        "token": "GT"
+                    },
+                    {
+                        "name": "lt",
+                        "type": "pure-token",
+                        "token": "LT"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/expiretime.json
+++ b/vendor/redis-7.2.6-commands/expiretime.json
@@ -1,0 +1,61 @@
+{
+    "EXPIRETIME": {
+        "summary": "Returns the expiration time of a key as a Unix timestamp.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "7.0.0",
+        "arity": 2,
+        "function": "expiretimeCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "integer",
+                    "description": "Expiration Unix timestamp in seconds.",
+                    "minimum": 0
+                },
+                {
+                    "const": -1,
+                    "description": "The key exists but has no associated expiration time."
+                },
+                {
+                    "const": -2,
+                    "description": "The key does not exist."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/failover.json
+++ b/vendor/redis-7.2.6-commands/failover.json
@@ -1,0 +1,54 @@
+{
+    "FAILOVER": {
+        "summary": "Starts a coordinated failover from a server to one of its replicas.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "6.2.0",
+        "arity": -1,
+        "function": "failoverCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "STALE"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "target",
+                "token": "TO",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "host",
+                        "type": "string"
+                    },
+                    {
+                        "name": "port",
+                        "type": "integer"
+                    },
+                    {
+                        "token": "FORCE",
+                        "name": "force",
+                        "type": "pure-token",
+                        "optional": true
+                    }
+                ]
+            },
+            {
+                "token": "ABORT",
+                "name": "abort",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "token": "TIMEOUT",
+                "name": "milliseconds",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/fcall.json
+++ b/vendor/redis-7.2.6-commands/fcall.json
@@ -1,0 +1,69 @@
+{
+    "FCALL": {
+        "summary": "Invokes a function.",
+        "complexity": "Depends on the function that is executed.",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": -3,
+        "function": "fcallCommand",
+        "get_keys_function": "functionGetKeys",
+        "command_flags": [
+            "NOSCRIPT",
+            "SKIP_MONITOR",
+            "MAY_REPLICATE",
+            "NO_MANDATORY_KEYS",
+            "STALE"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "key_specs": [
+            {
+                "notes": "We cannot tell how the keys will be used so we assume the worst, RW and UPDATE",
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "function",
+                "type": "string"
+            },
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "optional": true,
+                "multiple": true
+            },
+            {
+                "name": "arg",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "Return value depends on the function that is executed"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/fcall_ro.json
+++ b/vendor/redis-7.2.6-commands/fcall_ro.json
@@ -1,0 +1,68 @@
+{
+    "FCALL_RO": {
+        "summary": "Invokes a read-only function.",
+        "complexity": "Depends on the function that is executed.",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": -3,
+        "function": "fcallroCommand",
+        "get_keys_function": "functionGetKeys",
+        "command_flags": [
+            "NOSCRIPT",
+            "SKIP_MONITOR",
+            "NO_MANDATORY_KEYS",
+            "STALE",
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "key_specs": [
+            {
+                "notes": "We cannot tell how the keys will be used so we assume the worst, RO and ACCESS",
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "function",
+                "type": "string"
+            },
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "optional": true,
+                "multiple": true
+            },
+            {
+                "name": "arg",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "Return value depends on the function that is executed"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/flushall.json
+++ b/vendor/redis-7.2.6-commands/flushall.json
@@ -1,0 +1,55 @@
+{
+    "FLUSHALL": {
+        "summary": "Removes all keys from all databases.",
+        "complexity": "O(N) where N is the total number of keys in all databases",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": -1,
+        "function": "flushallCommand",
+        "history": [
+            [
+                "4.0.0",
+                "Added the `ASYNC` flushing mode modifier."
+            ],
+            [
+                "6.2.0",
+                "Added the `SYNC` flushing mode modifier."
+            ]
+        ],
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "KEYSPACE",
+            "DANGEROUS"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "flush-type",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "async",
+                        "type": "pure-token",
+                        "token": "ASYNC",
+                        "since": "4.0.0"
+                    },
+                    {
+                        "name": "sync",
+                        "type": "pure-token",
+                        "token": "SYNC",
+                        "since": "6.2.0"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/flushdb.json
+++ b/vendor/redis-7.2.6-commands/flushdb.json
@@ -1,0 +1,55 @@
+{
+    "FLUSHDB": {
+        "summary": "Remove all keys from the current database.",
+        "complexity": "O(N) where N is the number of keys in the selected database",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": -1,
+        "function": "flushdbCommand",
+        "history": [
+            [
+                "4.0.0",
+                "Added the `ASYNC` flushing mode modifier."
+            ],
+            [
+                "6.2.0",
+                "Added the `SYNC` flushing mode modifier."
+            ]
+        ],
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "KEYSPACE",
+            "DANGEROUS"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "flush-type",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "async",
+                        "type": "pure-token",
+                        "token": "ASYNC",
+                        "since": "4.0.0"
+                    },
+                    {
+                        "name": "sync",
+                        "type": "pure-token",
+                        "token": "SYNC",
+                        "since": "6.2.0"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/function-delete.json
+++ b/vendor/redis-7.2.6-commands/function-delete.json
@@ -1,0 +1,31 @@
+{
+    "DELETE": {
+        "summary": "Deletes a library and its functions.",
+        "complexity": "O(1)",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": 3,
+        "container": "FUNCTION",
+        "function": "functionDeleteCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "WRITE"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "arguments": [
+            {
+                "name": "library-name",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/function-dump.json
+++ b/vendor/redis-7.2.6-commands/function-dump.json
@@ -1,0 +1,21 @@
+{
+    "DUMP": {
+        "summary": "Dumps all libraries into a serialized binary payload.",
+        "complexity": "O(N) where N is the number of functions",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": 2,
+        "container": "FUNCTION",
+        "function": "functionDumpCommand",
+        "command_flags": [
+            "NOSCRIPT"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "reply_schema": {
+            "description": "the serialized payload",
+            "type": "string"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/function-flush.json
+++ b/vendor/redis-7.2.6-commands/function-flush.json
@@ -1,0 +1,44 @@
+{
+    "FLUSH": {
+        "summary": "Deletes all libraries and functions.",
+        "complexity": "O(N) where N is the number of functions deleted",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": -2,
+        "container": "FUNCTION",
+        "function": "functionFlushCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "WRITE"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "arguments": [
+            {
+                "name": "flush-type",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "async",
+                        "type": "pure-token",
+                        "token": "ASYNC"
+                    },
+                    {
+                        "name": "sync",
+                        "type": "pure-token",
+                        "token": "SYNC"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/function-help.json
+++ b/vendor/redis-7.2.6-commands/function-help.json
@@ -1,0 +1,25 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": 2,
+        "container": "FUNCTION",
+        "function": "functionHelpCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/function-kill.json
+++ b/vendor/redis-7.2.6-commands/function-kill.json
@@ -1,0 +1,25 @@
+{
+    "KILL": {
+        "summary": "Terminates a function during execution.",
+        "complexity": "O(1)",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": 2,
+        "container": "FUNCTION",
+        "function": "functionKillCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "ALLOW_BUSY"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:ONE_SUCCEEDED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/function-list.json
+++ b/vendor/redis-7.2.6-commands/function-list.json
@@ -1,0 +1,87 @@
+{
+    "LIST": {
+        "summary": "Returns information about all libraries.",
+        "complexity": "O(N) where N is the number of functions",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": -2,
+        "container": "FUNCTION",
+        "function": "functionListCommand",
+        "command_flags": [
+            "NOSCRIPT"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "library_name": {
+                        "description": " the name of the library",
+                        "type": "string"
+                    },
+                    "engine": {
+                        "description": "the engine of the library",
+                        "type": "string"
+                    },
+                    "functions": {
+                        "description": "the list of functions in the library",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "name": {
+                                    "description": "the name of the function",
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "description": "the function's description",
+                                    "oneOf": [
+                                        {
+                                            "type": "null"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "flags": {
+                                    "description": "an array of function flags",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "library_code": {
+                        "description": "the library's source code (when given the WITHCODE modifier)",
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "arguments": [
+            {
+                "name": "library-name-pattern",
+                "type": "string",
+                "token": "LIBRARYNAME",
+                "optional": true
+            },
+            {
+                "name": "withcode",
+                "type": "pure-token",
+                "token": "WITHCODE",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/function-load.json
+++ b/vendor/redis-7.2.6-commands/function-load.json
@@ -1,0 +1,39 @@
+{
+    "LOAD": {
+        "summary": "Creates a library.",
+        "complexity": "O(1) (considering compilation time is redundant)",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": -3,
+        "container": "FUNCTION",
+        "function": "functionLoadCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "arguments": [
+            {
+                "name": "replace",
+                "type": "pure-token",
+                "token": "REPLACE",
+                "optional": true
+            },
+            {
+                "name": "function-code",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "description": "The library name that was loaded",
+            "type": "string"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/function-restore.json
+++ b/vendor/redis-7.2.6-commands/function-restore.json
@@ -1,0 +1,54 @@
+{
+    "RESTORE": {
+        "summary": "Restores all libraries from a payload.",
+        "complexity": "O(N) where N is the number of functions on the payload",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": -3,
+        "container": "FUNCTION",
+        "function": "functionRestoreCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "arguments": [
+            {
+                "name": "serialized-value",
+                "type": "string"
+            },
+            {
+                "name": "policy",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "flush",
+                        "type": "pure-token",
+                        "token": "FLUSH"
+                    },
+                    {
+                        "name": "append",
+                        "type": "pure-token",
+                        "token": "APPEND"
+                    },
+                    {
+                        "name": "replace",
+                        "type": "pure-token",
+                        "token": "REPLACE"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/function-stats.json
+++ b/vendor/redis-7.2.6-commands/function-stats.json
@@ -1,0 +1,81 @@
+{
+    "STATS": {
+        "summary": "Returns information about a function during execution.",
+        "complexity": "O(1)",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": 2,
+        "container": "FUNCTION",
+        "function": "functionStatsCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "ALLOW_BUSY"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
+        "reply_schema": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "running_script": {
+                    "description": "information about the running script.",
+                    "oneOf": [
+                        {
+                            "description": "If there's no in-flight function",
+                            "type": "null"
+                        },
+                        {
+                            "description": "a map with the information about the running script",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "name": {
+                                    "description": "the name of the function.",
+                                    "type": "string"
+                                },
+                                "command": {
+                                    "description": "the command and arguments used for invoking the function.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "duration_ms": {
+                                    "description": "the function's runtime duration in milliseconds.",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "engines": {
+                    "description": "A map when each entry in the map represent a single engine.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^.*$": {
+                            "description": "Engine map contains statistics about the engine",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "libraries_count": {
+                                    "description": "number of libraries",
+                                    "type": "integer"
+                                },
+                                "functions_count": {
+                                    "description": "number of functions",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/function.json
+++ b/vendor/redis-7.2.6-commands/function.json
@@ -1,0 +1,9 @@
+{
+    "FUNCTION": {
+        "summary": "A container for function commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "scripting",
+        "since": "7.0.0",
+        "arity": -2
+    }
+}

--- a/vendor/redis-7.2.6-commands/geoadd.json
+++ b/vendor/redis-7.2.6-commands/geoadd.json
@@ -1,0 +1,98 @@
+{
+    "GEOADD": {
+        "summary": "Adds one or more members to a geospatial index. The key is created if it doesn't exist.",
+        "complexity": "O(log(N)) for each item added, where N is the number of elements in the sorted set.",
+        "group": "geo",
+        "since": "3.2.0",
+        "arity": -5,
+        "function": "geoaddCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added the `CH`, `NX` and `XX` options."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "GEO"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "since": "6.2.0",
+                "arguments": [
+                    {
+                        "name": "nx",
+                        "type": "pure-token",
+                        "token": "NX"
+                    },
+                    {
+                        "name": "xx",
+                        "type": "pure-token",
+                        "token": "XX"
+                    }
+                ]
+            },
+            {
+                "name": "change",
+                "token": "CH",
+                "type": "pure-token",
+                "optional": true,
+                "since": "6.2.0"
+            },
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "longitude",
+                        "type": "double"
+                    },
+                    {
+                        "name": "latitude",
+                        "type": "double"
+                    },
+                    {
+                        "name": "member",
+                        "type": "string"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "description": "When used without optional arguments, the number of elements added to the sorted set (excluding score updates).  If the CH option is specified, the number of elements that were changed (added or updated).",
+            "type": "integer"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/geodist.json
+++ b/vendor/redis-7.2.6-commands/geodist.json
@@ -1,0 +1,91 @@
+{
+    "GEODIST": {
+        "summary": "Returns the distance between two members of a geospatial index.",
+        "complexity": "O(1)",
+        "group": "geo",
+        "since": "3.2.0",
+        "arity": -4,
+        "function": "geodistCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "GEO"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member1",
+                "type": "string"
+            },
+            {
+                "name": "member2",
+                "type": "string"
+            },
+            {
+                "name": "unit",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "m",
+                        "type": "pure-token",
+                        "token": "m"
+                    },
+                    {
+                        "name": "km",
+                        "type": "pure-token",
+                        "token": "km"
+                    },
+                    {
+                        "name": "ft",
+                        "type": "pure-token",
+                        "token": "ft"
+                    },
+                    {
+                        "name": "mi",
+                        "type": "pure-token",
+                        "token": "mi"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "one or both of elements are missing",
+                    "type": "null"
+                },
+                {
+                    "description": "distance as a double (represented as a string) in the specified units",
+                    "type": "string",
+                    "pattern": "^[0-9]*(.[0-9]*)?$"
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/geohash.json
+++ b/vendor/redis-7.2.6-commands/geohash.json
@@ -1,0 +1,56 @@
+{
+    "GEOHASH": {
+        "summary": "Returns members from a geospatial index as geohash strings.",
+        "complexity": "O(1) for each member requested.",
+        "group": "geo",
+        "since": "3.2.0",
+        "arity": -2,
+        "function": "geohashCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "GEO"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string",
+                "multiple": true,
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "An array where each element is the Geohash corresponding to each member name passed as argument to the command.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/geopos.json
+++ b/vendor/redis-7.2.6-commands/geopos.json
@@ -1,0 +1,76 @@
+{
+    "GEOPOS": {
+        "summary": "Returns the longitude and latitude of members from a geospatial index.",
+        "complexity": "O(1) for each member requested.",
+        "group": "geo",
+        "since": "3.2.0",
+        "arity": -2,
+        "function": "geoposCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "GEO"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string",
+                "multiple": true,
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "An array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command",
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "Element does not exist",
+                        "type": "null"
+                    },
+                    {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "description": "Latitude (x)",
+                                "type": "number"
+                            },
+                            {
+                                "description": "Longitude (y)",
+                                "type": "number"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/georadius.json
+++ b/vendor/redis-7.2.6-commands/georadius.json
@@ -1,0 +1,270 @@
+{
+    "GEORADIUS": {
+        "summary": "Queries a geospatial index for members within a distance from a coordinate, optionally stores the result.",
+        "complexity": "O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.",
+        "group": "geo",
+        "since": "3.2.0",
+        "arity": -6,
+        "function": "georadiusCommand",
+        "get_keys_function": "georadiusGetKeys",
+        "history": [
+            [
+                "6.2.0",
+                "Added the `ANY` option for `COUNT`."
+            ],
+            [
+                "7.0.0",
+                "Added support for uppercase unit names."
+            ]
+        ],
+        "deprecated_since": "6.2.0",
+        "replaced_by": "`GEOSEARCH` and `GEOSEARCHSTORE` with the `BYRADIUS` argument",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "GEO"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "keyword": {
+                        "keyword": "STORE",
+                        "startfrom": 6
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "keyword": {
+                        "keyword": "STOREDIST",
+                        "startfrom": 6
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "longitude",
+                "type": "double"
+            },
+            {
+                "name": "latitude",
+                "type": "double"
+            },
+            {
+                "name": "radius",
+                "type": "double"
+            },
+            {
+                "name": "unit",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "m",
+                        "type": "pure-token",
+                        "token": "m"
+                    },
+                    {
+                        "name": "km",
+                        "type": "pure-token",
+                        "token": "km"
+                    },
+                    {
+                        "name": "ft",
+                        "type": "pure-token",
+                        "token": "ft"
+                    },
+                    {
+                        "name": "mi",
+                        "type": "pure-token",
+                        "token": "mi"
+                    }
+                ]
+            },
+            {
+                "name": "withcoord",
+                "token": "WITHCOORD",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "withdist",
+                "token": "WITHDIST",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "withhash",
+                "token": "WITHHASH",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "count-block",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "COUNT",
+                        "name": "count",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "any",
+                        "token": "ANY",
+                        "type": "pure-token",
+                        "optional": true,
+                        "since": "6.2.0"
+                    }
+                ]
+            },
+            {
+                "name": "order",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "asc",
+                        "type": "pure-token",
+                        "token": "ASC"
+                    },
+                    {
+                        "name": "desc",
+                        "type": "pure-token",
+                        "token": "DESC"
+                    }
+                ]
+            },
+            {
+                "name": "store",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "STORE",
+                        "name": "storekey",
+                        "display": "key",
+                        "type": "key",
+                        "key_spec_index": 1
+                    },
+                    {
+                        "token": "STOREDIST",
+                        "name": "storedistkey",
+                        "display": "key",
+                        "type": "key",
+                        "key_spec_index": 2
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "description": "Array of matched members information",
+            "anyOf": [
+                {
+                    "description": "If no WITH* option is specified, array of matched members names",
+                    "type": "array",
+                    "items": {
+                        "description": "name",
+                        "type": "string"
+                    }
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 4,
+                        "items": [
+                            {
+                                "description": "Matched member name",
+                                "type": "string"
+                            }
+                        ],
+                        "additionalItems": {
+                            "oneOf": [
+                                {
+                                    "description": "If WITHDIST option is specified, the distance from the center as a floating point number, in the same unit specified in the radius",
+                                    "type": "string"
+                                },
+                                {
+                                    "description": "If WITHHASH option is specified, the geohash integer",
+                                    "type": "integer"
+                                },
+                                {
+                                    "description": "If WITHCOORD option is specified, the coordinates as a two items x,y array (longitude,latitude)",
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": [
+                                        {
+                                            "description": "latitude (x)",
+                                            "type": "number"
+                                        },
+                                        {
+                                            "description": "longitude (y)",
+                                            "type": "number"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "description": "number of items stored in key",
+                    "type": "integer"
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/georadius_ro.json
+++ b/vendor/redis-7.2.6-commands/georadius_ro.json
@@ -1,0 +1,201 @@
+{
+    "GEORADIUS_RO": {
+        "summary": "Returns members from a geospatial index that are within a distance from a coordinate.",
+        "complexity": "O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.",
+        "group": "geo",
+        "since": "3.2.10",
+        "arity": -6,
+        "function": "georadiusroCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added the `ANY` option for `COUNT`."
+            ]
+        ],
+        "deprecated_since": "6.2.0",
+        "replaced_by": "`GEOSEARCH` with the `BYRADIUS` argument",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "GEO"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "longitude",
+                "type": "double"
+            },
+            {
+                "name": "latitude",
+                "type": "double"
+            },
+            {
+                "name": "radius",
+                "type": "double"
+            },
+            {
+                "name": "unit",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "m",
+                        "type": "pure-token",
+                        "token": "m"
+                    },
+                    {
+                        "name": "km",
+                        "type": "pure-token",
+                        "token": "km"
+                    },
+                    {
+                        "name": "ft",
+                        "type": "pure-token",
+                        "token": "ft"
+                    },
+                    {
+                        "name": "mi",
+                        "type": "pure-token",
+                        "token": "mi"
+                    }
+                ]
+            },
+            {
+                "name": "withcoord",
+                "token": "WITHCOORD",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "withdist",
+                "token": "WITHDIST",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "withhash",
+                "token": "WITHHASH",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "count-block",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "COUNT",
+                        "name": "count",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "any",
+                        "token": "ANY",
+                        "type": "pure-token",
+                        "optional": true,
+                        "since": "6.2.0"
+                    }
+                ]
+            },
+            {
+                "name": "order",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "asc",
+                        "type": "pure-token",
+                        "token": "ASC"
+                    },
+                    {
+                        "name": "desc",
+                        "type": "pure-token",
+                        "token": "DESC"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "description": "Array of matched members information",
+            "anyOf": [
+                {
+                    "description": "If no WITH* option is specified, array of matched members names",
+                    "type": "array",
+                    "items": {
+                        "description": "name",
+                        "type": "string"
+                    }
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 4,
+                        "items": [
+                            {
+                                "description": "Matched member name",
+                                "type": "string"
+                            }
+                        ],
+                        "additionalItems": {
+                            "oneOf": [
+                                {
+                                    "description": "If WITHDIST option is specified, the distance from the center as a floating point number, in the same unit specified in the radius",
+                                    "type": "string"
+                                },
+                                {
+                                    "description": "If WITHHASH option is specified, the geohash integer",
+                                    "type": "integer"
+                                },
+                                {
+                                    "description": "If WITHCOORD option is specified, the coordinates as a two items x,y array (longitude,latitude)",
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": [
+                                        {
+                                            "description": "latitude (x)",
+                                            "type": "number"
+                                        },
+                                        {
+                                            "description": "longitude (y)",
+                                            "type": "number"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/georadiusbymember.json
+++ b/vendor/redis-7.2.6-commands/georadiusbymember.json
@@ -1,0 +1,261 @@
+{
+    "GEORADIUSBYMEMBER": {
+        "summary": "Queries a geospatial index for members within a distance from a member, optionally stores the result.",
+        "complexity": "O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.",
+        "group": "geo",
+        "since": "3.2.0",
+        "arity": -5,
+        "function": "georadiusbymemberCommand",
+        "get_keys_function": "georadiusGetKeys",
+        "history": [
+            [
+                "7.0.0",
+                "Added support for uppercase unit names."
+            ]
+        ],
+        "deprecated_since": "6.2.0",
+        "replaced_by": "`GEOSEARCH` and `GEOSEARCHSTORE` with the `BYRADIUS` and `FROMMEMBER` arguments",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "GEO"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "keyword": {
+                        "keyword": "STORE",
+                        "startfrom": 5
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "keyword": {
+                        "keyword": "STOREDIST",
+                        "startfrom": 5
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string"
+            },
+            {
+                "name": "radius",
+                "type": "double"
+            },
+            {
+                "name": "unit",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "m",
+                        "type": "pure-token",
+                        "token": "m"
+                    },
+                    {
+                        "name": "km",
+                        "type": "pure-token",
+                        "token": "km"
+                    },
+                    {
+                        "name": "ft",
+                        "type": "pure-token",
+                        "token": "ft"
+                    },
+                    {
+                        "name": "mi",
+                        "type": "pure-token",
+                        "token": "mi"
+                    }
+                ]
+            },
+            {
+                "name": "withcoord",
+                "token": "WITHCOORD",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "withdist",
+                "token": "WITHDIST",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "withhash",
+                "token": "WITHHASH",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "count-block",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "COUNT",
+                        "name": "count",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "any",
+                        "token": "ANY",
+                        "type": "pure-token",
+                        "optional": true
+                    }
+                ]
+            },
+            {
+                "name": "order",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "asc",
+                        "type": "pure-token",
+                        "token": "ASC"
+                    },
+                    {
+                        "name": "desc",
+                        "type": "pure-token",
+                        "token": "DESC"
+                    }
+                ]
+            },
+            {
+                "name": "store",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "STORE",
+                        "name": "storekey",
+                        "display": "key",
+                        "type": "key",
+                        "key_spec_index": 1
+                    },
+                    {
+                        "token": "STOREDIST",
+                        "name": "storedistkey",
+                        "display": "key",
+                        "type": "key",
+                        "key_spec_index": 2
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "description": "Array of matched members information",
+            "anyOf": [
+                {
+                    "description": "If no WITH* option is specified, array of matched members names",
+                    "type": "array",
+                    "items": {
+                        "description": "name",
+                        "type": "string"
+                    }
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 4,
+                        "items": [
+                            {
+                                "description": "Matched member name",
+                                "type": "string"
+                            }
+                        ],
+                        "additionalItems": {
+                            "oneOf": [
+                                {
+                                    "description": "If WITHDIST option is specified, the distance from the center as a floating point number, in the same unit specified in the radius",
+                                    "type": "string"
+                                },
+                                {
+                                    "description": "If WITHHASH option is specified, the geohash integer",
+                                    "type": "integer"
+                                },
+                                {
+                                    "description": "If WITHCOORD option is specified, the coordinates as a two items x,y array (longitude,latitude)",
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": [
+                                        {
+                                            "description": "latitude (x)",
+                                            "type": "number"
+                                        },
+                                        {
+                                            "description": "longitude (y)",
+                                            "type": "number"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "description": "number of items stored in key",
+                    "type": "integer"
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/georadiusbymember_ro.json
+++ b/vendor/redis-7.2.6-commands/georadiusbymember_ro.json
@@ -1,0 +1,190 @@
+{
+    "GEORADIUSBYMEMBER_RO": {
+        "summary": "Returns members from a geospatial index that are within a distance from a member.",
+        "complexity": "O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.",
+        "group": "geo",
+        "since": "3.2.10",
+        "arity": -5,
+        "function": "georadiusbymemberroCommand",
+        "deprecated_since": "6.2.0",
+        "replaced_by": "`GEOSEARCH` with the `BYRADIUS` and `FROMMEMBER` arguments",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "GEO"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string"
+            },
+            {
+                "name": "radius",
+                "type": "double"
+            },
+            {
+                "name": "unit",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "m",
+                        "type": "pure-token",
+                        "token": "m"
+                    },
+                    {
+                        "name": "km",
+                        "type": "pure-token",
+                        "token": "km"
+                    },
+                    {
+                        "name": "ft",
+                        "type": "pure-token",
+                        "token": "ft"
+                    },
+                    {
+                        "name": "mi",
+                        "type": "pure-token",
+                        "token": "mi"
+                    }
+                ]
+            },
+            {
+                "name": "withcoord",
+                "token": "WITHCOORD",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "withdist",
+                "token": "WITHDIST",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "withhash",
+                "token": "WITHHASH",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "count-block",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "COUNT",
+                        "name": "count",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "any",
+                        "token": "ANY",
+                        "type": "pure-token",
+                        "optional": true
+                    }
+                ]
+            },
+            {
+                "name": "order",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "asc",
+                        "type": "pure-token",
+                        "token": "ASC"
+                    },
+                    {
+                        "name": "desc",
+                        "type": "pure-token",
+                        "token": "DESC"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "description": "Array of matched members information",
+            "anyOf": [
+                {
+                    "description": "If no WITH* option is specified, array of matched members names",
+                    "type": "array",
+                    "items": {
+                        "description": "name",
+                        "type": "string"
+                    }
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 4,
+                        "items": [
+                            {
+                                "description": "Matched member name",
+                                "type": "string"
+                            }
+                        ],
+                        "additionalItems": {
+                            "oneOf": [
+                                {
+                                    "description": "If WITHDIST option is specified, the distance from the center as a floating point number, in the same unit specified in the radius",
+                                    "type": "string"
+                                },
+                                {
+                                    "description": "If WITHHASH option is specified, the geohash integer",
+                                    "type": "integer"
+                                },
+                                {
+                                    "description": "If WITHCOORD option is specified, the coordinates as a two items x,y array (longitude,latitude)",
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": [
+                                        {
+                                            "description": "latitude (x)",
+                                            "type": "number"
+                                        },
+                                        {
+                                            "description": "longitude (y)",
+                                            "type": "number"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/geosearch.json
+++ b/vendor/redis-7.2.6-commands/geosearch.json
@@ -1,0 +1,267 @@
+{
+    "GEOSEARCH": {
+        "summary": "Queries a geospatial index for members inside an area of a box or a circle.",
+        "complexity": "O(N+log(M)) where N is the number of elements in the grid-aligned bounding box area around the shape provided as the filter and M is the number of items inside the shape",
+        "group": "geo",
+        "since": "6.2.0",
+        "arity": -7,
+        "function": "geosearchCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added support for uppercase unit names."
+            ]
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "GEO"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "from",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "token": "FROMMEMBER",
+                        "name": "member",
+                        "type": "string"
+                    },
+                    {
+                        "token": "FROMLONLAT",
+                        "name": "fromlonlat",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "longitude",
+                                "type": "double"
+                            },
+                            {
+                                "name": "latitude",
+                                "type": "double"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "by",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "circle",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "token": "BYRADIUS",
+                                "name": "radius",
+                                "type": "double"
+                            },
+                            {
+                                "name": "unit",
+                                "type": "oneof",
+                                "arguments": [
+                                    {
+                                        "name": "m",
+                                        "type": "pure-token",
+                                        "token": "m"
+                                    },
+                                    {
+                                        "name": "km",
+                                        "type": "pure-token",
+                                        "token": "km"
+                                    },
+                                    {
+                                        "name": "ft",
+                                        "type": "pure-token",
+                                        "token": "ft"
+                                    },
+                                    {
+                                        "name": "mi",
+                                        "type": "pure-token",
+                                        "token": "mi"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "name": "box",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "token": "BYBOX",
+                                "name": "width",
+                                "type": "double"
+                            },
+                            {
+                                "name": "height",
+                                "type": "double"
+                            },
+                            {
+                                "name": "unit",
+                                "type": "oneof",
+                                "arguments": [
+                                    {
+                                        "name": "m",
+                                        "type": "pure-token",
+                                        "token": "m"
+                                    },
+                                    {
+                                        "name": "km",
+                                        "type": "pure-token",
+                                        "token": "km"
+                                    },
+                                    {
+                                        "name": "ft",
+                                        "type": "pure-token",
+                                        "token": "ft"
+                                    },
+                                    {
+                                        "name": "mi",
+                                        "type": "pure-token",
+                                        "token": "mi"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "order",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "asc",
+                        "type": "pure-token",
+                        "token": "ASC"
+                    },
+                    {
+                        "name": "desc",
+                        "type": "pure-token",
+                        "token": "DESC"
+                    }
+                ]
+            },
+            {
+                "name": "count-block",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "COUNT",
+                        "name": "count",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "any",
+                        "token": "ANY",
+                        "type": "pure-token",
+                        "optional": true
+                    }
+                ]
+            },
+            {
+                "name": "withcoord",
+                "token": "WITHCOORD",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "withdist",
+                "token": "WITHDIST",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "withhash",
+                "token": "WITHHASH",
+                "type": "pure-token",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "Array of matched members information",
+            "anyOf": [
+                {
+                    "description": "If no WITH* option is specified, array of matched members names",
+                    "type": "array",
+                    "items": {
+                        "description": "name",
+                        "type": "string"
+                    }
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 4,
+                        "items": [
+                            {
+                                "description": "Matched member name",
+                                "type": "string"
+                            }
+                        ],
+                        "additionalItems": {
+                            "oneOf": [
+                                {
+                                    "description": "If WITHDIST option is specified, the distance from the center as a floating point number, in the same unit specified in the radius",
+                                    "type": "string"
+                                },
+                                {
+                                    "description": "If WITHHASH option is specified, the geohash integer",
+                                    "type": "integer"
+                                },
+                                {
+                                    "description": "If WITHCOORD option is specified, the coordinates as a two items x,y array (longitude,latitude)",
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": [
+                                        {
+                                            "description": "latitude (x)",
+                                            "type": "number"
+                                        },
+                                        {
+                                            "description": "longitude (y)",
+                                            "type": "number"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/geosearchstore.json
+++ b/vendor/redis-7.2.6-commands/geosearchstore.json
@@ -1,0 +1,228 @@
+{
+    "GEOSEARCHSTORE": {
+        "summary": "Queries a geospatial index for members inside an area of a box or a circle, optionally stores the result.",
+        "complexity": "O(N+log(M)) where N is the number of elements in the grid-aligned bounding box area around the shape provided as the filter and M is the number of items inside the shape",
+        "group": "geo",
+        "since": "6.2.0",
+        "arity": -8,
+        "function": "geosearchstoreCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added support for uppercase unit names."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "GEO"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "source",
+                "type": "key",
+                "key_spec_index": 1
+            },
+            {
+                "name": "from",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "token": "FROMMEMBER",
+                        "name": "member",
+                        "type": "string"
+                    },
+                    {
+                        "token": "FROMLONLAT",
+                        "name": "fromlonlat",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "longitude",
+                                "type": "double"
+                            },
+                            {
+                                "name": "latitude",
+                                "type": "double"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "by",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "circle",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "token": "BYRADIUS",
+                                "name": "radius",
+                                "type": "double"
+                            },
+                            {
+                                "name": "unit",
+                                "type": "oneof",
+                                "arguments": [
+                                    {
+                                        "name": "m",
+                                        "type": "pure-token",
+                                        "token": "m"
+                                    },
+                                    {
+                                        "name": "km",
+                                        "type": "pure-token",
+                                        "token": "km"
+                                    },
+                                    {
+                                        "name": "ft",
+                                        "type": "pure-token",
+                                        "token": "ft"
+                                    },
+                                    {
+                                        "name": "mi",
+                                        "type": "pure-token",
+                                        "token": "mi"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "name": "box",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "token": "BYBOX",
+                                "name": "width",
+                                "type": "double"
+                            },
+                            {
+                                "name": "height",
+                                "type": "double"
+                            },
+                            {
+                                "name": "unit",
+                                "type": "oneof",
+                                "arguments": [
+                                    {
+                                        "name": "m",
+                                        "type": "pure-token",
+                                        "token": "m"
+                                    },
+                                    {
+                                        "name": "km",
+                                        "type": "pure-token",
+                                        "token": "km"
+                                    },
+                                    {
+                                        "name": "ft",
+                                        "type": "pure-token",
+                                        "token": "ft"
+                                    },
+                                    {
+                                        "name": "mi",
+                                        "type": "pure-token",
+                                        "token": "mi"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "order",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "asc",
+                        "type": "pure-token",
+                        "token": "ASC"
+                    },
+                    {
+                        "name": "desc",
+                        "type": "pure-token",
+                        "token": "DESC"
+                    }
+                ]
+            },
+            {
+                "name": "count-block",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "COUNT",
+                        "name": "count",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "any",
+                        "token": "ANY",
+                        "type": "pure-token",
+                        "optional": true
+                    }
+                ]
+            },
+            {
+                "name": "storedist",
+                "token": "STOREDIST",
+                "type": "pure-token",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "the number of elements in the resulting set",
+            "type": "integer"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/get.json
+++ b/vendor/redis-7.2.6-commands/get.json
@@ -1,0 +1,56 @@
+{
+    "GET": {
+        "summary": "Returns the string value of a key.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "1.0.0",
+        "arity": 2,
+        "function": "getCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The value of the key.",
+                    "type": "string"
+                },
+                {
+                    "description": "Key does not exist.",
+                    "type": "null"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/getbit.json
+++ b/vendor/redis-7.2.6-commands/getbit.json
@@ -1,0 +1,59 @@
+{
+    "GETBIT": {
+        "summary": "Returns a bit value by offset.",
+        "complexity": "O(1)",
+        "group": "bitmap",
+        "since": "2.2.0",
+        "arity": 3,
+        "function": "getbitCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "BITMAP"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The bit value stored at offset.",
+            "oneOf": [
+                {
+                    "const": 0
+                },
+                {
+                    "const": 1
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "offset",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/getdel.json
+++ b/vendor/redis-7.2.6-commands/getdel.json
@@ -1,0 +1,57 @@
+{
+    "GETDEL": {
+        "summary": "Returns the string value of a key after deleting the key.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "6.2.0",
+        "arity": 2,
+        "function": "getdelCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The value of the key.",
+                    "type": "string"
+                },
+                {
+                    "description": "The key does not exist.",
+                    "type": "null"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/getex.json
+++ b/vendor/redis-7.2.6-commands/getex.json
@@ -1,0 +1,90 @@
+{
+    "GETEX": {
+        "summary": "Returns the string value of a key after setting its expiration time.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "6.2.0",
+        "arity": -2,
+        "function": "getexCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "notes": "RW and UPDATE because it changes the TTL",
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The value of the key.",
+                    "type": "string"
+                },
+                {
+                    "description": "Key does not exist.",
+                    "type": "null"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "expiration",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "seconds",
+                        "type": "integer",
+                        "token": "EX"
+                    },
+                    {
+                        "name": "milliseconds",
+                        "type": "integer",
+                        "token": "PX"
+                    },
+                    {
+                        "name": "unix-time-seconds",
+                        "type": "unix-time",
+                        "token": "EXAT"
+                    },
+                    {
+                        "name": "unix-time-milliseconds",
+                        "type": "unix-time",
+                        "token": "PXAT"
+                    },
+                    {
+                        "name": "persist",
+                        "type": "pure-token",
+                        "token": "PERSIST"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/getrange.json
+++ b/vendor/redis-7.2.6-commands/getrange.json
@@ -1,0 +1,55 @@
+{
+    "GETRANGE": {
+        "summary": "Returns a substring of the string stored at a key.",
+        "complexity": "O(N) where N is the length of the returned string. The complexity is ultimately determined by the returned length, but because creating a substring from an existing string is very cheap, it can be considered O(1) for small strings.",
+        "group": "string",
+        "since": "2.4.0",
+        "arity": 4,
+        "function": "getrangeCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "string",
+            "description": "The substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer"
+            },
+            {
+                "name": "end",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/getset.json
+++ b/vendor/redis-7.2.6-commands/getset.json
@@ -1,0 +1,67 @@
+{
+    "GETSET": {
+        "summary": "Returns the previous string value of a key after setting it to a new value.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "1.0.0",
+        "arity": 3,
+        "function": "getsetCommand",
+        "deprecated_since": "6.2.0",
+        "replaced_by": "`SET` with the `!GET` argument",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The old value stored at the key.",
+                    "type": "string"
+                },
+                {
+                    "description": "The key does not exist.",
+                    "type": "null"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hdel.json
+++ b/vendor/redis-7.2.6-commands/hdel.json
@@ -1,0 +1,59 @@
+{
+    "HDEL": {
+        "summary": "Deletes one or more fields and their values from a hash. Deletes the hash if no fields remain.",
+        "complexity": "O(N) where N is the number of fields to be removed.",
+        "group": "hash",
+        "since": "2.0.0",
+        "arity": -3,
+        "function": "hdelCommand",
+        "history": [
+            [
+                "2.4.0",
+                "Accepts multiple `field` arguments."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "The number of fields that were removed from the hash."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "field",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hello.json
+++ b/vendor/redis-7.2.6-commands/hello.json
@@ -1,0 +1,111 @@
+{
+    "HELLO": {
+        "summary": "Handshakes with the Redis server.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "6.0.0",
+        "arity": -1,
+        "function": "helloCommand",
+        "history": [
+            [
+                "6.2.0",
+                "`protover` made optional; when called without arguments the command reports the current connection's context."
+            ]
+        ],
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "FAST",
+            "NO_AUTH",
+            "SENTINEL",
+            "ALLOW_BUSY"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "server": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "proto": {
+                    "const": 3
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "mode": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "modules": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "ver": {
+                                "type": "integer"
+                            },
+                            "path": {
+                                "type": "string"
+                            },
+                            "args": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "arguments": [
+            {
+                "name": "arguments",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "protover",
+                        "type": "integer"
+                    },
+                    {
+                        "token": "AUTH",
+                        "name": "auth",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                            {
+                                "name": "username",
+                                "type": "string"
+                            },
+                            {
+                                "name": "password",
+                                "type": "string"
+                            }
+                        ]
+                    },
+                    {
+                        "token": "SETNAME",
+                        "name": "clientname",
+                        "type": "string",
+                        "optional": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hexists.json
+++ b/vendor/redis-7.2.6-commands/hexists.json
@@ -1,0 +1,59 @@
+{
+    "HEXISTS": {
+        "summary": "Determines whether a field exists in a hash.",
+        "complexity": "O(1)",
+        "group": "hash",
+        "since": "2.0.0",
+        "arity": 3,
+        "function": "hexistsCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The hash does not contain the field, or key does not exist.",
+                    "const": 0
+                },
+                {
+                    "description": "The hash contains the field.",
+                    "const": 1
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "field",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hget.json
+++ b/vendor/redis-7.2.6-commands/hget.json
@@ -1,0 +1,60 @@
+{
+    "HGET": {
+        "summary": "Returns the value of a field in a hash.",
+        "complexity": "O(1)",
+        "group": "hash",
+        "since": "2.0.0",
+        "arity": 3,
+        "function": "hgetCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The value associated with the field.",
+                    "type": "string"
+                },
+                {
+                    "description": "If the field is not present in the hash or key does not exist.",
+                    "type": "null"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "field",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hgetall.json
+++ b/vendor/redis-7.2.6-commands/hgetall.json
@@ -1,0 +1,53 @@
+{
+    "HGETALL": {
+        "summary": "Returns all fields and values in a hash.",
+        "complexity": "O(N) where N is the size of the hash.",
+        "group": "hash",
+        "since": "2.0.0",
+        "arity": 2,
+        "function": "hgetallCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "object",
+            "description": "Map of fields and their values stored in the hash, or an empty list when key does not exist. In RESP2 this is returned as a flat array.",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hincrby.json
+++ b/vendor/redis-7.2.6-commands/hincrby.json
@@ -1,0 +1,58 @@
+{
+    "HINCRBY": {
+        "summary": "Increments the integer value of a field in a hash by a number. Uses 0 as initial value if the field doesn't exist.",
+        "complexity": "O(1)",
+        "group": "hash",
+        "since": "2.0.0",
+        "arity": 4,
+        "function": "hincrbyCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "The value of the field after the increment operation."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "field",
+                "type": "string"
+            },
+            {
+                "name": "increment",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hincrbyfloat.json
+++ b/vendor/redis-7.2.6-commands/hincrbyfloat.json
@@ -1,0 +1,58 @@
+{
+    "HINCRBYFLOAT": {
+        "summary": "Increments the floating point value of a field by a number. Uses 0 as initial value if the field doesn't exist.",
+        "complexity": "O(1)",
+        "group": "hash",
+        "since": "2.6.0",
+        "arity": 4,
+        "function": "hincrbyfloatCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "string",
+            "description": "The value of the field after the increment operation."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "field",
+                "type": "string"
+            },
+            {
+                "name": "increment",
+                "type": "double"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hkeys.json
+++ b/vendor/redis-7.2.6-commands/hkeys.json
@@ -1,0 +1,54 @@
+{
+    "HKEYS": {
+        "summary": "Returns all fields in a hash.",
+        "complexity": "O(N) where N is the size of the hash.",
+        "group": "hash",
+        "since": "2.0.0",
+        "arity": 2,
+        "function": "hkeysCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List of fields in the hash, or an empty list when the key does not exist.",
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hlen.json
+++ b/vendor/redis-7.2.6-commands/hlen.json
@@ -1,0 +1,47 @@
+{
+    "HLEN": {
+        "summary": "Returns the number of fields in a hash.",
+        "complexity": "O(1)",
+        "group": "hash",
+        "since": "2.0.0",
+        "arity": 2,
+        "function": "hlenCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "Number of the fields in the hash, or 0 when the key does not exist."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hmget.json
+++ b/vendor/redis-7.2.6-commands/hmget.json
@@ -1,0 +1,64 @@
+{
+    "HMGET": {
+        "summary": "Returns the values of all fields in a hash.",
+        "complexity": "O(N) where N is the number of fields being requested.",
+        "group": "hash",
+        "since": "2.0.0",
+        "arity": -3,
+        "function": "hmgetCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "List of values associated with the given fields, in the same order as they are requested.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "null"
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "field",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hmset.json
+++ b/vendor/redis-7.2.6-commands/hmset.json
@@ -1,0 +1,68 @@
+{
+    "HMSET": {
+        "summary": "Sets the values of multiple fields.",
+        "complexity": "O(N) where N is the number of fields being set.",
+        "group": "hash",
+        "since": "2.0.0",
+        "arity": -4,
+        "function": "hsetCommand",
+        "deprecated_since": "4.0.0",
+        "replaced_by": "`HSET` with multiple field-value pairs",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "field",
+                        "type": "string"
+                    },
+                    {
+                        "name": "value",
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hrandfield.json
+++ b/vendor/redis-7.2.6-commands/hrandfield.json
@@ -1,0 +1,101 @@
+{
+    "HRANDFIELD": {
+        "summary": "Returns one or more random fields from a hash.",
+        "complexity": "O(N) where N is the number of fields returned",
+        "group": "hash",
+        "since": "6.2.0",
+        "arity": -2,
+        "function": "hrandfieldCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "description": "Key doesn't exist",
+                    "type": "null"
+                },
+                {
+                    "description": "A single random field. Returned in case `COUNT` was not used.",
+                    "type": "string"
+                },
+                {
+                    "description": "A list of fields. Returned in case `COUNT` was used.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "description": "Fields and their values. Returned in case `COUNT` and `WITHVALUES` were used. In RESP2 this is returned as a flat array.",
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "description": "Field",
+                                "type": "string"
+                            },
+                            {
+                                "description": "Value",
+                                "type": "string"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "options",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "withvalues",
+                        "token": "WITHVALUES",
+                        "type": "pure-token",
+                        "optional": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hscan.json
+++ b/vendor/redis-7.2.6-commands/hscan.json
@@ -1,0 +1,81 @@
+{
+    "HSCAN": {
+        "summary": "Iterates over fields and values of a hash.",
+        "complexity": "O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.",
+        "group": "hash",
+        "since": "2.8.0",
+        "arity": -3,
+        "function": "hscanCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "cursor",
+                "type": "integer"
+            },
+            {
+                "token": "MATCH",
+                "name": "pattern",
+                "type": "pattern",
+                "optional": true
+            },
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "cursor and scan response in array form",
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": [
+                {
+                    "description": "cursor",
+                    "type": "string"
+                },
+                {
+                    "description": "list of key/value pairs from the hash where each even element is the key, and each odd element is the value",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/hset.json
+++ b/vendor/redis-7.2.6-commands/hset.json
@@ -1,0 +1,70 @@
+{
+    "HSET": {
+        "summary": "Creates or modifies the value of a field in a hash.",
+        "complexity": "O(1) for each field/value pair added, so O(N) to add N field/value pairs when the command is called with multiple field/value pairs.",
+        "group": "hash",
+        "since": "2.0.0",
+        "arity": -4,
+        "function": "hsetCommand",
+        "history": [
+            [
+                "4.0.0",
+                "Accepts multiple `field` and `value` arguments."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of fields that were added",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "field",
+                        "type": "string"
+                    },
+                    {
+                        "name": "value",
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hsetnx.json
+++ b/vendor/redis-7.2.6-commands/hsetnx.json
@@ -1,0 +1,65 @@
+{
+    "HSETNX": {
+        "summary": "Sets the value of a field in a hash only when the field doesn't exist.",
+        "complexity": "O(1)",
+        "group": "hash",
+        "since": "2.0.0",
+        "arity": 4,
+        "function": "hsetnxCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The field is a new field in the hash and value was set.",
+                    "const": 0
+                },
+                {
+                    "description": "The field already exists in the hash and no operation was performed.",
+                    "const": 1
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "field",
+                "type": "string"
+            },
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hstrlen.json
+++ b/vendor/redis-7.2.6-commands/hstrlen.json
@@ -1,0 +1,52 @@
+{
+    "HSTRLEN": {
+        "summary": "Returns the length of the value of a field.",
+        "complexity": "O(1)",
+        "group": "hash",
+        "since": "3.2.0",
+        "arity": 3,
+        "function": "hstrlenCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "String length of the value associated with the field, or zero when the field is not present in the hash or key does not exist at all.",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "field",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/hvals.json
+++ b/vendor/redis-7.2.6-commands/hvals.json
@@ -1,0 +1,53 @@
+{
+    "HVALS": {
+        "summary": "Returns all values in a hash.",
+        "complexity": "O(N) where N is the size of the hash.",
+        "group": "hash",
+        "since": "2.0.0",
+        "arity": 2,
+        "function": "hvalsCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "HASH"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List of values in the hash, or an empty list when the key does not exist.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/incr.json
+++ b/vendor/redis-7.2.6-commands/incr.json
@@ -1,0 +1,50 @@
+{
+    "INCR": {
+        "summary": "Increments the integer value of a key by one. Uses 0 as initial value if the key doesn't exist.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "1.0.0",
+        "arity": 2,
+        "function": "incrCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "reply_schema": {
+            "description": "The value of key after the increment",
+            "type": "integer"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/incrby.json
+++ b/vendor/redis-7.2.6-commands/incrby.json
@@ -1,0 +1,54 @@
+{
+    "INCRBY": {
+        "summary": "Increments the integer value of a key by a number. Uses 0 as initial value if the key doesn't exist.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "1.0.0",
+        "arity": 3,
+        "function": "incrbyCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "The value of the key after incrementing it."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "increment",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/incrbyfloat.json
+++ b/vendor/redis-7.2.6-commands/incrbyfloat.json
@@ -1,0 +1,54 @@
+{
+    "INCRBYFLOAT": {
+        "summary": "Increment the floating point value of a key by a number. Uses 0 as initial value if the key doesn't exist.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "2.6.0",
+        "arity": 3,
+        "function": "incrbyfloatCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "string",
+            "description": "The value of the key after incrementing it."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "increment",
+                "type": "double"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/info.json
+++ b/vendor/redis-7.2.6-commands/info.json
@@ -1,0 +1,41 @@
+{
+    "INFO": {
+        "summary": "Returns information and statistics about the server.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": -1,
+        "function": "infoCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added support for taking multiple section arguments."
+            ]
+        ],
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "DANGEROUS"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
+        "reply_schema": {
+            "description": "A map of info fields, one field per line in the form of <field>:<value> where the value can be a comma separated map like <key>=<val>. Also contains section header lines starting with `#` and blank lines.",
+            "type": "string"
+        },
+        "arguments": [
+            {
+                "name": "section",
+                "type": "string",
+                "multiple": true,
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/keys.json
+++ b/vendor/redis-7.2.6-commands/keys.json
@@ -1,0 +1,34 @@
+{
+    "KEYS": {
+        "summary": "Returns all key names that match a pattern.",
+        "complexity": "O(N) with N being the number of keys in the database, under the assumption that the key names in the database and the given pattern have limited length.",
+        "group": "generic",
+        "since": "1.0.0",
+        "arity": 2,
+        "function": "keysCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "KEYSPACE",
+            "DANGEROUS"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "arguments": [
+            {
+                "name": "pattern",
+                "type": "pattern"
+            }
+        ],
+        "reply_schema": {
+            "description": "list of keys matching pattern",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/lastsave.json
+++ b/vendor/redis-7.2.6-commands/lastsave.json
@@ -1,0 +1,26 @@
+{
+    "LASTSAVE": {
+        "summary": "Returns the Unix timestamp of the last successful save to disk.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": 1,
+        "function": "lastsaveCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "FAST"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS"
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "UNIX TIME of the last DB save executed with success."
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/latency-doctor.json
+++ b/vendor/redis-7.2.6-commands/latency-doctor.json
@@ -1,0 +1,26 @@
+{
+    "DOCTOR": {
+        "summary": "Returns a human-readable latency analysis report.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "2.8.13",
+        "arity": 2,
+        "container": "LATENCY",
+        "function": "latencyCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
+        "reply_schema": {
+            "type": "string",
+            "description": "A human readable latency analysis report."
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/latency-graph.json
+++ b/vendor/redis-7.2.6-commands/latency-graph.json
@@ -1,0 +1,32 @@
+{
+    "GRAPH": {
+        "summary": "Returns a latency graph for an event.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "2.8.13",
+        "arity": 3,
+        "container": "LATENCY",
+        "function": "latencyCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
+        "arguments": [
+            {
+                "name": "event",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "type": "string",
+            "description": "Latency graph"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/latency-help.json
+++ b/vendor/redis-7.2.6-commands/latency-help.json
@@ -1,0 +1,22 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "2.8.13",
+        "arity": 2,
+        "container": "LATENCY",
+        "function": "latencyCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/latency-histogram.json
+++ b/vendor/redis-7.2.6-commands/latency-histogram.json
@@ -1,0 +1,54 @@
+{
+    "HISTOGRAM": {
+        "summary": "Returns the cumulative distribution of latencies of a subset or all commands.",
+        "complexity": "O(N) where N is the number of commands with latency information being retrieved.",
+        "group": "server",
+        "since": "7.0.0",
+        "arity": -2,
+        "container": "LATENCY",
+        "function": "latencyCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
+        "reply_schema": {
+            "type": "object",
+            "description": "A map where each key is a command name, and each value is a map with the total calls, and an inner map of the histogram time buckets.",
+            "patternProperties": {
+                "^.*$": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "calls": {
+                            "description": "The total calls for the command.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "histogram_usec": {
+                            "description": "Histogram map, bucket id to latency",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "arguments": [
+            {
+                "name": "COMMAND",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/latency-history.json
+++ b/vendor/redis-7.2.6-commands/latency-history.json
@@ -1,0 +1,49 @@
+{
+    "HISTORY": {
+        "summary": "Returns timestamp-latency samples for an event.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "2.8.13",
+        "arity": 3,
+        "container": "LATENCY",
+        "function": "latencyCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "An array where each element is a two elements array representing the timestamp and the latency of the event.",
+            "items": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "items": [
+                    {
+                        "description": "timestamp of the event",
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    {
+                        "description": "latency of the event",
+                        "type": "integer",
+                        "minimum": 0
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "event",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/latency-latest.json
+++ b/vendor/redis-7.2.6-commands/latency-latest.json
@@ -1,0 +1,49 @@
+{
+    "LATEST": {
+        "summary": "Returns the latest latency samples for all events.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "2.8.13",
+        "arity": 2,
+        "container": "LATENCY",
+        "function": "latencyCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "An array where each element is a four elements array representing the event's name, timestamp, latest and all-time latency measurements.",
+            "items": {
+                "type": "array",
+                "minItems": 4,
+                "maxItems": 4,
+                "items": [
+                    {
+                        "type": "string",
+                        "description": "Event name."
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Timestamp."
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Latest latency in milliseconds."
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max latency in milliseconds."
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/latency-reset.json
+++ b/vendor/redis-7.2.6-commands/latency-reset.json
@@ -1,0 +1,33 @@
+{
+    "RESET": {
+        "summary": "Resets the latency data for one or more events.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "2.8.13",
+        "arity": -2,
+        "container": "LATENCY",
+        "function": "latencyCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:AGG_SUM"
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "Number of event time series that were reset."
+        },
+        "arguments": [
+            {
+                "name": "event",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/latency.json
+++ b/vendor/redis-7.2.6-commands/latency.json
@@ -1,0 +1,9 @@
+{
+    "LATENCY": {
+        "summary": "A container for latency diagnostics commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "server",
+        "since": "2.8.13",
+        "arity": -2
+    }
+}

--- a/vendor/redis-7.2.6-commands/lcs.json
+++ b/vendor/redis-7.2.6-commands/lcs.json
@@ -1,0 +1,127 @@
+{
+    "LCS": {
+        "summary": "Finds the longest common substring.",
+        "complexity": "O(N*M) where N and M are the lengths of s1 and s2, respectively",
+        "group": "string",
+        "since": "7.0.0",
+        "arity": -3,
+        "function": "lcsCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "description": "The longest common subsequence."
+                },
+                {
+                    "type": "integer",
+                    "description": "The length of the longest common subsequence when 'LEN' is given."
+                },
+                {
+                    "type": "object",
+                    "description": "Array with the LCS length and all the ranges in both the strings when 'IDX' is given. In RESP2 this is returned as a flat array",
+                    "additionalProperties": false,
+                    "properties": {
+                        "matches": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "maxItems": 3,
+                                "items": [
+                                    {
+                                        "type": "array",
+                                        "description": "Matched range in the first string.",
+                                        "minItems": 2,
+                                        "maxItems": 2,
+                                        "items": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    {
+                                        "type": "array",
+                                        "description": "Matched range in the second string.",
+                                        "minItems": 2,
+                                        "maxItems": 2,
+                                        "items": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                ],
+                                "additionalItems": {
+                                    "type": "integer",
+                                    "description": "The length of the match when 'WITHMATCHLEN' is given."
+                                }
+                            }
+                        },
+                        "len": {
+                            "type": "integer",
+                            "description": "Length of the longest common subsequence."
+                        }
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key1",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "key2",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "len",
+                "token": "LEN",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "idx",
+                "token": "IDX",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "token": "MINMATCHLEN",
+                "name": "min-match-len",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "name": "withmatchlen",
+                "token": "WITHMATCHLEN",
+                "type": "pure-token",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/lindex.json
+++ b/vendor/redis-7.2.6-commands/lindex.json
@@ -1,0 +1,59 @@
+{
+    "LINDEX": {
+        "summary": "Returns an element from a list by its index.",
+        "complexity": "O(N) where N is the number of elements to traverse to get to the element at index. This makes asking for the first or the last element of the list O(1).",
+        "group": "list",
+        "since": "1.0.0",
+        "arity": 3,
+        "function": "lindexCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "null",
+                    "description": "Index is out of range"
+                },
+                {
+                    "description": "The requested element",
+                    "type": "string"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/linsert.json
+++ b/vendor/redis-7.2.6-commands/linsert.json
@@ -1,0 +1,85 @@
+{
+    "LINSERT": {
+        "summary": "Inserts an element before or after another element in a list.",
+        "complexity": "O(N) where N is the number of elements to traverse before seeing the value pivot. This means that inserting somewhere on the left end on the list (head) can be considered O(1) and inserting somewhere on the right end (tail) is O(N).",
+        "group": "list",
+        "since": "2.2.0",
+        "arity": 5,
+        "function": "linsertCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "List length after a successful insert operation.",
+                    "type": "integer",
+                    "minimum": 1
+                },
+                {
+                    "description": "in case key doesn't exist.",
+                    "const": 0
+                },
+                {
+                    "description": "when the pivot wasn't found.",
+                    "const": -1
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "where",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "before",
+                        "type": "pure-token",
+                        "token": "BEFORE"
+                    },
+                    {
+                        "name": "after",
+                        "type": "pure-token",
+                        "token": "AFTER"
+                    }
+                ]
+            },
+            {
+                "name": "pivot",
+                "type": "string"
+            },
+            {
+                "name": "element",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/llen.json
+++ b/vendor/redis-7.2.6-commands/llen.json
@@ -1,0 +1,48 @@
+{
+    "LLEN": {
+        "summary": "Returns the length of a list.",
+        "complexity": "O(1)",
+        "group": "list",
+        "since": "1.0.0",
+        "arity": 2,
+        "function": "llenCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "List length.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/lmove.json
+++ b/vendor/redis-7.2.6-commands/lmove.json
@@ -1,0 +1,104 @@
+{
+    "LMOVE": {
+        "summary": "Returns an element after popping it from one list and pushing it to another. Deletes the list if the last element was moved.",
+        "complexity": "O(1)",
+        "group": "list",
+        "since": "6.2.0",
+        "arity": 5,
+        "function": "lmoveCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The element being popped and pushed.",
+            "type": "string"
+        },
+        "arguments": [
+            {
+                "name": "source",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 1
+            },
+            {
+                "name": "wherefrom",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "left",
+                        "type": "pure-token",
+                        "token": "LEFT"
+                    },
+                    {
+                        "name": "right",
+                        "type": "pure-token",
+                        "token": "RIGHT"
+                    }
+                ]
+            },
+            {
+                "name": "whereto",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "left",
+                        "type": "pure-token",
+                        "token": "LEFT"
+                    },
+                    {
+                        "name": "right",
+                        "type": "pure-token",
+                        "token": "RIGHT"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/lmpop.json
+++ b/vendor/redis-7.2.6-commands/lmpop.json
@@ -1,0 +1,100 @@
+{
+    "LMPOP": {
+        "summary": "Returns multiple elements from a list after removing them. Deletes the list if the last element was popped.",
+        "complexity": "O(N+M) where N is the number of provided keys and M is the number of elements returned.",
+        "group": "list",
+        "since": "7.0.0",
+        "arity": -4,
+        "function": "lmpopCommand",
+        "get_keys_function": "lmpopGetKeys",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "description": "If no element could be popped.",
+                    "type": "null"
+                },
+                {
+                    "description": "List key from which elements were popped.",
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "description": "Name of the key from which elements were popped.",
+                            "type": "string"
+                        },
+                        {
+                            "description": "Array of popped elements.",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "name": "where",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "left",
+                        "type": "pure-token",
+                        "token": "LEFT"
+                    },
+                    {
+                        "name": "right",
+                        "type": "pure-token",
+                        "token": "RIGHT"
+                    }
+                ]
+            },
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/lolwut.json
+++ b/vendor/redis-7.2.6-commands/lolwut.json
@@ -1,0 +1,25 @@
+{
+    "LOLWUT": {
+        "summary": "Displays computer art and the Redis version",
+        "group": "server",
+        "since": "5.0.0",
+        "arity": -1,
+        "function": "lolwutCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "reply_schema": {
+            "type": "string",
+            "description": "String containing the generative computer art, and a text with the Redis version."
+        },
+        "arguments": [
+            {
+                "token": "VERSION",
+                "name": "version",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/lpop.json
+++ b/vendor/redis-7.2.6-commands/lpop.json
@@ -1,0 +1,77 @@
+{
+    "LPOP": {
+        "summary": "Returns the first elements in a list after removing it. Deletes the list if the last element was popped.",
+        "complexity": "O(N) where N is the number of elements returned",
+        "group": "list",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "lpopCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added the `count` argument."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Key does not exist.",
+                    "type": "null"
+                },
+                {
+                    "description": "In case `count` argument was not given, the value of the first element.",
+                    "type": "string"
+                },
+                {
+                    "description": "In case `count` argument was given, a list of popped elements",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "optional": true,
+                "since": "6.2.0"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/lpos.json
+++ b/vendor/redis-7.2.6-commands/lpos.json
@@ -1,0 +1,85 @@
+{
+    "LPOS": {
+        "summary": "Returns the index of matching elements in a list.",
+        "complexity": "O(N) where N is the number of elements in the list, for the average case. When searching for elements near the head or the tail of the list, or when the MAXLEN option is provided, the command may run in constant time.",
+        "group": "list",
+        "since": "6.0.6",
+        "arity": -3,
+        "function": "lposCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "description": "In case there is no matching element",
+                    "type": "null"
+                },
+                {
+                    "description": "An integer representing the matching element",
+                    "type": "integer"
+                },
+                {
+                    "description": "If the COUNT option is given, an array of integers representing the matching elements (empty if there are no matches)",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "element",
+                "type": "string"
+            },
+            {
+                "token": "RANK",
+                "name": "rank",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "token": "COUNT",
+                "name": "num-matches",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "token": "MAXLEN",
+                "name": "len",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/lpush.json
+++ b/vendor/redis-7.2.6-commands/lpush.json
@@ -1,0 +1,60 @@
+{
+    "LPUSH": {
+        "summary": "Prepends one or more elements to a list. Creates the key if it doesn't exist.",
+        "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
+        "group": "list",
+        "since": "1.0.0",
+        "arity": -3,
+        "function": "lpushCommand",
+        "history": [
+            [
+                "2.4.0",
+                "Accepts multiple `element` arguments."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Length of the list after the push operations.",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "element",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/lpushx.json
+++ b/vendor/redis-7.2.6-commands/lpushx.json
@@ -1,0 +1,61 @@
+{
+    "LPUSHX": {
+        "summary": "Prepends one or more elements to a list only when the list exists.",
+        "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
+        "group": "list",
+        "since": "2.2.0",
+        "arity": -3,
+        "function": "lpushxCommand",
+        "history": [
+            [
+                "4.0.0",
+                "Accepts multiple `element` arguments."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "the length of the list after the push operation",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "element",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/lrange.json
+++ b/vendor/redis-7.2.6-commands/lrange.json
@@ -1,0 +1,58 @@
+{
+    "LRANGE": {
+        "summary": "Returns a range of elements from a list.",
+        "complexity": "O(S+N) where S is the distance of start offset from HEAD for small lists, from nearest end (HEAD or TAIL) for large lists; and N is the number of elements in the specified range.",
+        "group": "list",
+        "since": "1.0.0",
+        "arity": 4,
+        "function": "lrangeCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer"
+            },
+            {
+                "name": "stop",
+                "type": "integer"
+            }
+        ],
+        "reply_schema": {
+            "description": "List of elements in the specified range",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/lrem.json
+++ b/vendor/redis-7.2.6-commands/lrem.json
@@ -1,0 +1,56 @@
+{
+    "LREM": {
+        "summary": "Removes elements from a list. Deletes the list if the last element was removed.",
+        "complexity": "O(N+M) where N is the length of the list and M is the number of elements removed.",
+        "group": "list",
+        "since": "1.0.0",
+        "arity": 4,
+        "function": "lremCommand",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of removed elements.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "count",
+                "type": "integer"
+            },
+            {
+                "name": "element",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/lset.json
+++ b/vendor/redis-7.2.6-commands/lset.json
@@ -1,0 +1,55 @@
+{
+    "LSET": {
+        "summary": "Sets the value of an element in a list by its index.",
+        "complexity": "O(N) where N is the length of the list. Setting either the first or the last element of the list is O(1).",
+        "group": "list",
+        "since": "1.0.0",
+        "arity": 4,
+        "function": "lsetCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer"
+            },
+            {
+                "name": "element",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/ltrim.json
+++ b/vendor/redis-7.2.6-commands/ltrim.json
@@ -1,0 +1,54 @@
+{
+    "LTRIM": {
+        "summary": "Removes elements from both ends a list. Deletes the list if all elements were trimmed.",
+        "complexity": "O(N) where N is the number of elements to be removed by the operation.",
+        "group": "list",
+        "since": "1.0.0",
+        "arity": 4,
+        "function": "ltrimCommand",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer"
+            },
+            {
+                "name": "stop",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/memory-doctor.json
+++ b/vendor/redis-7.2.6-commands/memory-doctor.json
@@ -1,0 +1,20 @@
+{
+    "DOCTOR": {
+        "summary": "Outputs a memory problems report.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "4.0.0",
+        "arity": 2,
+        "container": "MEMORY",
+        "function": "memoryCommand",
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
+        "reply_schema": {
+            "description": "memory problems report",
+            "type": "string"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/memory-help.json
+++ b/vendor/redis-7.2.6-commands/memory-help.json
@@ -1,0 +1,22 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "4.0.0",
+        "arity": 2,
+        "container": "MEMORY",
+        "function": "memoryCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/memory-malloc-stats.json
+++ b/vendor/redis-7.2.6-commands/memory-malloc-stats.json
@@ -1,0 +1,20 @@
+{
+    "MALLOC-STATS": {
+        "summary": "Returns the allocator statistics.",
+        "complexity": "Depends on how much memory is allocated, could be slow",
+        "group": "server",
+        "since": "4.0.0",
+        "arity": 2,
+        "container": "MEMORY",
+        "function": "memoryCommand",
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
+        "reply_schema": {
+            "type": "string",
+            "description": "The memory allocator's internal statistics report."
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/memory-purge.json
+++ b/vendor/redis-7.2.6-commands/memory-purge.json
@@ -1,0 +1,18 @@
+{
+    "PURGE": {
+        "summary": "Asks the allocator to release memory.",
+        "complexity": "Depends on how much memory is allocated, could be slow",
+        "group": "server",
+        "since": "4.0.0",
+        "arity": 2,
+        "container": "MEMORY",
+        "function": "memoryCommand",
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/memory-stats.json
+++ b/vendor/redis-7.2.6-commands/memory-stats.json
@@ -1,0 +1,121 @@
+{
+    "STATS": {
+        "summary": "Returns details about memory usage.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "4.0.0",
+        "arity": 2,
+        "container": "MEMORY",
+        "function": "memoryCommand",
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
+        "reply_schema": {
+            "description": "memory usage details",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "peak.allocated": {
+                    "type": "integer"
+                },
+                "total.allocated": {
+                    "type": "integer"
+                },
+                "startup.allocated": {
+                    "type": "integer"
+                },
+                "replication.backlog": {
+                    "type": "integer"
+                },
+                "clients.slaves": {
+                    "type": "integer"
+                },
+                "clients.normal": {
+                    "type": "integer"
+                },
+                "cluster.links": {
+                    "type": "integer"
+                },
+                "aof.buffer": {
+                    "type": "integer"
+                },
+                "lua.caches": {
+                    "type": "integer"
+                },
+                "functions.caches": {
+                    "type": "integer"
+                },
+                "overhead.total": {
+                    "type": "integer"
+                },
+                "keys.count": {
+                    "type": "integer"
+                },
+                "keys.bytes-per-key": {
+                    "type": "integer"
+                },
+                "dataset.bytes": {
+                    "type": "integer"
+                },
+                "dataset.percentage": {
+                    "type": "number"
+                },
+                "peak.percentage": {
+                    "type": "number"
+                },
+                "allocator.allocated": {
+                    "type": "integer"
+                },
+                "allocator.active": {
+                    "type": "integer"
+                },
+                "allocator.resident": {
+                    "type": "integer"
+                },
+                "allocator-fragmentation.ratio": {
+                    "type": "number"
+                },
+                "allocator-fragmentation.bytes": {
+                    "type": "integer"
+                },
+                "allocator-rss.ratio": {
+                    "type": "number"
+                },
+                "allocator-rss.bytes": {
+                    "type": "integer"
+                },
+                "rss-overhead.ratio": {
+                    "type": "number"
+                },
+                "rss-overhead.bytes": {
+                    "type": "integer"
+                },
+                "fragmentation": {
+                    "type": "number"
+                },
+                "fragmentation.bytes": {
+                    "type": "integer"
+                }
+            },
+            "patternProperties": {
+                "^db.": {
+                    "type": "object",
+                    "properties": {
+                        "overhead.hashtable.main": {
+                            "type": "integer"
+                        },
+                        "overhead.hashtable.expires": {
+                            "type": "integer"
+                        },
+                        "overhead.hashtable.slot-to-keys": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/memory-usage.json
+++ b/vendor/redis-7.2.6-commands/memory-usage.json
@@ -1,0 +1,58 @@
+{
+    "USAGE": {
+        "summary": "Estimates the memory usage of a key.",
+        "complexity": "O(N) where N is the number of samples.",
+        "group": "server",
+        "since": "4.0.0",
+        "arity": -3,
+        "container": "MEMORY",
+        "function": "memoryCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Number of bytes that a key and its value require to be stored in RAM.",
+                    "type": "integer"
+                },
+                {
+                    "description": "Key does not exist.",
+                    "type": "null"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "token": "SAMPLES",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/memory.json
+++ b/vendor/redis-7.2.6-commands/memory.json
@@ -1,0 +1,9 @@
+{
+    "MEMORY": {
+        "summary": "A container for memory diagnostics commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "server",
+        "since": "4.0.0",
+        "arity": -2
+    }
+}

--- a/vendor/redis-7.2.6-commands/mget.json
+++ b/vendor/redis-7.2.6-commands/mget.json
@@ -1,0 +1,63 @@
+{
+    "MGET": {
+        "summary": "Atomically returns the string values of one or more keys.",
+        "complexity": "O(N) where N is the number of keys to retrieve.",
+        "group": "string",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "mgetCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:MULTI_SHARD"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "List of values at the specified keys.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "null"
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/migrate.json
+++ b/vendor/redis-7.2.6-commands/migrate.json
@@ -1,0 +1,181 @@
+{
+    "MIGRATE": {
+        "summary": "Atomically transfers a key from one Redis instance to another.",
+        "complexity": "This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.",
+        "group": "generic",
+        "since": "2.6.0",
+        "arity": -6,
+        "function": "migrateCommand",
+        "get_keys_function": "migrateGetKeys",
+        "history": [
+            [
+                "3.0.0",
+                "Added the `COPY` and `REPLACE` options."
+            ],
+            [
+                "3.0.6",
+                "Added the `KEYS` option."
+            ],
+            [
+                "4.0.7",
+                "Added the `AUTH` option."
+            ],
+            [
+                "6.0.0",
+                "Added the `AUTH2` option."
+            ]
+        ],
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "KEYSPACE",
+            "DANGEROUS"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 3
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE",
+                    "INCOMPLETE"
+                ],
+                "begin_search": {
+                    "keyword": {
+                        "keyword": "KEYS",
+                        "startfrom": -2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "const": "OK",
+                    "description": "Success."
+                },
+                {
+                    "const": "NOKEY",
+                    "description": "No keys were found in the source instance."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "host",
+                "type": "string"
+            },
+            {
+                "name": "port",
+                "type": "integer"
+            },
+            {
+                "name": "key-selector",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "key",
+                        "type": "key",
+                        "key_spec_index": 0
+                    },
+                    {
+                        "name": "empty-string",
+                        "type": "pure-token",
+                        "token": "\"\""
+                    }
+                ]
+            },
+            {
+                "name": "destination-db",
+                "type": "integer"
+            },
+            {
+                "name": "timeout",
+                "type": "integer"
+            },
+            {
+                "name": "copy",
+                "token": "COPY",
+                "type": "pure-token",
+                "optional": true,
+                "since": "3.0.0"
+            },
+            {
+                "name": "replace",
+                "token": "REPLACE",
+                "type": "pure-token",
+                "optional": true,
+                "since": "3.0.0"
+            },
+            {
+                "name": "authentication",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "AUTH",
+                        "name": "auth",
+                        "display": "password",
+                        "type": "string",
+                        "since": "4.0.7"
+                    },
+                    {
+                        "token": "AUTH2",
+                        "name": "auth2",
+                        "type": "block",
+                        "since": "6.0.0",
+                        "arguments": [
+                            {
+                                "name": "username",
+                                "type": "string"
+                            },
+                            {
+                                "name": "password",
+                                "type": "string"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "token": "KEYS",
+                "name": "keys",
+                "display": "key",
+                "type": "key",
+                "key_spec_index": 1,
+                "optional": true,
+                "multiple": true,
+                "since": "3.0.6"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/module-help.json
+++ b/vendor/redis-7.2.6-commands/module-help.json
@@ -1,0 +1,22 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "5.0.0",
+        "arity": 2,
+        "container": "MODULE",
+        "function": "moduleCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/module-list.json
+++ b/vendor/redis-7.2.6-commands/module-list.json
@@ -1,0 +1,47 @@
+{
+    "LIST": {
+        "summary": "Returns all loaded modules.",
+        "complexity": "O(N) where N is the number of loaded modules.",
+        "group": "server",
+        "since": "4.0.0",
+        "arity": 2,
+        "container": "MODULE",
+        "function": "moduleCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Returns information about the modules loaded to the server.",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the module."
+                    },
+                    "ver": {
+                        "type": "integer",
+                        "description": "Version of the module."
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "Module path."
+                    },
+                    "args": {
+                        "type": "array",
+                        "description": "Module arguments.",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/module-load.json
+++ b/vendor/redis-7.2.6-commands/module-load.json
@@ -1,0 +1,32 @@
+{
+    "LOAD": {
+        "summary": "Loads a module.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "4.0.0",
+        "arity": -3,
+        "container": "MODULE",
+        "function": "moduleCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "NOSCRIPT",
+            "PROTECTED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "path",
+                "type": "string"
+            },
+            {
+                "name": "arg",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/module-loadex.json
+++ b/vendor/redis-7.2.6-commands/module-loadex.json
@@ -1,0 +1,51 @@
+{
+    "LOADEX": {
+        "summary": "Loads a module using extended parameters.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "7.0.0",
+        "arity": -3,
+        "container": "MODULE",
+        "function": "moduleCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "NOSCRIPT",
+            "PROTECTED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "path",
+                "type": "string"
+            },
+            {
+                "name": "configs",
+                "token": "CONFIG",
+                "type": "block",
+                "multiple": true,
+                "multiple_token": true,
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "value",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "args",
+                "token": "ARGS",
+                "type": "string",
+                "multiple": true,
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/module-unload.json
+++ b/vendor/redis-7.2.6-commands/module-unload.json
@@ -1,0 +1,26 @@
+{
+    "UNLOAD": {
+        "summary": "Unloads a module.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "4.0.0",
+        "arity": 3,
+        "container": "MODULE",
+        "function": "moduleCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "NOSCRIPT",
+            "PROTECTED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "name",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/module.json
+++ b/vendor/redis-7.2.6-commands/module.json
@@ -1,0 +1,9 @@
+{
+    "MODULE": {
+        "summary": "A container for module commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "server",
+        "since": "4.0.0",
+        "arity": -2
+    }
+}

--- a/vendor/redis-7.2.6-commands/monitor.json
+++ b/vendor/redis-7.2.6-commands/monitor.json
@@ -1,0 +1,16 @@
+{
+    "MONITOR": {
+        "summary": "Listens for all requests received by the server in real-time.",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": 1,
+        "function": "monitorCommand",
+        "history": [],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/move.json
+++ b/vendor/redis-7.2.6-commands/move.json
@@ -1,0 +1,61 @@
+{
+    "MOVE": {
+        "summary": "Moves a key to another database.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "1.0.0",
+        "arity": 3,
+        "function": "moveCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "db",
+                "type": "integer"
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "key was moved",
+                    "const": 1
+                },
+                {
+                    "description": "key wasn't moved",
+                    "const": 0
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/mset.json
+++ b/vendor/redis-7.2.6-commands/mset.json
@@ -1,0 +1,62 @@
+{
+    "MSET": {
+        "summary": "Atomically creates or modifies the string values of one or more keys.",
+        "complexity": "O(N) where N is the number of keys to set.",
+        "group": "string",
+        "since": "1.0.1",
+        "arity": -3,
+        "function": "msetCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:MULTI_SHARD",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 2,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "key",
+                        "type": "key",
+                        "key_spec_index": 0
+                    },
+                    {
+                        "name": "value",
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/msetnx.json
+++ b/vendor/redis-7.2.6-commands/msetnx.json
@@ -1,0 +1,67 @@
+{
+    "MSETNX": {
+        "summary": "Atomically modifies the string values of one or more keys only when all keys don't exist.",
+        "complexity": "O(N) where N is the number of keys to set.",
+        "group": "string",
+        "since": "1.0.1",
+        "arity": -3,
+        "function": "msetnxCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 2,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "No key was set (at least one key already existed).",
+                    "const": 0
+                },
+                {
+                    "description": "All the keys were set.",
+                    "const": 1
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "key",
+                        "type": "key",
+                        "key_spec_index": 0
+                    },
+                    {
+                        "name": "value",
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/multi.json
+++ b/vendor/redis-7.2.6-commands/multi.json
@@ -1,0 +1,23 @@
+{
+    "MULTI": {
+        "summary": "Starts a transaction.",
+        "complexity": "O(1)",
+        "group": "transactions",
+        "since": "1.2.0",
+        "arity": 1,
+        "function": "multiCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "FAST",
+            "ALLOW_BUSY"
+        ],
+        "acl_categories": [
+            "TRANSACTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/object-encoding.json
+++ b/vendor/redis-7.2.6-commands/object-encoding.json
@@ -1,0 +1,58 @@
+{
+    "ENCODING": {
+        "summary": "Returns the internal encoding of a Redis object.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "2.2.3",
+        "arity": 3,
+        "container": "OBJECT",
+        "function": "objectCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "key doesn't exist",
+                    "type": "null"
+                },
+                {
+                    "description": "encoding of the object",
+                    "type": "string"
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/object-freq.json
+++ b/vendor/redis-7.2.6-commands/object-freq.json
@@ -1,0 +1,50 @@
+{
+    "FREQ": {
+        "summary": "Returns the logarithmic access frequency counter of a Redis object.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "4.0.0",
+        "arity": 3,
+        "container": "OBJECT",
+        "function": "objectCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "reply_schema": {
+            "description": "the counter's value",
+            "type": "integer"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/object-help.json
+++ b/vendor/redis-7.2.6-commands/object-help.json
@@ -1,0 +1,25 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "6.2.0",
+        "arity": 2,
+        "container": "OBJECT",
+        "function": "objectCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/object-idletime.json
+++ b/vendor/redis-7.2.6-commands/object-idletime.json
@@ -1,0 +1,50 @@
+{
+    "IDLETIME": {
+        "summary": "Returns the time since the last access to a Redis object.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "2.2.3",
+        "arity": 3,
+        "container": "OBJECT",
+        "function": "objectCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "reply_schema": {
+            "description": "the idle time in seconds",
+            "type": "integer"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/object-refcount.json
+++ b/vendor/redis-7.2.6-commands/object-refcount.json
@@ -1,0 +1,50 @@
+{
+    "REFCOUNT": {
+        "summary": "Returns the reference count of a value of a key.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "2.2.3",
+        "arity": 3,
+        "container": "OBJECT",
+        "function": "objectCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "reply_schema": {
+            "description": "the number of references",
+            "type": "integer"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/object.json
+++ b/vendor/redis-7.2.6-commands/object.json
@@ -1,0 +1,9 @@
+{
+    "OBJECT": {
+        "summary": "A container for object introspection commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "generic",
+        "since": "2.2.3",
+        "arity": -2
+    }
+}

--- a/vendor/redis-7.2.6-commands/persist.json
+++ b/vendor/redis-7.2.6-commands/persist.json
@@ -1,0 +1,56 @@
+{
+    "PERSIST": {
+        "summary": "Removes the expiration time of a key.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "2.2.0",
+        "arity": 2,
+        "function": "persistCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "const": 0,
+                    "description": "Key does not exist or does not have an associated timeout."
+                },
+                {
+                    "const": 1,
+                    "description": "The timeout has been removed."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/pexpire.json
+++ b/vendor/redis-7.2.6-commands/pexpire.json
@@ -1,0 +1,94 @@
+{
+    "PEXPIRE": {
+        "summary": "Sets the expiration time of a key in milliseconds.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "2.6.0",
+        "arity": -3,
+        "function": "pexpireCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added options: `NX`, `XX`, `GT` and `LT`."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "const": 0,
+                    "description": "The timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments."
+                },
+                {
+                    "const": 1,
+                    "description": "The timeout was set."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "milliseconds",
+                "type": "integer"
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "since": "7.0.0",
+                "arguments": [
+                    {
+                        "name": "nx",
+                        "type": "pure-token",
+                        "token": "NX"
+                    },
+                    {
+                        "name": "xx",
+                        "type": "pure-token",
+                        "token": "XX"
+                    },
+                    {
+                        "name": "gt",
+                        "type": "pure-token",
+                        "token": "GT"
+                    },
+                    {
+                        "name": "lt",
+                        "type": "pure-token",
+                        "token": "LT"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/pexpireat.json
+++ b/vendor/redis-7.2.6-commands/pexpireat.json
@@ -1,0 +1,94 @@
+{
+    "PEXPIREAT": {
+        "summary": "Sets the expiration time of a key to a Unix milliseconds timestamp.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "2.6.0",
+        "arity": -3,
+        "function": "pexpireatCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added options: `NX`, `XX`, `GT` and `LT`."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "const": 1,
+                    "description": "The timeout was set."
+                },
+                {
+                    "const": 0,
+                    "description": "The timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "unix-time-milliseconds",
+                "type": "unix-time"
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "since": "7.0.0",
+                "arguments": [
+                    {
+                        "name": "nx",
+                        "type": "pure-token",
+                        "token": "NX"
+                    },
+                    {
+                        "name": "xx",
+                        "type": "pure-token",
+                        "token": "XX"
+                    },
+                    {
+                        "name": "gt",
+                        "type": "pure-token",
+                        "token": "GT"
+                    },
+                    {
+                        "name": "lt",
+                        "type": "pure-token",
+                        "token": "LT"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/pexpiretime.json
+++ b/vendor/redis-7.2.6-commands/pexpiretime.json
@@ -1,0 +1,61 @@
+{
+    "PEXPIRETIME": {
+        "summary": "Returns the expiration time of a key as a Unix milliseconds timestamp.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "7.0.0",
+        "arity": 2,
+        "function": "pexpiretimeCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "integer",
+                    "description": "Expiration Unix timestamp in milliseconds.",
+                    "minimum": 0
+                },
+                {
+                    "const": -1,
+                    "description": "The key exists but has no associated expiration time."
+                },
+                {
+                    "const": -2,
+                    "description": "The key does not exist."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/pfadd.json
+++ b/vendor/redis-7.2.6-commands/pfadd.json
@@ -1,0 +1,63 @@
+{
+    "PFADD": {
+        "summary": "Adds elements to a HyperLogLog key. Creates the key if it doesn't exist.",
+        "complexity": "O(1) to add every element.",
+        "group": "hyperloglog",
+        "since": "2.8.9",
+        "arity": -2,
+        "function": "pfaddCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "HYPERLOGLOG"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "element",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "if at least 1 HyperLogLog internal register was altered",
+                    "const": 1
+                },
+                {
+                    "description": "if no HyperLogLog internal register were altered",
+                    "const": 0
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/pfcount.json
+++ b/vendor/redis-7.2.6-commands/pfcount.json
@@ -1,0 +1,50 @@
+{
+    "PFCOUNT": {
+        "summary": "Returns the approximated cardinality of the set(s) observed by the HyperLogLog key(s).",
+        "complexity": "O(1) with a very small average constant time when called with a single key. O(N) with N being the number of keys, and much bigger constant times, when called with multiple keys.",
+        "group": "hyperloglog",
+        "since": "2.8.9",
+        "arity": -2,
+        "function": "pfcountCommand",
+        "command_flags": [
+            "READONLY",
+            "MAY_REPLICATE"
+        ],
+        "acl_categories": [
+            "HYPERLOGLOG"
+        ],
+        "key_specs": [
+            {
+                "notes": "RW because it may change the internal representation of the key, and propagate to replicas",
+                "flags": [
+                    "RW",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "The approximated number of unique elements observed via PFADD",
+            "type": "integer"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/pfdebug.json
+++ b/vendor/redis-7.2.6-commands/pfdebug.json
@@ -1,0 +1,52 @@
+{
+    "PFDEBUG": {
+        "summary": "Internal commands for debugging HyperLogLog values.",
+        "complexity": "N/A",
+        "group": "hyperloglog",
+        "since": "2.8.9",
+        "arity": 3,
+        "function": "pfdebugCommand",
+        "doc_flags": [
+            "SYSCMD"
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "ADMIN"
+        ],
+        "acl_categories": [
+            "HYPERLOGLOG"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "subcommand",
+                "type": "string"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/pfmerge.json
+++ b/vendor/redis-7.2.6-commands/pfmerge.json
@@ -1,0 +1,73 @@
+{
+    "PFMERGE": {
+        "summary": "Merges one or more HyperLogLog values into a single key.",
+        "complexity": "O(N) to merge N HyperLogLogs, but with high constant times.",
+        "group": "hyperloglog",
+        "since": "2.8.9",
+        "arity": -2,
+        "function": "pfmergeCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "HYPERLOGLOG"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "destkey",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "sourcekey",
+                "type": "key",
+                "key_spec_index": 1,
+                "optional": true,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/pfselftest.json
+++ b/vendor/redis-7.2.6-commands/pfselftest.json
@@ -1,0 +1,22 @@
+{
+    "PFSELFTEST": {
+        "summary": "An internal command for testing HyperLogLog values.",
+        "complexity": "N/A",
+        "group": "hyperloglog",
+        "since": "2.8.9",
+        "arity": 1,
+        "function": "pfselftestCommand",
+        "doc_flags": [
+            "SYSCMD"
+        ],
+        "command_flags": [
+            "ADMIN"
+        ],
+        "acl_categories": [
+            "HYPERLOGLOG"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/ping.json
+++ b/vendor/redis-7.2.6-commands/ping.json
@@ -1,0 +1,40 @@
+{
+    "PING": {
+        "summary": "Returns the server's liveliness response.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "1.0.0",
+        "arity": -1,
+        "function": "pingCommand",
+        "command_flags": [
+            "FAST",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "const": "PONG",
+                    "description": "Default reply."
+                },
+                {
+                    "type": "string",
+                    "description": "Relay of given `message`."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "message",
+                "type": "string",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/psetex.json
+++ b/vendor/redis-7.2.6-commands/psetex.json
@@ -1,0 +1,60 @@
+{
+    "PSETEX": {
+        "summary": "Sets both string value and expiration time in milliseconds of a key. The key is created if it doesn't exist.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "2.6.0",
+        "arity": 4,
+        "function": "psetexCommand",
+        "deprecated_since": "2.6.12",
+        "replaced_by": "`SET` with the `PX` argument",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "milliseconds",
+                "type": "integer"
+            },
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/psubscribe.json
+++ b/vendor/redis-7.2.6-commands/psubscribe.json
@@ -1,0 +1,24 @@
+{
+    "PSUBSCRIBE": {
+        "summary": "Listens for messages published to channels that match one or more patterns.",
+        "complexity": "O(N) where N is the number of patterns to subscribe to.",
+        "group": "pubsub",
+        "since": "2.0.0",
+        "arity": -2,
+        "function": "psubscribeCommand",
+        "command_flags": [
+            "PUBSUB",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "arguments": [
+            {
+                "name": "pattern",
+                "type": "pattern",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/psync.json
+++ b/vendor/redis-7.2.6-commands/psync.json
@@ -1,0 +1,25 @@
+{
+    "PSYNC": {
+        "summary": "An internal command used in replication.",
+        "group": "server",
+        "since": "2.8.0",
+        "arity": -3,
+        "function": "syncCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "NO_MULTI",
+            "NOSCRIPT"
+        ],
+        "arguments": [
+            {
+                "name": "replicationid",
+                "type": "string"
+            },
+            {
+                "name": "offset",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/pttl.json
+++ b/vendor/redis-7.2.6-commands/pttl.json
@@ -1,0 +1,70 @@
+{
+    "PTTL": {
+        "summary": "Returns the expiration time in milliseconds of a key.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "2.6.0",
+        "arity": 2,
+        "function": "pttlCommand",
+        "history": [
+            [
+                "2.8.0",
+                "Added the -2 reply."
+            ]
+        ],
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "TTL in milliseconds.",
+                    "type": "integer",
+                    "minimum": 0
+                },
+                {
+                    "description": "The key exists but has no associated expire.",
+                    "const": -1
+                },
+                {
+                    "description": "The key does not exist.",
+                    "const": -2
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/publish.json
+++ b/vendor/redis-7.2.6-commands/publish.json
@@ -1,0 +1,33 @@
+{
+    "PUBLISH": {
+        "summary": "Posts a message to a channel.",
+        "complexity": "O(N+M) where N is the number of clients subscribed to the receiving channel and M is the total number of subscribed patterns (by any client).",
+        "group": "pubsub",
+        "since": "2.0.0",
+        "arity": 3,
+        "function": "publishCommand",
+        "command_flags": [
+            "PUBSUB",
+            "LOADING",
+            "STALE",
+            "FAST",
+            "MAY_REPLICATE",
+            "SENTINEL"
+        ],
+        "arguments": [
+            {
+                "name": "channel",
+                "type": "string"
+            },
+            {
+                "name": "message",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "description": "the number of clients that received the message. Note that in a Redis Cluster, only clients that are connected to the same node as the publishing client are included in the count",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/pubsub-channels.json
+++ b/vendor/redis-7.2.6-commands/pubsub-channels.json
@@ -1,0 +1,31 @@
+{
+    "CHANNELS": {
+        "summary": "Returns the active channels.",
+        "complexity": "O(N) where N is the number of active channels, and assuming constant time pattern matching (relatively short channels and patterns)",
+        "group": "pubsub",
+        "since": "2.8.0",
+        "arity": -2,
+        "container": "PUBSUB",
+        "function": "pubsubCommand",
+        "command_flags": [
+            "PUBSUB",
+            "LOADING",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "pattern",
+                "type": "pattern",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "a list of active channels, optionally matching the specified pattern",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/pubsub-help.json
+++ b/vendor/redis-7.2.6-commands/pubsub-help.json
@@ -1,0 +1,22 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "pubsub",
+        "since": "6.2.0",
+        "arity": 2,
+        "container": "PUBSUB",
+        "function": "pubsubCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/pubsub-numpat.json
+++ b/vendor/redis-7.2.6-commands/pubsub-numpat.json
@@ -1,0 +1,21 @@
+{
+    "NUMPAT": {
+        "summary": "Returns a count of unique pattern subscriptions.",
+        "complexity": "O(1)",
+        "group": "pubsub",
+        "since": "2.8.0",
+        "arity": 2,
+        "container": "PUBSUB",
+        "function": "pubsubCommand",
+        "command_flags": [
+            "PUBSUB",
+            "LOADING",
+            "STALE"
+        ],
+        "reply_schema": {
+            "description": "the number of patterns all the clients are subscribed to",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/pubsub-numsub.json
+++ b/vendor/redis-7.2.6-commands/pubsub-numsub.json
@@ -1,0 +1,28 @@
+{
+    "NUMSUB": {
+        "summary": "Returns a count of subscribers to channels.",
+        "complexity": "O(N) for the NUMSUB subcommand, where N is the number of requested channels",
+        "group": "pubsub",
+        "since": "2.8.0",
+        "arity": -2,
+        "container": "PUBSUB",
+        "function": "pubsubCommand",
+        "command_flags": [
+            "PUBSUB",
+            "LOADING",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "channel",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "the number of subscribers per channel, each even element (including 0th) is channel name, each odd element is the number of subscribers",
+            "type": "array"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/pubsub-shardchannels.json
+++ b/vendor/redis-7.2.6-commands/pubsub-shardchannels.json
@@ -1,0 +1,31 @@
+{
+    "SHARDCHANNELS": {
+        "summary": "Returns the active shard channels.",
+        "complexity": "O(N) where N is the number of active shard channels, and assuming constant time pattern matching (relatively short shard channels).",
+        "group": "pubsub",
+        "since": "7.0.0",
+        "arity": -2,
+        "container": "PUBSUB",
+        "function": "pubsubCommand",
+        "command_flags": [
+            "PUBSUB",
+            "LOADING",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "pattern",
+                "type": "pattern",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "a list of active channels, optionally matching the specified pattern",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/pubsub-shardnumsub.json
+++ b/vendor/redis-7.2.6-commands/pubsub-shardnumsub.json
@@ -1,0 +1,28 @@
+{
+    "SHARDNUMSUB": {
+        "summary": "Returns the count of subscribers of shard channels.",
+        "complexity": "O(N) for the SHARDNUMSUB subcommand, where N is the number of requested shard channels",
+        "group": "pubsub",
+        "since": "7.0.0",
+        "arity": -2,
+        "container": "PUBSUB",
+        "function": "pubsubCommand",
+        "command_flags": [
+            "PUBSUB",
+            "LOADING",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "shardchannel",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "the number of subscribers per shard channel, each even element (including 0th) is channel name, each odd element is the number of subscribers",
+            "type": "array"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/pubsub.json
+++ b/vendor/redis-7.2.6-commands/pubsub.json
@@ -1,0 +1,9 @@
+{
+    "PUBSUB": {
+        "summary": "A container for Pub/Sub commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "pubsub",
+        "since": "2.8.0",
+        "arity": -2
+    }
+}

--- a/vendor/redis-7.2.6-commands/punsubscribe.json
+++ b/vendor/redis-7.2.6-commands/punsubscribe.json
@@ -1,0 +1,25 @@
+{
+    "PUNSUBSCRIBE": {
+        "summary": "Stops listening to messages published to channels that match one or more patterns.",
+        "complexity": "O(N) where N is the number of patterns to unsubscribe.",
+        "group": "pubsub",
+        "since": "2.0.0",
+        "arity": -1,
+        "function": "punsubscribeCommand",
+        "command_flags": [
+            "PUBSUB",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "arguments": [
+            {
+                "name": "pattern",
+                "type": "pattern",
+                "optional": true,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/quit.json
+++ b/vendor/redis-7.2.6-commands/quit.json
@@ -1,0 +1,29 @@
+{
+    "QUIT": {
+        "summary": "Closes the connection.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "1.0.0",
+        "arity": -1,
+        "function": "quitCommand",
+        "deprecated_since": "7.2.0",
+        "replaced_by": "just closing the connection",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "ALLOW_BUSY",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "FAST",
+            "NO_AUTH"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/randomkey.json
+++ b/vendor/redis-7.2.6-commands/randomkey.json
@@ -1,0 +1,34 @@
+{
+    "RANDOMKEY": {
+        "summary": "Returns a random key name from the database.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "1.0.0",
+        "arity": 1,
+        "function": "randomkeyCommand",
+        "command_flags": [
+            "READONLY",
+            "TOUCHES_ARBITRARY_KEYS"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:SPECIAL",
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "when the database is empty",
+                    "type": "null"
+                },
+                {
+                    "description": "random key in db",
+                    "type": "string"
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/readonly.json
+++ b/vendor/redis-7.2.6-commands/readonly.json
@@ -1,0 +1,21 @@
+{
+    "READONLY": {
+        "summary": "Enables read-only queries for a connection to a Redis Cluster replica node.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 1,
+        "function": "readonlyCommand",
+        "command_flags": [
+            "FAST",
+            "LOADING",
+            "STALE"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/readwrite.json
+++ b/vendor/redis-7.2.6-commands/readwrite.json
@@ -1,0 +1,21 @@
+{
+    "READWRITE": {
+        "summary": "Enables read-write queries for a connection to a Reids Cluster replica node.",
+        "complexity": "O(1)",
+        "group": "cluster",
+        "since": "3.0.0",
+        "arity": 1,
+        "function": "readwriteCommand",
+        "command_flags": [
+            "FAST",
+            "LOADING",
+            "STALE"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/rename.json
+++ b/vendor/redis-7.2.6-commands/rename.json
@@ -1,0 +1,72 @@
+{
+    "RENAME": {
+        "summary": "Renames a key and overwrites the destination.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "1.0.0",
+        "arity": 3,
+        "function": "renameCommand",
+        "history": [],
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "newkey",
+                "type": "key",
+                "key_spec_index": 1
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/renamenx.json
+++ b/vendor/redis-7.2.6-commands/renamenx.json
@@ -1,0 +1,86 @@
+{
+    "RENAMENX": {
+        "summary": "Renames a key only when the target key name doesn't exist.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "1.0.0",
+        "arity": 3,
+        "function": "renamenxCommand",
+        "history": [
+            [
+                "3.2.0",
+                "The command no longer returns an error when source and destination names are the same."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "OW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "newkey",
+                "type": "key",
+                "key_spec_index": 1
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "key was renamed to newkey",
+                    "const": 1
+                },
+                {
+                    "description": "new key already exists",
+                    "const": 0
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/replconf.json
+++ b/vendor/redis-7.2.6-commands/replconf.json
@@ -1,0 +1,23 @@
+{
+    "REPLCONF": {
+        "summary": "An internal command for configuring the replication stream.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "3.0.0",
+        "arity": -1,
+        "function": "replconfCommand",
+        "doc_flags": [
+            "SYSCMD"
+        ],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "ALLOW_BUSY"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/replicaof.json
+++ b/vendor/redis-7.2.6-commands/replicaof.json
@@ -1,0 +1,59 @@
+{
+    "REPLICAOF": {
+        "summary": "Configures a server as replica of another, or promotes it to a master.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "5.0.0",
+        "arity": 3,
+        "function": "replicaofCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "NOSCRIPT",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "args",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "host-port",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "host",
+                                "type": "string"
+                            },
+                            {
+                                "name": "port",
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "no-one",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "no",
+                                "type": "pure-token",
+                                "token": "NO"
+                            },
+                            {
+                                "name": "one",
+                                "type": "pure-token",
+                                "token": "ONE"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "description": "replicaOf status",
+            "type": "string",
+            "pattern": "OK*"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/reset.json
+++ b/vendor/redis-7.2.6-commands/reset.json
@@ -1,0 +1,24 @@
+{
+    "RESET": {
+        "summary": "Resets the connection.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "6.2.0",
+        "arity": 1,
+        "function": "resetCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "FAST",
+            "NO_AUTH",
+            "ALLOW_BUSY"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "RESET"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/restore-asking.json
+++ b/vendor/redis-7.2.6-commands/restore-asking.json
@@ -1,0 +1,102 @@
+{
+    "RESTORE-ASKING": {
+        "summary": "An internal command for migrating keys in a cluster.",
+        "complexity": "O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).",
+        "group": "server",
+        "since": "3.0.0",
+        "arity": -4,
+        "function": "restoreCommand",
+        "history": [
+            [
+                "3.0.0",
+                "Added the `REPLACE` modifier."
+            ],
+            [
+                "5.0.0",
+                "Added the `ABSTTL` modifier."
+            ],
+            [
+                "5.0.0",
+                "Added the `IDLETIME` and `FREQ` options."
+            ]
+        ],
+        "doc_flags": [
+            "SYSCMD"
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "ASKING"
+        ],
+        "acl_categories": [
+            "KEYSPACE",
+            "DANGEROUS"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "ttl",
+                "type": "integer"
+            },
+            {
+                "name": "serialized-value",
+                "type": "string"
+            },
+            {
+                "name": "replace",
+                "token": "REPLACE",
+                "type": "pure-token",
+                "optional": true,
+                "since": "3.0.0"
+            },
+            {
+                "name": "absttl",
+                "token": "ABSTTL",
+                "type": "pure-token",
+                "optional": true,
+                "since": "5.0.0"
+            },
+            {
+                "token": "IDLETIME",
+                "name": "seconds",
+                "type": "integer",
+                "optional": true,
+                "since": "5.0.0"
+            },
+            {
+                "token": "FREQ",
+                "name": "frequency",
+                "type": "integer",
+                "optional": true,
+                "since": "5.0.0"
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/restore.json
+++ b/vendor/redis-7.2.6-commands/restore.json
@@ -1,0 +1,98 @@
+{
+    "RESTORE": {
+        "summary": "Creates a key from the serialized representation of a value.",
+        "complexity": "O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).",
+        "group": "generic",
+        "since": "2.6.0",
+        "arity": -4,
+        "function": "restoreCommand",
+        "history": [
+            [
+                "3.0.0",
+                "Added the `REPLACE` modifier."
+            ],
+            [
+                "5.0.0",
+                "Added the `ABSTTL` modifier."
+            ],
+            [
+                "5.0.0",
+                "Added the `IDLETIME` and `FREQ` options."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "KEYSPACE",
+            "DANGEROUS"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "ttl",
+                "type": "integer"
+            },
+            {
+                "name": "serialized-value",
+                "type": "string"
+            },
+            {
+                "name": "replace",
+                "token": "REPLACE",
+                "type": "pure-token",
+                "optional": true,
+                "since": "3.0.0"
+            },
+            {
+                "name": "absttl",
+                "token": "ABSTTL",
+                "type": "pure-token",
+                "optional": true,
+                "since": "5.0.0"
+            },
+            {
+                "token": "IDLETIME",
+                "name": "seconds",
+                "type": "integer",
+                "optional": true,
+                "since": "5.0.0"
+            },
+            {
+                "token": "FREQ",
+                "name": "frequency",
+                "type": "integer",
+                "optional": true,
+                "since": "5.0.0"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/role.json
+++ b/vendor/redis-7.2.6-commands/role.json
@@ -1,0 +1,134 @@
+{
+    "ROLE": {
+        "summary": "Returns the replication role.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "2.8.12",
+        "arity": 1,
+        "function": "roleCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "FAST",
+            "SENTINEL"
+        ],
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS"
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "array",
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "items": [
+                        {
+                            "const": "master"
+                        },
+                        {
+                            "description": "current replication master offset",
+                            "type": "integer"
+                        },
+                        {
+                            "description": "connected replicas",
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "minItems": 3,
+                                "maxItems": 3,
+                                "items": [
+                                    {
+                                        "description": "replica ip",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "description": "replica port",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "description": "last acknowledged replication offset",
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "array",
+                    "minItems": 5,
+                    "maxItems": 5,
+                    "items": [
+                        {
+                            "const": "slave"
+                        },
+                        {
+                            "description": "ip of master",
+                            "type": "string"
+                        },
+                        {
+                            "description": "port number of master",
+                            "type": "integer"
+                        },
+                        {
+                            "description": "state of the replication from the point of view of the master",
+                            "oneOf": [
+                                {
+                                    "description": "the instance is in handshake with its master",
+                                    "const": "handshake"
+                                },
+                                {
+                                    "description": "the instance in not active",
+                                    "const": "none"
+                                },
+                                {
+                                    "description": "the instance needs to connect to its master",
+                                    "const": "connect"
+                                },
+                                {
+                                    "description": "the master-replica connection is in progress",
+                                    "const": "connecting"
+                                },
+                                {
+                                    "description": "the master and replica are trying to perform the synchronization",
+                                    "const": "sync"
+                                },
+                                {
+                                    "description": "the replica is online",
+                                    "const": "connected"
+                                },
+                                {
+                                    "description": "instance state is unknown",
+                                    "const": "unknown"
+                                }
+                            ]
+                        },
+                        {
+                            "description": "the amount of data received from the replica so far in terms of master replication offset",
+                            "type": "integer"
+                        }
+                    ]
+                },
+                {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "const": "sentinel"
+                        },
+                        {
+                            "description": "list of master names monitored by this sentinel instance",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/rpop.json
+++ b/vendor/redis-7.2.6-commands/rpop.json
@@ -1,0 +1,76 @@
+{
+    "RPOP": {
+        "summary": "Returns and removes the last elements of a list. Deletes the list if the last element was popped.",
+        "complexity": "O(N) where N is the number of elements returned",
+        "group": "list",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "rpopCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added the `count` argument."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "null",
+                    "description": "Key does not exist."
+                },
+                {
+                    "type": "string",
+                    "description": "When 'COUNT' was not given, the value of the last element."
+                },
+                {
+                    "type": "array",
+                    "description": "When 'COUNT' was given, list of popped elements.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "optional": true,
+                "since": "6.2.0"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/rpoplpush.json
+++ b/vendor/redis-7.2.6-commands/rpoplpush.json
@@ -1,0 +1,85 @@
+{
+    "RPOPLPUSH": {
+        "summary": "Returns the last element of a list after removing and pushing it to another list. Deletes the list if the last element was popped.",
+        "complexity": "O(1)",
+        "group": "list",
+        "since": "1.2.0",
+        "arity": 3,
+        "function": "rpoplpushCommand",
+        "deprecated_since": "6.2.0",
+        "replaced_by": "`LMOVE` with the `RIGHT` and `LEFT` arguments",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "description": "The element being popped and pushed."
+                },
+                {
+                    "type": "null",
+                    "description": "Source list is empty."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "source",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 1
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/rpush.json
+++ b/vendor/redis-7.2.6-commands/rpush.json
@@ -1,0 +1,61 @@
+{
+    "RPUSH": {
+        "summary": "Appends one or more elements to a list. Creates the key if it doesn't exist.",
+        "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
+        "group": "list",
+        "since": "1.0.0",
+        "arity": -3,
+        "function": "rpushCommand",
+        "history": [
+            [
+                "2.4.0",
+                "Accepts multiple `element` arguments."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Length of the list after the push operations.",
+            "type": "integer",
+            "minimum": 1
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "element",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/rpushx.json
+++ b/vendor/redis-7.2.6-commands/rpushx.json
@@ -1,0 +1,61 @@
+{
+    "RPUSHX": {
+        "summary": "Appends an element to a list only when the list exists.",
+        "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
+        "group": "list",
+        "since": "2.2.0",
+        "arity": -3,
+        "function": "rpushxCommand",
+        "history": [
+            [
+                "4.0.0",
+                "Accepts multiple `element` arguments."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "LIST"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "Length of the list after the push operation.",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "element",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sadd.json
+++ b/vendor/redis-7.2.6-commands/sadd.json
@@ -1,0 +1,60 @@
+{
+    "SADD": {
+        "summary": "Adds one or more members to a set. Creates the key if it doesn't exist.",
+        "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": -3,
+        "function": "saddCommand",
+        "history": [
+            [
+                "2.4.0",
+                "Accepts multiple `member` arguments."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of elements that were added to the set, not including all the elements already present in the set.",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/save.json
+++ b/vendor/redis-7.2.6-commands/save.json
@@ -1,0 +1,19 @@
+{
+    "SAVE": {
+        "summary": "Synchronously saves the database(s) to disk.",
+        "complexity": "O(N) where N is the total number of keys in all databases",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": 1,
+        "function": "saveCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "NOSCRIPT",
+            "NO_MULTI"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/scan.json
+++ b/vendor/redis-7.2.6-commands/scan.json
@@ -1,0 +1,72 @@
+{
+    "SCAN": {
+        "summary": "Iterates over the key names in the database.",
+        "complexity": "O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.",
+        "group": "generic",
+        "since": "2.8.0",
+        "arity": -2,
+        "function": "scanCommand",
+        "history": [
+            [
+                "6.0.0",
+                "Added the `TYPE` subcommand."
+            ]
+        ],
+        "command_flags": [
+            "READONLY",
+            "TOUCHES_ARBITRARY_KEYS"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:SPECIAL",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
+        "arguments": [
+            {
+                "name": "cursor",
+                "type": "integer"
+            },
+            {
+                "token": "MATCH",
+                "name": "pattern",
+                "type": "pattern",
+                "optional": true
+            },
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "token": "TYPE",
+                "name": "type",
+                "type": "string",
+                "optional": true,
+                "since": "6.0.0"
+            }
+        ],
+        "reply_schema": {
+            "description": "cursor and scan response in array form",
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": [
+                {
+                    "description": "cursor",
+                    "type": "string"
+                },
+                {
+                    "description": "list of keys",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/scard.json
+++ b/vendor/redis-7.2.6-commands/scard.json
@@ -1,0 +1,48 @@
+{
+    "SCARD": {
+        "summary": "Returns the number of members in a set.",
+        "complexity": "O(1)",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": 2,
+        "function": "scardCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The cardinality (number of elements) of the set, or 0 if key does not exist.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/script-debug.json
+++ b/vendor/redis-7.2.6-commands/script-debug.json
@@ -1,0 +1,43 @@
+{
+    "DEBUG": {
+        "summary": "Sets the debug mode of server-side Lua scripts.",
+        "complexity": "O(1)",
+        "group": "scripting",
+        "since": "3.2.0",
+        "arity": 3,
+        "container": "SCRIPT",
+        "function": "scriptCommand",
+        "command_flags": [
+            "NOSCRIPT"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "arguments": [
+            {
+                "name": "mode",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "yes",
+                        "type": "pure-token",
+                        "token": "YES"
+                    },
+                    {
+                        "name": "sync",
+                        "type": "pure-token",
+                        "token": "SYNC"
+                    },
+                    {
+                        "name": "no",
+                        "type": "pure-token",
+                        "token": "NO"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/script-exists.json
+++ b/vendor/redis-7.2.6-commands/script-exists.json
@@ -1,0 +1,44 @@
+{
+    "EXISTS": {
+        "summary": "Determines whether server-side Lua scripts exist in the script cache.",
+        "complexity": "O(N) with N being the number of scripts to check (so checking a single script is an O(1) operation).",
+        "group": "scripting",
+        "since": "2.6.0",
+        "arity": -3,
+        "container": "SCRIPT",
+        "function": "scriptCommand",
+        "command_flags": [
+            "NOSCRIPT"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:AGG_LOGICAL_AND"
+        ],
+        "arguments": [
+            {
+                "name": "sha1",
+                "type": "string",
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "An array of integers that correspond to the specified SHA1 digest arguments.",
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "sha1 hash exists in script cache",
+                        "const": 1
+                    },
+                    {
+                        "description": "sha1 hash does not exist in script cache",
+                        "const": 0
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/script-flush.json
+++ b/vendor/redis-7.2.6-commands/script-flush.json
@@ -1,0 +1,50 @@
+{
+    "FLUSH": {
+        "summary": "Removes all server-side Lua scripts from the script cache.",
+        "complexity": "O(N) with N being the number of scripts in cache",
+        "group": "scripting",
+        "since": "2.6.0",
+        "arity": -2,
+        "container": "SCRIPT",
+        "function": "scriptCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added the `ASYNC` and `SYNC` flushing mode modifiers."
+            ]
+        ],
+        "command_flags": [
+            "NOSCRIPT"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "arguments": [
+            {
+                "name": "flush-type",
+                "type": "oneof",
+                "optional": true,
+                "since": "6.2.0",
+                "arguments": [
+                    {
+                        "name": "async",
+                        "type": "pure-token",
+                        "token": "ASYNC"
+                    },
+                    {
+                        "name": "sync",
+                        "type": "pure-token",
+                        "token": "SYNC"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/script-help.json
+++ b/vendor/redis-7.2.6-commands/script-help.json
@@ -1,0 +1,25 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "scripting",
+        "since": "5.0.0",
+        "arity": 2,
+        "container": "SCRIPT",
+        "function": "scriptCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/script-kill.json
+++ b/vendor/redis-7.2.6-commands/script-kill.json
@@ -1,0 +1,25 @@
+{
+    "KILL": {
+        "summary": "Terminates a server-side Lua script during execution.",
+        "complexity": "O(1)",
+        "group": "scripting",
+        "since": "2.6.0",
+        "arity": 2,
+        "container": "SCRIPT",
+        "function": "scriptCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "ALLOW_BUSY"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:ONE_SUCCEEDED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/script-load.json
+++ b/vendor/redis-7.2.6-commands/script-load.json
@@ -1,0 +1,32 @@
+{
+    "LOAD": {
+        "summary": "Loads a server-side Lua script to the script cache.",
+        "complexity": "O(N) with N being the length in bytes of the script body.",
+        "group": "scripting",
+        "since": "2.6.0",
+        "arity": 3,
+        "container": "SCRIPT",
+        "function": "scriptCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "STALE"
+        ],
+        "acl_categories": [
+            "SCRIPTING"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "arguments": [
+            {
+                "name": "script",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "description": "The SHA1 digest of the script added into the script cache",
+            "type": "string"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/script.json
+++ b/vendor/redis-7.2.6-commands/script.json
@@ -1,0 +1,9 @@
+{
+    "SCRIPT": {
+        "summary": "A container for Lua scripts management commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "scripting",
+        "since": "2.6.0",
+        "arity": -2
+    }
+}

--- a/vendor/redis-7.2.6-commands/sdiff.json
+++ b/vendor/redis-7.2.6-commands/sdiff.json
@@ -1,0 +1,55 @@
+{
+    "SDIFF": {
+        "summary": "Returns the difference of multiple sets.",
+        "complexity": "O(N) where N is the total number of elements in all given sets.",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "sdiffCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List with the members of the resulting set.",
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sdiffstore.json
+++ b/vendor/redis-7.2.6-commands/sdiffstore.json
@@ -1,0 +1,73 @@
+{
+    "SDIFFSTORE": {
+        "summary": "Stores the difference of multiple sets in a key.",
+        "complexity": "O(N) where N is the total number of elements in all given sets.",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": -3,
+        "function": "sdiffstoreCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of the elements in the resulting set.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 1,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/select.json
+++ b/vendor/redis-7.2.6-commands/select.json
@@ -1,0 +1,27 @@
+{
+    "SELECT": {
+        "summary": "Changes the selected database.",
+        "complexity": "O(1)",
+        "group": "connection",
+        "since": "1.0.0",
+        "arity": 2,
+        "function": "selectCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "index",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-ckquorum.json
+++ b/vendor/redis-7.2.6-commands/sentinel-ckquorum.json
@@ -1,0 +1,26 @@
+{
+    "CKQUORUM": {
+        "summary": "Checks for a Redis Sentinel quorum.",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": 3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "string",
+            "description": "Returns OK if the current Sentinel configuration is able to reach the quorum needed to failover a master, and the majority needed to authorize the failover.",
+            "pattern": "OK"
+        },
+        "arguments": [
+            {
+                "name": "master-name",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-config.json
+++ b/vendor/redis-7.2.6-commands/sentinel-config.json
@@ -1,0 +1,121 @@
+{
+    "CONFIG": {
+        "summary": "Configures Redis Sentinel.",
+        "complexity": "O(N) when N is the number of configuration parameters provided",
+        "group": "sentinel",
+        "since": "6.2.0",
+        "arity": -4,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "history": [
+            [
+                "7.2.0",
+                "Added the ability to set and get multiple parameters in one call."
+            ]
+        ],
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "description": "When 'SENTINEL-CONFIG GET' is called, returns a map.",
+                    "properties": {
+                        "resolve-hostnames": {
+                            "oneOf": [
+                                {
+                                    "const": "yes"
+                                },
+                                {
+                                    "const": "no"
+                                }
+                            ]
+                        },
+                        "announce-hostnames": {
+                            "oneOf": [
+                                {
+                                    "const": "yes"
+                                },
+                                {
+                                    "const": "no"
+                                }
+                            ]
+                        },
+                        "announce-ip": {
+                            "type": "string"
+                        },
+                        "announce-port": {
+                            "type": "string"
+                        },
+                        "sentinel-user": {
+                            "type": "string"
+                        },
+                        "sentinel-pass": {
+                            "type": "string"
+                        },
+                        "loglevel": {
+                            "oneOf": [
+                                {
+                                    "const": "debug"
+                                },
+                                {
+                                    "const": "verbose"
+                                },
+                                {
+                                    "const": "notice"
+                                },
+                                {
+                                    "const": "warning"
+                                },
+                                {
+                                    "const": "nothing"
+                                },
+                                {
+                                    "const": "unknown"
+                                }
+                            ]
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "const": "OK",
+                    "description": "When 'SENTINEL-CONFIG SET' is called, returns OK on success."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name":"action",
+                "type":"oneof",
+                "arguments":[
+                    {
+                        "name":"set",
+                        "token":"SET",
+                        "type":"block",
+                        "multiple": true,
+                        "arguments":[
+                            {
+                                "name":"parameter",
+                                "type":"string"
+                            },
+                            {
+                                "name":"value",
+                                "type":"string"
+                            }
+                        ]
+                    },
+                    {
+                        "token":"GET",
+                        "name":"parameter",
+                        "type":"string",
+                        "multiple": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-debug.json
+++ b/vendor/redis-7.2.6-commands/sentinel-debug.json
@@ -1,0 +1,49 @@
+{
+    "DEBUG": {
+        "summary": "Lists or updates the current configurable parameters of Redis Sentinel.",
+        "complexity": "O(N) where N is the number of configurable parameters",
+        "group": "sentinel",
+        "since": "7.0.0",
+        "arity": -2,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The configuration update was successful.",
+                    "const": "OK"
+                },
+                {
+                    "description": "List of configurable time parameters and their values (milliseconds).",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "data",
+                "type": "block",
+                "optional": true,
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "parameter",
+                        "type": "string"
+                    },
+                    {
+                        "name": "value",
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-failover.json
+++ b/vendor/redis-7.2.6-commands/sentinel-failover.json
@@ -1,0 +1,25 @@
+{
+    "FAILOVER": {
+        "summary": "Forces a Redis Sentinel failover.",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": 3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "const": "OK",
+            "description": "Force a fail over as if the master was not reachable, and without asking for agreement to other Sentinels."
+        },
+        "arguments": [
+            {
+                "name": "master-name",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-flushconfig.json
+++ b/vendor/redis-7.2.6-commands/sentinel-flushconfig.json
@@ -1,0 +1,20 @@
+{
+    "FLUSHCONFIG": {
+        "summary": "Rewrites the Redis Sentinel configuration file.",
+        "complexity": "O(1)",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": 2,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "const": "OK",
+            "description": "Force Sentinel to rewrite its configuration on disk, including the current Sentinel state."
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-get-master-addr-by-name.json
+++ b/vendor/redis-7.2.6-commands/sentinel-get-master-addr-by-name.json
@@ -1,0 +1,38 @@
+{
+    "GET-MASTER-ADDR-BY-NAME": {
+        "summary": "Returns the port and address of a master Redis instance.",
+        "complexity": "O(1)",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": 3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": [
+                {
+                    "type": "string",
+                    "description": "IP addr or hostname."
+                },
+                {
+                    "type": "string",
+                    "description": "Port.",
+                    "pattern": "[0-9]+"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "master-name",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-help.json
+++ b/vendor/redis-7.2.6-commands/sentinel-help.json
@@ -1,0 +1,24 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "sentinel",
+        "since": "6.2.0",
+        "arity": 2,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-info-cache.json
+++ b/vendor/redis-7.2.6-commands/sentinel-info-cache.json
@@ -1,0 +1,64 @@
+{
+    "INFO-CACHE": {
+        "summary": "Returns the cached `INFO` replies from the deployment's instances.",
+        "complexity": "O(N) where N is the number of instances",
+        "group": "sentinel",
+        "since": "3.2.0",
+        "arity": -3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "This is actually a map, the odd entries are a master name, and the even entries are the last cached INFO output from that master and all its replicas.",
+            "minItems": 0,
+            "maxItems": 4294967295,
+            "items": [
+                {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "description": "The master name."
+                        },
+                        {
+                            "type": "array",
+                            "description": "This is an array of pairs, the odd entries are the INFO age, and the even entries are the cached INFO string. The first pair belong to the master and the rest are its replicas.",
+                            "minItems": 2,
+                            "maxItems": 2,
+                            "items": [
+                                {
+                                    "description": "The number of milliseconds since when the INFO was cached.",
+                                    "type": "integer"
+                                },
+                                {
+                                    "description": "The cached INFO string or null.",
+                                    "oneOf": [
+                                        {
+                                            "description": "The cached INFO string.",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "description": "No cached INFO string.",
+                                            "type": "null"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "nodename",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-is-master-down-by-addr.json
+++ b/vendor/redis-7.2.6-commands/sentinel-is-master-down-by-addr.json
@@ -1,0 +1,61 @@
+{
+    "IS-MASTER-DOWN-BY-ADDR": {
+        "summary": "Determines whether a master Redis instance is down.",
+        "complexity": "O(1)",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": 6,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 3,
+            "items": [
+                {
+                    "oneOf": [
+                        {
+                            "const": 0,
+                            "description": "Master is up."
+                        },
+                        {
+                            "const": 1,
+                            "description": "Master is down."
+                        }
+                    ]
+                },
+                {
+                    "type": "string",
+                    "description": "Sentinel address."
+                },
+                {
+                    "type": "integer",
+                    "description": "Port."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "ip",
+                "type": "string"
+            },
+            {
+                "name": "port",
+                "type": "integer"
+            },
+            {
+                "name": "current-epoch",
+                "type": "integer"
+            },
+            {
+                "name": "runid",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-master.json
+++ b/vendor/redis-7.2.6-commands/sentinel-master.json
@@ -1,0 +1,29 @@
+{
+    "MASTER": {
+        "summary": "Returns the state of a master Redis instance.",
+        "complexity": "O(1)",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": 3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "object",
+            "description": "The state and info of the specified master.",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "arguments": [
+            {
+                "name": "master-name",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-masters.json
+++ b/vendor/redis-7.2.6-commands/sentinel-masters.json
@@ -1,0 +1,26 @@
+{
+    "MASTERS": {
+        "summary": "Returns a list of monitored Redis masters.",
+        "complexity": "O(N) where N is the number of masters",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": 2,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List of monitored Redis masters, and their state.",
+            "items": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-monitor.json
+++ b/vendor/redis-7.2.6-commands/sentinel-monitor.json
@@ -1,0 +1,37 @@
+{
+    "MONITOR": {
+        "summary": "Starts monitoring.",
+        "complexity": "O(1)",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": 6,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "name": "ip",
+                "type": "string"
+            },
+            {
+                "name": "port",
+                "type": "integer"
+            },
+            {
+                "name": "quorum",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-myid.json
+++ b/vendor/redis-7.2.6-commands/sentinel-myid.json
@@ -1,0 +1,20 @@
+{
+    "MYID": {
+        "summary": "Returns the Redis Sentinel instance ID.",
+        "complexity": "O(1)",
+        "group": "sentinel",
+        "since": "6.2.0",
+        "arity": 2,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "description": "Node ID of the sentinel instance.",
+            "type": "string"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-pending-scripts.json
+++ b/vendor/redis-7.2.6-commands/sentinel-pending-scripts.json
@@ -1,0 +1,52 @@
+{
+    "PENDING-SCRIPTS": {
+        "summary": "Returns information about pending scripts for Redis Sentinel.",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": 2,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List of pending scripts.",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "argv": {
+                        "type": "array",
+                        "description": "Script arguments.",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "flags": {
+                        "type": "string",
+                        "description": "Script flags."
+                    },
+                    "pid": {
+                        "type": "string",
+                        "description": "Script pid."
+                    },
+                    "run-time": {
+                        "type": "string",
+                        "description": "Script run-time."
+                    },
+                    "run-delay": {
+                        "type": "string",
+                        "description": "Script run-delay."
+                    },
+                    "retry-num": {
+                        "type": "string",
+                        "description": "Number of times we tried to execute the script."
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-remove.json
+++ b/vendor/redis-7.2.6-commands/sentinel-remove.json
@@ -1,0 +1,25 @@
+{
+    "REMOVE": {
+        "summary": "Stops monitoring.",
+        "complexity": "O(1)",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": 3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "master-name",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-replicas.json
+++ b/vendor/redis-7.2.6-commands/sentinel-replicas.json
@@ -1,0 +1,32 @@
+{
+    "REPLICAS": {
+        "summary": "Returns a list of the monitored Redis replicas.",
+        "complexity": "O(N) where N is the number of replicas",
+        "group": "sentinel",
+        "since": "5.0.0",
+        "arity": 3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List of replicas for this master, and their state.",
+            "items": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
+                }
+            }
+        },
+        "arguments": [
+            {
+                "name": "master-name",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-reset.json
+++ b/vendor/redis-7.2.6-commands/sentinel-reset.json
@@ -1,0 +1,26 @@
+{
+    "RESET": {
+        "summary": "Resets Redis masters by name matching a pattern.",
+        "complexity": "O(N) where N is the number of monitored masters",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": 3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "The number of masters that were reset."
+        },
+        "arguments": [
+            {
+                "name": "pattern",
+                "type": "pattern"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-sentinels.json
+++ b/vendor/redis-7.2.6-commands/sentinel-sentinels.json
@@ -1,0 +1,32 @@
+{
+    "SENTINELS": {
+        "summary": "Returns a list of Sentinel instances.",
+        "complexity": "O(N) where N is the number of Sentinels",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": 3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List of sentinel instances, and their state.",
+            "items": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
+                }
+            }
+        },
+        "arguments": [
+            {
+                "name": "master-name",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-set.json
+++ b/vendor/redis-7.2.6-commands/sentinel-set.json
@@ -1,0 +1,40 @@
+{
+    "SET": {
+        "summary": "Changes the configuration of a monitored Redis master.",
+        "complexity": "O(1)",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": -5,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "master-name",
+                "type": "string"
+            },
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "option",
+                        "type": "string"
+                    },
+                    {
+                        "name": "value",
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-simulate-failure.json
+++ b/vendor/redis-7.2.6-commands/sentinel-simulate-failure.json
@@ -1,0 +1,52 @@
+{
+    "SIMULATE-FAILURE": {
+        "summary": "Simulates failover scenarios.",
+        "group": "sentinel",
+        "since": "3.2.0",
+        "arity": -3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The simulated flag was set.",
+                    "const": "OK"
+                },
+                {
+                    "description": "Supported simulates flags. Returned in case `HELP` was used.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "mode",
+                "type": "oneof",
+                "optional":true,
+                "multiple":true,
+                "arguments": [
+                    {
+                        "name": "crash-after-election",
+                        "type": "pure-token"
+                    },
+                    {
+                        "name": "crash-after-promotion",
+                        "type": "pure-token"
+                    },
+                    {
+                        "name": "help",
+                        "type": "pure-token"
+                    }
+                ]
+            }            
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel-slaves.json
+++ b/vendor/redis-7.2.6-commands/sentinel-slaves.json
@@ -1,0 +1,37 @@
+{
+    "SLAVES": {
+        "summary": "Returns a list of the monitored replicas.",
+        "complexity": "O(N) where N is the number of replicas.",
+        "group": "sentinel",
+        "since": "2.8.0",
+        "arity": 3,
+        "container": "SENTINEL",
+        "function": "sentinelCommand",
+        "deprecated_since": "5.0.0",
+        "replaced_by": "`SENTINEL REPLICAS`",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List of monitored replicas, and their state.",
+            "items": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
+                }
+            }
+        },
+        "arguments": [
+            {
+                "name": "master-name",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sentinel.json
+++ b/vendor/redis-7.2.6-commands/sentinel.json
@@ -1,0 +1,14 @@
+{
+    "SENTINEL": {
+        "summary": "A container for Redis Sentinel commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "sentinel",
+        "since": "2.8.4",
+        "arity": -2,
+        "command_flags": [
+            "ADMIN",
+            "SENTINEL",
+            "ONLY_SENTINEL"
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/set.json
+++ b/vendor/redis-7.2.6-commands/set.json
@@ -1,0 +1,152 @@
+{
+    "SET": {
+        "summary": "Sets the string value of a key, ignoring its type. The key is created if it doesn't exist.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "1.0.0",
+        "arity": -3,
+        "function": "setCommand",
+        "get_keys_function": "setGetKeys",
+        "history": [
+            [
+                "2.6.12",
+                "Added the `EX`, `PX`, `NX` and `XX` options."
+            ],
+            [
+                "6.0.0",
+                "Added the `KEEPTTL` option."
+            ],
+            [
+                "6.2.0",
+                "Added the `GET`, `EXAT` and `PXAT` option."
+            ],
+            [
+                "7.0.0",
+                "Allowed the `NX` and `GET` options to be used together."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "notes": "RW and ACCESS due to the optional `GET` argument",
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE",
+                    "VARIABLE_FLAGS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf":[
+                {
+                    "description": "`GET` not given: Operation was aborted (conflict with one of the `XX`/`NX` options).",
+                    "type": "null"
+                },
+                {
+                    "description": "`GET` not given: The key was set.",
+                    "const": "OK"
+                },
+                {
+                    "description": "`GET` given: The key didn't exist before the `SET`",
+                    "type": "null"
+                },
+                {
+                    "description": "`GET` given: The previous value of the key",
+                    "type": "string"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "value",
+                "type": "string"
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "since": "2.6.12",
+                "arguments": [
+                    {
+                        "name": "nx",
+                        "type": "pure-token",
+                        "token": "NX"
+                    },
+                    {
+                        "name": "xx",
+                        "type": "pure-token",
+                        "token": "XX"
+                    }
+                ]
+            },
+            {
+                "name": "get",
+                "token": "GET",
+                "type": "pure-token",
+                "optional": true,
+                "since": "6.2.0"
+            },
+            {
+                "name": "expiration",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "seconds",
+                        "type": "integer",
+                        "token": "EX",
+                        "since": "2.6.12"
+                    },
+                    {
+                        "name": "milliseconds",
+                        "type": "integer",
+                        "token": "PX",
+                        "since": "2.6.12"
+                    },
+                    {
+                        "name": "unix-time-seconds",
+                        "type": "unix-time",
+                        "token": "EXAT",
+                        "since": "6.2.0"
+                    },
+                    {
+                        "name": "unix-time-milliseconds",
+                        "type": "unix-time",
+                        "token": "PXAT",
+                        "since": "6.2.0"
+                    },
+                    {
+                        "name": "keepttl",
+                        "type": "pure-token",
+                        "token": "KEEPTTL",
+                        "since": "6.0.0"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/setbit.json
+++ b/vendor/redis-7.2.6-commands/setbit.json
@@ -1,0 +1,64 @@
+{
+    "SETBIT": {
+        "summary": "Sets or clears the bit at offset of the string value. Creates the key if it doesn't exist.",
+        "complexity": "O(1)",
+        "group": "bitmap",
+        "since": "2.2.0",
+        "arity": 4,
+        "function": "setbitCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "BITMAP"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The original bit value stored at offset.",
+            "oneOf": [
+                {
+                    "const": 0
+                },
+                {
+                    "const": 1
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "offset",
+                "type": "integer"
+            },
+            {
+                "name": "value",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/setex.json
+++ b/vendor/redis-7.2.6-commands/setex.json
@@ -1,0 +1,60 @@
+{
+    "SETEX": {
+        "summary": "Sets the string value and expiration time of a key. Creates the key if it doesn't exist.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "2.0.0",
+        "arity": 4,
+        "function": "setexCommand",
+        "deprecated_since": "2.6.12",
+        "replaced_by": "`SET` with the `EX` argument",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "seconds",
+                "type": "integer"
+            },
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/setnx.json
+++ b/vendor/redis-7.2.6-commands/setnx.json
@@ -1,0 +1,66 @@
+{
+    "SETNX": {
+        "summary": "Set the string value of a key only when the key doesn't exist.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "1.0.0",
+        "arity": 3,
+        "function": "setnxCommand",
+        "deprecated_since": "2.6.12",
+        "replaced_by": "`SET` with the `NX` argument",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The key was set.",
+                    "const": 0
+                },
+                {
+                    "description": "The key was not set.",
+                    "const": 1
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/setrange.json
+++ b/vendor/redis-7.2.6-commands/setrange.json
@@ -1,0 +1,57 @@
+{
+    "SETRANGE": {
+        "summary": "Overwrites a part of a string value with another by an offset. Creates the key if it doesn't exist.",
+        "complexity": "O(1), not counting the time taken to copy the new string in place. Usually, this string is very small so the amortized complexity is O(1). Otherwise, complexity is O(M) with M being the length of the value argument.",
+        "group": "string",
+        "since": "2.2.0",
+        "arity": 4,
+        "function": "setrangeCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Length of the string after it was modified by the command.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "offset",
+                "type": "integer"
+            },
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/shutdown.json
+++ b/vendor/redis-7.2.6-commands/shutdown.json
@@ -1,0 +1,69 @@
+{
+    "SHUTDOWN": {
+        "summary": "Synchronously saves the database(s) to disk and shuts down the Redis server.",
+        "complexity": "O(N) when saving, where N is the total number of keys in all databases when saving data, otherwise O(1)",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": -1,
+        "function": "shutdownCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added the `NOW`, `FORCE` and `ABORT` modifiers."
+            ]
+        ],
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "NO_MULTI",
+            "SENTINEL",
+            "ALLOW_BUSY"
+        ],
+        "arguments": [
+            {
+                "name": "save-selector",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "nosave",
+                        "type": "pure-token",
+                        "token": "NOSAVE"
+                    },
+                    {
+                        "name": "save",
+                        "type": "pure-token",
+                        "token": "SAVE"
+                    }
+                ]
+            },
+            {
+                "name": "now",
+                "type": "pure-token",
+                "token": "NOW",
+                "optional": true,
+                "since": "7.0.0"
+            },
+            {
+                "name": "force",
+                "type": "pure-token",
+                "token": "FORCE",
+                "optional": true,
+                "since": "7.0.0"
+            },
+            {
+                "name": "abort",
+                "type": "pure-token",
+                "token": "ABORT",
+                "optional": true,
+                "since": "7.0.0"
+            }
+        ],
+        "reply_schema": {
+            "description": "OK if ABORT was specified and shutdown was aborted. On successful shutdown, nothing is returned since the server quits and the connection is closed. On failure, an error is returned.",
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/sinter.json
+++ b/vendor/redis-7.2.6-commands/sinter.json
@@ -1,0 +1,55 @@
+{
+    "SINTER": {
+        "summary": "Returns the intersect of multiple sets.",
+        "complexity": "O(N*M) worst case where N is the cardinality of the smallest set and M is the number of sets.",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "sinterCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List with the members of the resulting set.",
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sintercard.json
+++ b/vendor/redis-7.2.6-commands/sintercard.json
@@ -1,0 +1,60 @@
+{
+    "SINTERCARD": {
+        "summary": "Returns the number of members of the intersect of multiple sets.",
+        "complexity": "O(N*M) worst case where N is the cardinality of the smallest set and M is the number of sets.",
+        "group": "set",
+        "since": "7.0.0",
+        "arity": -3,
+        "function": "sinterCardCommand",
+        "get_keys_function": "sintercardGetKeys",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of the elements in the resulting intersection.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "token": "LIMIT",
+                "name": "limit",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sinterstore.json
+++ b/vendor/redis-7.2.6-commands/sinterstore.json
@@ -1,0 +1,73 @@
+{
+    "SINTERSTORE": {
+        "summary": "Stores the intersect of multiple sets in a key.",
+        "complexity": "O(N*M) worst case where N is the cardinality of the smallest set and M is the number of sets.",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": -3,
+        "function": "sinterstoreCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of the elements in the result set.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 1,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sismember.json
+++ b/vendor/redis-7.2.6-commands/sismember.json
@@ -1,0 +1,59 @@
+{
+    "SISMEMBER": {
+        "summary": "Determines whether a member belongs to a set.",
+        "complexity": "O(1)",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": 3,
+        "function": "sismemberCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "const": 0,
+                    "description": "The element is not a member of the set, or the key does not exist."
+                },
+                {
+                    "const": 1,
+                    "description": "The element is a member of the set."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/slaveof.json
+++ b/vendor/redis-7.2.6-commands/slaveof.json
@@ -1,0 +1,64 @@
+{
+    "SLAVEOF": {
+        "summary": "Sets a Redis server as a replica of another, or promotes it to being a master.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": 3,
+        "function": "replicaofCommand",
+        "deprecated_since": "5.0.0",
+        "replaced_by": "`REPLICAOF`",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "NOSCRIPT",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "args",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "host-port",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "host",
+                                "type": "string"
+                            },
+                            {
+                                "name": "port",
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "no-one",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "no",
+                                "type": "pure-token",
+                                "token": "NO"
+                            },
+                            {
+                                "name": "one",
+                                "type": "pure-token",
+                                "token": "ONE"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "description": "slaveOf status",
+            "type": "string",
+            "pattern": "OK*"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/slowlog-get.json
+++ b/vendor/redis-7.2.6-commands/slowlog-get.json
@@ -1,0 +1,74 @@
+{
+    "GET": {
+        "summary": "Returns the slow log's entries.",
+        "complexity": "O(N) where N is the number of entries returned",
+        "group": "server",
+        "since": "2.2.12",
+        "arity": -2,
+        "container": "SLOWLOG",
+        "function": "slowlogCommand",
+        "history": [
+            [
+                "4.0.0",
+                "Added client IP address, port and name to the reply."
+            ]
+        ],
+        "command_flags": [
+            "ADMIN",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_NODES",
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Entries from the slow log in chronological order.",
+            "uniqueItems": true,
+            "items": {
+                "type": "array",
+                "minItems": 6,
+                "maxItems": 6,
+                "items": [
+                    {
+                        "type": "integer",
+                        "description": "Slow log entry ID."
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The unix timestamp at which the logged command was processed.",
+                        "minimum": 0
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The amount of time needed for its execution, in microseconds.",
+                        "minimum": 0
+                    },
+                    {
+                        "type": "array",
+                        "description": "The arguments of the command.",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Client IP address and port."
+                    },
+                    {
+                        "type": "string",
+                        "description": "Client name if set via the CLIENT SETNAME command."
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/slowlog-help.json
+++ b/vendor/redis-7.2.6-commands/slowlog-help.json
@@ -1,0 +1,22 @@
+{
+    "HELP": {
+        "summary": "Show helpful text about the different subcommands",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "6.2.0",
+        "arity": 2,
+        "container": "SLOWLOG",
+        "function": "slowlogCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/slowlog-len.json
+++ b/vendor/redis-7.2.6-commands/slowlog-len.json
@@ -1,0 +1,26 @@
+{
+    "LEN": {
+        "summary": "Returns the number of entries in the slow log.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "2.2.12",
+        "arity": 2,
+        "container": "SLOWLOG",
+        "function": "slowlogCommand",
+        "command_flags": [
+            "ADMIN",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:AGG_SUM",
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "Number of entries in the slow log.",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/slowlog-reset.json
+++ b/vendor/redis-7.2.6-commands/slowlog-reset.json
@@ -1,0 +1,23 @@
+{
+    "RESET": {
+        "summary": "Clears all entries from the slow log.",
+        "complexity": "O(N) where N is the number of entries in the slowlog",
+        "group": "server",
+        "since": "2.2.12",
+        "arity": 2,
+        "container": "SLOWLOG",
+        "function": "slowlogCommand",
+        "command_flags": [
+            "ADMIN",
+            "LOADING",
+            "STALE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/slowlog.json
+++ b/vendor/redis-7.2.6-commands/slowlog.json
@@ -1,0 +1,9 @@
+{
+    "SLOWLOG": {
+        "summary": "A container for slow log commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "server",
+        "since": "2.2.12",
+        "arity": -2
+    }
+}

--- a/vendor/redis-7.2.6-commands/smembers.json
+++ b/vendor/redis-7.2.6-commands/smembers.json
@@ -1,0 +1,54 @@
+{
+    "SMEMBERS": {
+        "summary": "Returns all members of a set.",
+        "complexity": "O(N) where N is the set cardinality.",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": 2,
+        "function": "sinterCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "All elements of the set.",
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/smismember.json
+++ b/vendor/redis-7.2.6-commands/smismember.json
@@ -1,0 +1,66 @@
+{
+    "SMISMEMBER": {
+        "summary": "Determines whether multiple members belong to a set.",
+        "complexity": "O(N) where N is the number of elements being checked for membership",
+        "group": "set",
+        "since": "6.2.0",
+        "arity": -3,
+        "function": "smismemberCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List representing the membership of the given elements, in the same order as they are requested.",
+            "minItems": 1,
+            "items": {
+                "oneOf": [
+                    {
+                        "const": 0,
+                        "description": "Not a member of the set or the key does not exist."
+                    },
+                    {
+                        "const": 1,
+                        "description": "A member of the set."
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/smove.json
+++ b/vendor/redis-7.2.6-commands/smove.json
@@ -1,0 +1,84 @@
+{
+    "SMOVE": {
+        "summary": "Moves a member from one set to another.",
+        "complexity": "O(1)",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": 4,
+        "function": "smoveCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "const": 1,
+                    "description": "Element is moved."
+                },
+                {
+                    "const": 0,
+                    "description": "The element is not a member of source and no operation was performed."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "source",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 1
+            },
+            {
+                "name": "member",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sort.json
+++ b/vendor/redis-7.2.6-commands/sort.json
@@ -1,0 +1,162 @@
+{
+    "SORT": {
+        "summary": "Sorts the elements in a list, a set, or a sorted set, optionally storing the result.",
+        "complexity": "O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is O(N).",
+        "group": "generic",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "sortCommand",
+        "get_keys_function": "sortGetKeys",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "SET",
+            "SORTEDSET",
+            "LIST",
+            "DANGEROUS"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "notes": "For the optional BY/GET keyword. It is marked 'unknown' because the key names derive from the content of the key we sort",
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "unknown": null
+                },
+                "find_keys": {
+                    "unknown": null
+                }
+            },
+            {
+                "notes": "For the optional STORE keyword. It is marked 'unknown' because the keyword can appear anywhere in the argument array",
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "unknown": null
+                },
+                "find_keys": {
+                    "unknown": null
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "token": "BY",
+                "name": "by-pattern",
+                "display": "pattern",
+                "type": "pattern",
+                "key_spec_index": 1,
+                "optional": true
+            },
+            {
+                "token": "LIMIT",
+                "name": "limit",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "offset",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    }
+                ]
+            },
+            {
+                "token": "GET",
+                "name": "get-pattern",
+                "display": "pattern",
+                "key_spec_index": 1,
+                "type": "pattern",
+                "optional": true,
+                "multiple": true,
+                "multiple_token": true
+            },
+            {
+                "name": "order",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "asc",
+                        "type": "pure-token",
+                        "token": "ASC"
+                    },
+                    {
+                        "name": "desc",
+                        "type": "pure-token",
+                        "token": "DESC"
+                    }
+                ]
+            },
+            {
+                "name": "sorting",
+                "token": "ALPHA",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "token": "STORE",
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 2,
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "when the store option is specified the command returns the number of sorted elements in the destination list",
+                    "type": "integer",
+                    "minimum": 0
+                },
+                {
+                    "description": "when not passing the store option the command returns a list of sorted elements",
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "description": "GET option is specified, but no object was found",
+                                "type": "null"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/sort_ro.json
+++ b/vendor/redis-7.2.6-commands/sort_ro.json
@@ -1,0 +1,132 @@
+{
+    "SORT_RO": {
+        "summary": "Returns the sorted elements of a list, a set, or a sorted set.",
+        "complexity": "O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is O(N).",
+        "group": "generic",
+        "since": "7.0.0",
+        "arity": -2,
+        "function": "sortroCommand",
+        "get_keys_function": "sortROGetKeys",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SET",
+            "SORTEDSET",
+            "LIST",
+            "DANGEROUS"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "notes": "For the optional BY/GET keyword. It is marked 'unknown' because the key names derive from the content of the key we sort",
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "unknown": null
+                },
+                "find_keys": {
+                    "unknown": null
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "token": "BY",
+                "name": "by-pattern",
+                "display": "pattern",
+                "type": "pattern",
+                "key_spec_index": 1,
+                "optional": true
+            },
+            {
+                "token": "LIMIT",
+                "name": "limit",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "offset",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    }
+                ]
+            },
+            {
+                "token": "GET",
+                "name": "get-pattern",
+                "display": "pattern",
+                "key_spec_index": 1,
+                "type": "pattern",
+                "optional": true,
+                "multiple": true,
+                "multiple_token": true
+            },
+            {
+                "name": "order",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "asc",
+                        "type": "pure-token",
+                        "token": "ASC"
+                    },
+                    {
+                        "name": "desc",
+                        "type": "pure-token",
+                        "token": "DESC"
+                    }
+                ]
+            },
+            {
+                "name": "sorting",
+                "token": "ALPHA",
+                "type": "pure-token",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "a list of sorted elements",
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "description": "GET option is specified, but no object was found",
+                        "type": "null"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/spop.json
+++ b/vendor/redis-7.2.6-commands/spop.json
@@ -1,0 +1,80 @@
+{
+    "SPOP": {
+        "summary": "Returns one or more random members from a set after removing them. Deletes the set if the last member was popped.",
+        "complexity": "Without the count argument O(1), otherwise O(N) where N is the value of the passed count.",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "spopCommand",
+        "history": [
+            [
+                "3.2.0",
+                "Added the `count` argument."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "null",
+                    "description": "The key does not exist."
+                },
+                {
+                    "type": "string",
+                    "description": "The removed member when 'COUNT' is not given."
+                },
+                {
+                    "type": "array",
+                    "description": "List to the removed members when 'COUNT' is given.",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "optional": true,
+                "since": "3.2.0"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/spublish.json
+++ b/vendor/redis-7.2.6-commands/spublish.json
@@ -1,0 +1,51 @@
+{
+    "SPUBLISH": {
+        "summary": "Post a message to a shard channel",
+        "complexity": "O(N) where N is the number of clients subscribed to the receiving shard channel.",
+        "group": "pubsub",
+        "since": "7.0.0",
+        "arity": 3,
+        "function": "spublishCommand",
+        "command_flags": [
+            "PUBSUB",
+            "LOADING",
+            "STALE",
+            "FAST",
+            "MAY_REPLICATE"
+        ],
+        "arguments": [
+            {
+                "name": "shardchannel",
+                "type": "string"
+            },
+            {
+                "name": "message",
+                "type": "string"
+            }
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "NOT_KEY"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "the number of clients that received the message. Note that in a Redis Cluster, only clients that are connected to the same node as the publishing client are included in the count",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/srandmember.json
+++ b/vendor/redis-7.2.6-commands/srandmember.json
@@ -1,0 +1,83 @@
+{
+    "SRANDMEMBER": {
+        "summary": "Get one or multiple random members from a set",
+        "complexity": "Without the count argument O(1), otherwise O(N) where N is the absolute value of the passed count.",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "srandmemberCommand",
+        "history": [
+            [
+                "2.6.0",
+                "Added the optional `count` argument."
+            ]
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "optional": true,
+                "since": "2.6.0"
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "In case `count` is not given and key doesn't exist",
+                    "type": "null"
+                },
+                {
+                    "description": "In case `count` is not given, randomly selected element",
+                    "type": "string"
+                },
+                {
+                    "description": "In case `count` is given, an array of elements",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1
+                },
+                {
+                    "description": "In case `count` is given and key doesn't exist",
+                    "type": "array",
+                    "maxItems": 0
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/srem.json
+++ b/vendor/redis-7.2.6-commands/srem.json
@@ -1,0 +1,60 @@
+{
+    "SREM": {
+        "summary": "Removes one or more members from a set. Deletes the set if the last member was removed.",
+        "complexity": "O(N) where N is the number of members to be removed.",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": -3,
+        "function": "sremCommand",
+        "history": [
+            [
+                "2.4.0",
+                "Accepts multiple `member` arguments."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of members that were removed from the set, not including non existing members.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sscan.json
+++ b/vendor/redis-7.2.6-commands/sscan.json
@@ -1,0 +1,81 @@
+{
+    "SSCAN": {
+        "summary": "Iterates over members of a set.",
+        "complexity": "O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.",
+        "group": "set",
+        "since": "2.8.0",
+        "arity": -3,
+        "function": "sscanCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "cursor",
+                "type": "integer"
+            },
+            {
+                "token": "MATCH",
+                "name": "pattern",
+                "type": "pattern",
+                "optional": true
+            },
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "cursor and scan response in array form",
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": [
+                {
+                    "description": "cursor",
+                    "type": "string"
+                },
+                {
+                    "description": "list of set members",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/ssubscribe.json
+++ b/vendor/redis-7.2.6-commands/ssubscribe.json
@@ -1,0 +1,42 @@
+{
+    "SSUBSCRIBE": {
+        "summary": "Listens for messages published to shard channels.",
+        "complexity": "O(N) where N is the number of shard channels to subscribe to.",
+        "group": "pubsub",
+        "since": "7.0.0",
+        "arity": -2,
+        "function": "ssubscribeCommand",
+        "command_flags": [
+            "PUBSUB",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "shardchannel",
+                "type": "string",
+                "multiple": true
+            }
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "NOT_KEY"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/strlen.json
+++ b/vendor/redis-7.2.6-commands/strlen.json
@@ -1,0 +1,48 @@
+{
+    "STRLEN": {
+        "summary": "Returns the length of a string value.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "2.2.0",
+        "arity": 2,
+        "function": "strlenCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The length of the string value stored at key, or 0 when key does not exist.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/subscribe.json
+++ b/vendor/redis-7.2.6-commands/subscribe.json
@@ -1,0 +1,25 @@
+{
+    "SUBSCRIBE": {
+        "summary": "Listens for messages published to channels.",
+        "complexity": "O(N) where N is the number of channels to subscribe to.",
+        "group": "pubsub",
+        "since": "2.0.0",
+        "arity": -2,
+        "function": "subscribeCommand",
+        "history": [],
+        "command_flags": [
+            "PUBSUB",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "arguments": [
+            {
+                "name": "channel",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/substr.json
+++ b/vendor/redis-7.2.6-commands/substr.json
@@ -1,0 +1,60 @@
+{
+    "SUBSTR": {
+        "summary": "Returns a substring from a string value.",
+        "complexity": "O(N) where N is the length of the returned string. The complexity is ultimately determined by the returned length, but because creating a substring from an existing string is very cheap, it can be considered O(1) for small strings.",
+        "group": "string",
+        "since": "1.0.0",
+        "arity": 4,
+        "function": "getrangeCommand",
+        "deprecated_since": "2.0.0",
+        "replaced_by": "`GETRANGE`",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "string",
+            "description": "The substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer"
+            },
+            {
+                "name": "end",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sunion.json
+++ b/vendor/redis-7.2.6-commands/sunion.json
@@ -1,0 +1,55 @@
+{
+    "SUNION": {
+        "summary": "Returns the union of multiple sets.",
+        "complexity": "O(N) where N is the total number of elements in all given sets.",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": -2,
+        "function": "sunionCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT_ORDER"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List with the members of the resulting set.",
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sunionstore.json
+++ b/vendor/redis-7.2.6-commands/sunionstore.json
@@ -1,0 +1,73 @@
+{
+    "SUNIONSTORE": {
+        "summary": "Stores the union of multiple sets in a key.",
+        "complexity": "O(N) where N is the total number of elements in all given sets.",
+        "group": "set",
+        "since": "1.0.0",
+        "arity": -3,
+        "function": "sunionstoreCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "SET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "Number of the elements in the resulting set.",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 1,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/sunsubscribe.json
+++ b/vendor/redis-7.2.6-commands/sunsubscribe.json
@@ -1,0 +1,43 @@
+{
+    "SUNSUBSCRIBE": {
+        "summary": "Stops listening to messages posted to shard channels.",
+        "complexity": "O(N) where N is the number of shard channels to unsubscribe.",
+        "group": "pubsub",
+        "since": "7.0.0",
+        "arity": -1,
+        "function": "sunsubscribeCommand",
+        "command_flags": [
+            "PUBSUB",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "shardchannel",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "NOT_KEY"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/swapdb.json
+++ b/vendor/redis-7.2.6-commands/swapdb.json
@@ -1,0 +1,31 @@
+{
+    "SWAPDB": {
+        "summary": "Swaps two Redis databases.",
+        "complexity": "O(N) where N is the count of clients watching or blocking on keys from both databases.",
+        "group": "server",
+        "since": "4.0.0",
+        "arity": 3,
+        "function": "swapdbCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE",
+            "DANGEROUS"
+        ],
+        "arguments": [
+            {
+                "name": "index1",
+                "type": "integer"
+            },
+            {
+                "name": "index2",
+                "type": "integer"
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/sync.json
+++ b/vendor/redis-7.2.6-commands/sync.json
@@ -1,0 +1,15 @@
+{
+    "SYNC": {
+        "summary": "An internal command used in replication.",
+        "group": "server",
+        "since": "1.0.0",
+        "arity": 1,
+        "function": "syncCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "NO_MULTI",
+            "NOSCRIPT"
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/time.json
+++ b/vendor/redis-7.2.6-commands/time.json
@@ -1,0 +1,28 @@
+{
+    "TIME": {
+        "summary": "Returns the server time.",
+        "complexity": "O(1)",
+        "group": "server",
+        "since": "2.6.0",
+        "arity": 1,
+        "function": "timeCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE",
+            "FAST"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Array containing two elements: Unix time in seconds and microseconds.",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": {
+                "type": "string",
+                "pattern": "[0-9]+"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/touch.json
+++ b/vendor/redis-7.2.6-commands/touch.json
@@ -1,0 +1,53 @@
+{
+    "TOUCH": {
+        "summary": "Returns the number of existing keys out of those specified after updating the time they were last accessed.",
+        "complexity": "O(N) where N is the number of keys that will be touched.",
+        "group": "generic",
+        "since": "3.2.1",
+        "arity": -2,
+        "function": "touchCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:MULTI_SHARD",
+            "RESPONSE_POLICY:AGG_SUM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "the number of touched keys",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/ttl.json
+++ b/vendor/redis-7.2.6-commands/ttl.json
@@ -1,0 +1,70 @@
+{
+    "TTL": {
+        "summary": "Returns the expiration time in seconds of a key.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "1.0.0",
+        "arity": 2,
+        "function": "ttlCommand",
+        "history": [
+            [
+                "2.8.0",
+                "Added the -2 reply."
+            ]
+        ],
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "TTL in seconds.",
+                    "type": "integer",
+                    "minimum": 0
+                },
+                {
+                    "description": "The key exists but has no associated expire.",
+                    "const": -1
+                },
+                {
+                    "description": "The key does not exist.",
+                    "const": -2
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/type.json
+++ b/vendor/redis-7.2.6-commands/type.json
@@ -1,0 +1,55 @@
+{
+    "TYPE": {
+        "summary": "Determines the type of value stored at a key.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "1.0.0",
+        "arity": 2,
+        "function": "typeCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Key doesn't exist",
+                    "type": "null"
+                },
+                {
+                    "description": "Type of the key",
+                    "type": "string"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/unlink.json
+++ b/vendor/redis-7.2.6-commands/unlink.json
@@ -1,0 +1,54 @@
+{
+    "UNLINK": {
+        "summary": "Asynchronously deletes one or more keys.",
+        "complexity": "O(1) for each key removed regardless of its size. Then the command does O(N) work in a different thread in order to reclaim memory, where N is the number of allocations the deleted objects where composed of.",
+        "group": "generic",
+        "since": "4.0.0",
+        "arity": -2,
+        "function": "unlinkCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:MULTI_SHARD",
+            "RESPONSE_POLICY:AGG_SUM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RM",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "the number of keys that were unlinked",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/unsubscribe.json
+++ b/vendor/redis-7.2.6-commands/unsubscribe.json
@@ -1,0 +1,25 @@
+{
+    "UNSUBSCRIBE": {
+        "summary": "Stops listening to messages posted to channels.",
+        "complexity": "O(N) where N is the number of channels to unsubscribe.",
+        "group": "pubsub",
+        "since": "2.0.0",
+        "arity": -1,
+        "function": "unsubscribeCommand",
+        "command_flags": [
+            "PUBSUB",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "SENTINEL"
+        ],
+        "arguments": [
+            {
+                "name": "channel",
+                "type": "string",
+                "optional": true,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/unwatch.json
+++ b/vendor/redis-7.2.6-commands/unwatch.json
@@ -1,0 +1,23 @@
+{
+    "UNWATCH": {
+        "summary": "Forgets about watched keys of a transaction.",
+        "complexity": "O(1)",
+        "group": "transactions",
+        "since": "2.2.0",
+        "arity": 1,
+        "function": "unwatchCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "FAST",
+            "ALLOW_BUSY"
+        ],
+        "acl_categories": [
+            "TRANSACTION"
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/wait.json
+++ b/vendor/redis-7.2.6-commands/wait.json
@@ -1,0 +1,34 @@
+{
+    "WAIT": {
+        "summary": "Blocks until the asynchronous replication of all preceding write commands sent by the connection is completed.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "3.0.0",
+        "arity": 3,
+        "function": "waitCommand",
+        "command_flags": [
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:AGG_MIN"
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "The number of replicas reached by all the writes performed in the context of the current connection.",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "numreplicas",
+                "type": "integer"
+            },
+            {
+                "name": "timeout",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/waitaof.json
+++ b/vendor/redis-7.2.6-commands/waitaof.json
@@ -1,0 +1,52 @@
+{
+    "WAITAOF": {
+        "summary": "Blocks until all of the preceding write commands sent by the connection are written to the append-only file of the master and/or replicas.",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "7.2.0",
+        "arity": 4,
+        "function": "waitaofCommand",
+        "command_flags": [
+            "NOSCRIPT"
+        ],
+        "acl_categories": [
+            "CONNECTION"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:AGG_MIN"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Number of local and remote AOF files in sync.",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": [
+                {
+                    "description": "Number of local AOF files.",
+                    "type": "integer",
+                    "minimum": 0
+                },
+                {
+                    "description": "Number of replica AOF files.",
+                    "type": "number",
+                    "minimum": 0
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "numlocal",
+                "type": "integer"
+            },
+            {
+                "name": "numreplicas",
+                "type": "integer"
+            },
+            {
+                "name": "timeout",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/watch.json
+++ b/vendor/redis-7.2.6-commands/watch.json
@@ -1,0 +1,50 @@
+{
+    "WATCH": {
+        "summary": "Monitors changes to keys to determine the execution of a transaction.",
+        "complexity": "O(1) for every key.",
+        "group": "transactions",
+        "since": "2.2.0",
+        "arity": -2,
+        "function": "watchCommand",
+        "command_flags": [
+            "NOSCRIPT",
+            "LOADING",
+            "STALE",
+            "FAST",
+            "ALLOW_BUSY"
+        ],
+        "acl_categories": [
+            "TRANSACTION"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/xack.json
+++ b/vendor/redis-7.2.6-commands/xack.json
@@ -1,0 +1,58 @@
+{
+    "XACK": {
+        "summary": "Returns the number of messages that were successfully acknowledged by the consumer group member of a stream.",
+        "complexity": "O(1) for each message ID processed.",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -4,
+        "function": "xackCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string"
+            },
+            {
+                "name": "ID",
+                "type": "string",
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "The command returns the number of messages successfully acknowledged. Certain message IDs may no longer be part of the PEL (for example because they have already been acknowledged), and XACK will not count them as successfully acknowledged.",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xadd.json
+++ b/vendor/redis-7.2.6-commands/xadd.json
@@ -1,0 +1,161 @@
+{
+    "XADD": {
+        "summary": "Appends a new message to a stream. Creates the key if it doesn't exist.",
+        "complexity": "O(1) when adding a new entry, O(N) when trimming where N being the number of entries evicted.",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -5,
+        "function": "xaddCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added the `NOMKSTREAM` option, `MINID` trimming strategy and the `LIMIT` option."
+            ],
+            [
+                "7.0.0",
+                "Added support for the `<ms>-*` explicit ID form."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "notes": "UPDATE instead of INSERT because of the optional trimming feature",
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "token": "NOMKSTREAM",
+                "name": "nomkstream",
+                "type": "pure-token",
+                "optional": true,
+                "since": "6.2.0"
+            },
+            {
+                "name": "trim",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "strategy",
+                        "type": "oneof",
+                        "arguments": [
+                            {
+                                "name": "maxlen",
+                                "type": "pure-token",
+                                "token": "MAXLEN"
+                            },
+                            {
+                                "name": "minid",
+                                "type": "pure-token",
+                                "token": "MINID",
+                                "since": "6.2.0"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "operator",
+                        "type": "oneof",
+                        "optional": true,
+                        "arguments": [
+                            {
+                                "name": "equal",
+                                "type": "pure-token",
+                                "token": "="
+                            },
+                            {
+                                "name": "approximately",
+                                "type": "pure-token",
+                                "token": "~"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "threshold",
+                        "type": "string"
+                    },
+                    {
+                        "token": "LIMIT",
+                        "name": "count",
+                        "type": "integer",
+                        "optional": true,
+                        "since": "6.2.0"
+                    }
+                ]
+            },
+            {
+                "name": "id-selector",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "auto-id",
+                        "type": "pure-token",
+                        "token": "*"
+                    },
+                    {
+                        "name": "id",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "field",
+                        "type": "string"
+                    },
+                    {
+                        "name": "value",
+                        "type": "string"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "oneOf":[
+                {
+                    "description": "The ID of the added entry. The ID is the one auto-generated if * is passed as ID argument, otherwise the command just returns the same ID specified by the user during insertion.",
+                    "type": "string",
+                    "pattern": "[0-9]+-[0-9]+"
+                },
+                {
+                    "description": "The NOMKSTREAM option is given and the key doesn't exist.",
+                    "type": "null"
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xautoclaim.json
+++ b/vendor/redis-7.2.6-commands/xautoclaim.json
@@ -1,0 +1,158 @@
+{
+    "XAUTOCLAIM": {
+        "summary": "Changes, or acquires, ownership of messages in a consumer group, as if the messages were delivered to as consumer group member.",
+        "complexity": "O(1) if COUNT is small.",
+        "group": "stream",
+        "since": "6.2.0",
+        "arity": -6,
+        "function": "xautoclaimCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added an element to the reply array, containing deleted entries the command cleared from the PEL"
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "description": "Claimed stream entries (with data, if `JUSTID` was not given).",
+                    "type": "array",
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "items": [
+                        {
+                            "description": "Cursor for next call.",
+                            "type": "string",
+                            "pattern": "[0-9]+-[0-9]+"
+                        },
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": [
+                                    {
+                                        "description": "Entry ID",
+                                        "type": "string",
+                                        "pattern": "[0-9]+-[0-9]+"
+                                    },
+                                    {
+                                        "description": "Data",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "description": "Entry IDs which no longer exist in the stream, and were deleted from the PEL in which they were found.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "pattern": "[0-9]+-[0-9]+"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "description": "Claimed stream entries (without data, if `JUSTID` was given).",
+                    "type": "array",
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "items": [
+                        {
+                            "description": "Cursor for next call.",
+                            "type": "string",
+                            "pattern": "[0-9]+-[0-9]+"
+                        },
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "pattern": "[0-9]+-[0-9]+"
+                            }
+                        },
+                        {
+                            "description": "Entry IDs which no longer exist in the stream, and were deleted from the PEL in which they were found.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "pattern": "[0-9]+-[0-9]+"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string"
+            },
+            {
+                "name": "consumer",
+                "type": "string"
+            },
+            {
+                "name": "min-idle-time",
+                "type": "string"
+            },
+            {
+                "name": "start",
+                "type": "string"
+            },
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "name": "justid",
+                "token": "JUSTID",
+                "type": "pure-token",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/xclaim.json
+++ b/vendor/redis-7.2.6-commands/xclaim.json
@@ -1,0 +1,138 @@
+{
+    "XCLAIM": {
+        "summary": "Changes, or acquires, ownership of a message in a consumer group, as if the message was delivered a consumer group member.",
+        "complexity": "O(log N) with N being the number of messages in the PEL of the consumer group.",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -6,
+        "function": "xclaimCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string"
+            },
+            {
+                "name": "consumer",
+                "type": "string"
+            },
+            {
+                "name": "min-idle-time",
+                "type": "string"
+            },
+            {
+                "name": "ID",
+                "type": "string",
+                "multiple": true
+            },
+            {
+                "token": "IDLE",
+                "name": "ms",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "token": "TIME",
+                "name": "unix-time-milliseconds",
+                "type": "unix-time",
+                "optional": true
+            },
+            {
+                "token": "RETRYCOUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "name": "force",
+                "token": "FORCE",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "justid",
+                "token": "JUSTID",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "lastid",
+                "token": "LASTID",
+                "type": "string",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "Stream entries with IDs matching the specified range.",
+            "anyOf": [
+                {
+                    "description": "If JUSTID option is specified, return just an array of IDs of messages successfully claimed",
+                    "type": "array",
+                    "items": {
+                        "description": "Entry ID",
+                        "type": "string",
+                        "pattern": "[0-9]+-[0-9]+"
+                    }
+                },
+                {
+                    "description": "array of stream entries that contains each entry as an array of 2 elements, the Entry ID and the entry data itself",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "description": "Entry ID",
+                                "type": "string",
+                                "pattern": "[0-9]+-[0-9]+"
+                            },
+                            {
+                                "description": "Data",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xdel.json
+++ b/vendor/redis-7.2.6-commands/xdel.json
@@ -1,0 +1,54 @@
+{
+    "XDEL": {
+        "summary": "Returns the number of messages after removing them from a stream.",
+        "complexity": "O(1) for each single item to delete in the stream, regardless of the stream size.",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -3,
+        "function": "xdelCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "ID",
+                "type": "string",
+                "multiple": true
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of entries actually deleted",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xgroup-create.json
+++ b/vendor/redis-7.2.6-commands/xgroup-create.json
@@ -1,0 +1,85 @@
+{
+    "CREATE": {
+        "summary": "Creates a consumer group.",
+        "complexity": "O(1)",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -5,
+        "container": "XGROUP",
+        "function": "xgroupCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added the `entries_read` named argument."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string"
+            },
+            {
+                "name": "id-selector",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "id",
+                        "type": "string"
+                    },
+                    {
+                        "name": "new-id",
+                        "type": "pure-token",
+                        "token": "$"
+                    }
+                ]
+            },
+            {
+                "token": "MKSTREAM",
+                "name": "mkstream",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "token": "ENTRIESREAD",
+                "name": "entries-read",
+                "type": "integer",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xgroup-createconsumer.json
+++ b/vendor/redis-7.2.6-commands/xgroup-createconsumer.json
@@ -1,0 +1,64 @@
+{
+    "CREATECONSUMER": {
+        "summary": "Creates a consumer in a consumer group.",
+        "complexity": "O(1)",
+        "group": "stream",
+        "since": "6.2.0",
+        "arity": 5,
+        "container": "XGROUP",
+        "function": "xgroupCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string"
+            },
+            {
+                "name": "consumer",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of created consumers (0 or 1)",
+            "oneOf": [
+                {
+                    "const": 1
+                },
+                {
+                    "const": 0
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xgroup-delconsumer.json
+++ b/vendor/redis-7.2.6-commands/xgroup-delconsumer.json
@@ -1,0 +1,57 @@
+{
+    "DELCONSUMER": {
+        "summary": "Deletes a consumer from a consumer group.",
+        "complexity": "O(1)",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": 5,
+        "container": "XGROUP",
+        "function": "xgroupCommand",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string"
+            },
+            {
+                "name": "consumer",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of pending messages that were yet associated with such a consumer",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xgroup-destroy.json
+++ b/vendor/redis-7.2.6-commands/xgroup-destroy.json
@@ -1,0 +1,59 @@
+{
+    "DESTROY": {
+        "summary": "Destroys a consumer group.",
+        "complexity": "O(N) where N is the number of entries in the group's pending entries list (PEL).",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": 4,
+        "container": "XGROUP",
+        "function": "xgroupCommand",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of destroyed consumer groups (0 or 1)",
+            "oneOf": [
+                {
+                    "const": 1
+                },
+                {
+                    "const": 0
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xgroup-help.json
+++ b/vendor/redis-7.2.6-commands/xgroup-help.json
@@ -1,0 +1,25 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": 2,
+        "container": "XGROUP",
+        "function": "xgroupCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xgroup-setid.json
+++ b/vendor/redis-7.2.6-commands/xgroup-setid.json
@@ -1,0 +1,79 @@
+{
+    "SETID": {
+        "summary": "Sets the last-delivered ID of a consumer group.",
+        "complexity": "O(1)",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -5,
+        "container": "XGROUP",
+        "function": "xgroupCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added the optional `entries_read` argument."
+            ]
+        ],
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string"
+            },
+            {
+                "name": "id-selector",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "id",
+                        "type": "string"
+                    },
+                    {
+                        "name": "new-id",
+                        "type": "pure-token",
+                        "token": "$"
+                    }
+                ]
+            },
+            {
+                "name": "entriesread",
+                "display": "entries-read",
+                "token": "ENTRIESREAD",
+                "type": "integer",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xgroup.json
+++ b/vendor/redis-7.2.6-commands/xgroup.json
@@ -1,0 +1,9 @@
+{
+    "XGROUP": {
+        "summary": "A container for consumer groups commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -2
+    }
+}

--- a/vendor/redis-7.2.6-commands/xinfo-consumers.json
+++ b/vendor/redis-7.2.6-commands/xinfo-consumers.json
@@ -1,0 +1,80 @@
+{
+    "CONSUMERS": {
+        "summary": "Returns a list of the consumers in a consumer group.",
+        "complexity": "O(1)",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": 4,
+        "container": "XINFO",
+        "function": "xinfoCommand",
+        "history": [
+            [
+                "7.2.0",
+                "Added the `inactive` field."
+            ]
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string"
+            }
+        ],
+        "reply_schema": {
+            "description": "Array list of consumers",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "pending": {
+                        "type": "integer"
+                    },
+                    "idle": {
+                        "type": "integer"
+                    },
+                    "inactive": {
+                        "type": "integer"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xinfo-groups.json
+++ b/vendor/redis-7.2.6-commands/xinfo-groups.json
@@ -1,0 +1,92 @@
+{
+    "GROUPS": {
+        "summary": "Returns a list of the consumer groups of a stream.",
+        "complexity": "O(1)",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": 3,
+        "container": "XINFO",
+        "history": [
+            [
+                "7.0.0",
+                "Added the `entries-read` and `lag` fields"
+            ]
+        ],
+        "function": "xinfoCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "consumers": {
+                        "type": "integer"
+                    },
+                    "pending": {
+                        "type": "integer"
+                    },
+                    "last-delivered-id": {
+                        "type": "string",
+                        "pattern": "[0-9]+-[0-9]+"
+                    },
+                    "entries-read": {
+                        "oneOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    "lag": {
+                        "oneOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "type": "integer"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/xinfo-help.json
+++ b/vendor/redis-7.2.6-commands/xinfo-help.json
@@ -1,0 +1,25 @@
+{
+    "HELP": {
+        "summary": "Returns helpful text about the different subcommands.",
+        "complexity": "O(1)",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": 2,
+        "container": "XINFO",
+        "function": "xinfoCommand",
+        "command_flags": [
+            "LOADING",
+            "STALE"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "Helpful text about subcommands.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xinfo-stream.json
+++ b/vendor/redis-7.2.6-commands/xinfo-stream.json
@@ -1,0 +1,361 @@
+{
+    "STREAM": {
+        "summary": "Returns information about a stream.",
+        "complexity": "O(1)",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -3,
+        "container": "XINFO",
+        "history": [
+            [
+                "6.0.0",
+                "Added the `FULL` modifier."
+            ],
+            [
+                "7.0.0",
+                "Added the `max-deleted-entry-id`, `entries-added`, `recorded-first-entry-id`, `entries-read` and `lag` fields"
+            ],
+            [
+                "7.2.0",
+                "Added the `active-time` field, and changed the meaning of `seen-time`."
+            ]
+        ],
+        "function": "xinfoCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Summary form, in case `FULL` was not given.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "length": {
+                            "description": "the number of entries in the stream (see `XLEN`)",
+                            "type": "integer"
+                        },
+                        "radix-tree-keys": {
+                            "description": "the number of keys in the underlying radix data structure",
+                            "type": "integer"
+                        },
+                        "radix-tree-nodes": {
+                            "description": "the number of nodes in the underlying radix data structure",
+                            "type": "integer"
+                        },
+                        "last-generated-id": {
+                            "description": "the ID of the least-recently entry that was added to the stream",
+                            "type": "string",
+                            "pattern": "[0-9]+-[0-9]+"
+                        },
+                        "max-deleted-entry-id": {
+                            "description": "the maximal entry ID that was deleted from the stream",
+                            "type": "string",
+                            "pattern": "[0-9]+-[0-9]+"
+                        },
+                        "recorded-first-entry-id": {
+                            "description": "cached copy of the first entry ID",
+                            "type": "string",
+                            "pattern": "[0-9]+-[0-9]+"
+                        },
+                        "entries-added": {
+                            "description": "the count of all entries added to the stream during its lifetime",
+                            "type": "integer"
+                        },
+                        "groups": {
+                            "description": "the number of consumer groups defined for the stream",
+                            "type": "integer"
+                        },
+                        "first-entry": {
+                            "description": "the first entry of the stream",
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": [
+                                        {
+                                            "description": "entry ID",
+                                            "type": "string",
+                                            "pattern": "[0-9]+-[0-9]+"
+                                        },
+                                        {
+                                            "description": "data",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "last-entry": {
+                            "description": "the last entry of the stream",
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": [
+                                        {
+                                            "description": "entry ID",
+                                            "type": "string",
+                                            "pattern": "[0-9]+-[0-9]+"
+                                        },
+                                        {
+                                            "description": "data",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "description": "Extended form, in case `FULL` was given.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "length": {
+                            "description": "the number of entries in the stream (see `XLEN`)",
+                            "type": "integer"
+                        },
+                        "radix-tree-keys": {
+                            "description": "the number of keys in the underlying radix data structure",
+                            "type": "integer"
+                        },
+                        "radix-tree-nodes": {
+                            "description": "the number of nodes in the underlying radix data structure",
+                            "type": "integer"
+                        },
+                        "last-generated-id": {
+                            "description": "the ID of the least-recently entry that was added to the stream",
+                            "type": "string",
+                            "pattern": "[0-9]+-[0-9]+"
+                        },
+                        "max-deleted-entry-id": {
+                            "description": "the maximal entry ID that was deleted from the stream",
+                            "type": "string",
+                            "pattern": "[0-9]+-[0-9]+"
+                        },
+                        "recorded-first-entry-id": {
+                            "description": "cached copy of the first entry ID",
+                            "type": "string",
+                            "pattern": "[0-9]+-[0-9]+"
+                        },
+                        "entries-added": {
+                            "description": "the count of all entries added to the stream during its lifetime",
+                            "type": "integer"
+                        },
+                        "entries": {
+                            "description": "all the entries of the stream",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": [
+                                    {
+                                        "description": "entry ID",
+                                        "type": "string",
+                                        "pattern": "[0-9]+-[0-9]+"
+                                    },
+                                    {
+                                        "description": "data",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "groups": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "name": {
+                                        "description": "group name",
+                                        "type": "string"
+                                    },
+                                    "last-delivered-id": {
+                                        "description": "last entry ID that was delivered to a consumer",
+                                        "type": "string",
+                                        "pattern": "[0-9]+-[0-9]+"
+                                    },
+                                    "entries-read": {
+                                        "description": "total number of entries ever read by consumers in the group",
+                                        "oneOf": [
+                                            {
+                                                "type": "null"
+                                            },
+                                            {
+                                                "type": "integer"
+                                            }
+                                        ]
+                                    },
+                                    "lag": {
+                                        "description": "number of entries left to be consumed from the stream",
+                                        "oneOf": [
+                                            {
+                                                "type": "null"
+                                            },
+                                            {
+                                                "type": "integer"
+                                            }
+                                        ]
+                                    },
+                                    "pel-count": {
+                                        "description": "total number of unacknowledged entries",
+                                        "type": "integer"
+                                    },
+                                    "pending": {
+                                        "description": "data about all of the unacknowledged entries",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "array",
+                                            "minItems": 4,
+                                            "maxItems": 4,
+                                            "items": [
+                                                {
+                                                    "description": "Entry ID",
+                                                    "type": "string",
+                                                    "pattern": "[0-9]+-[0-9]+"
+                                                },
+                                                {
+                                                    "description": "Consumer name",
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "description": "Delivery timestamp",
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "description": "Delivery count",
+                                                    "type": "integer"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "consumers": {
+                                        "description": "data about all of the consumers of the group",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "active-time": {
+                                                    "type": "integer",
+                                                    "description": "Last time this consumer was active (successful reading/claiming).",
+                                                    "minimum": 0
+                                                },
+                                                "name": {
+                                                    "description": "consumer name",
+                                                    "type": "string"
+                                                },
+                                                "seen-time": {
+                                                    "description": "timestamp of the last interaction attempt of the consumer",
+                                                    "type": "integer"
+                                                },
+                                                "pel-count": {
+                                                    "description": "number of unacknowledged entries that belong to the consumer",
+                                                    "type": "integer"
+                                                },
+                                                "pending": {
+                                                    "description": "data about the unacknowledged entries",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "array",
+                                                        "minItems": 3,
+                                                        "maxItems": 3,
+                                                        "items": [
+                                                            {
+                                                                "description": "Entry ID",
+                                                                "type": "string",
+                                                                "pattern": "[0-9]+-[0-9]+"
+                                                            },
+                                                            {
+                                                                "description": "Delivery timestamp",
+                                                                "type": "integer"
+                                                            },
+                                                            {
+                                                                "description": "Delivery count",
+                                                                "type": "integer"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "full-block",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "full",
+                        "token": "FULL",
+                        "type": "pure-token"
+                    },
+                    {
+                        "token": "COUNT",
+                        "name": "count",
+                        "type": "integer",
+                        "optional": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/xinfo.json
+++ b/vendor/redis-7.2.6-commands/xinfo.json
@@ -1,0 +1,9 @@
+{
+    "XINFO": {
+        "summary": "A container for stream introspection commands.",
+        "complexity": "Depends on subcommand.",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -2
+    }
+}

--- a/vendor/redis-7.2.6-commands/xlen.json
+++ b/vendor/redis-7.2.6-commands/xlen.json
@@ -1,0 +1,48 @@
+{
+    "XLEN": {
+        "summary": "Return the number of messages in a stream.",
+        "complexity": "O(1)",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": 2,
+        "function": "xlenCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of entries of the stream at key",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xpending.json
+++ b/vendor/redis-7.2.6-commands/xpending.json
@@ -1,0 +1,160 @@
+{
+    "XPENDING": {
+        "summary": "Returns the information and entries from a stream consumer group's pending entries list.",
+        "complexity": "O(N) with N being the number of elements returned, so asking for a small fixed number of entries per call is O(1). O(M), where M is the total number of entries scanned when used with the IDLE filter. When the command returns just the summary and the list of consumers is small, it runs in O(1) time; otherwise, an additional O(N) time for iterating every consumer.",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -3,
+        "function": "xpendingCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added the `IDLE` option and exclusive range intervals."
+            ]
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Extended form, in case `start` was given.",
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "minItems": 4,
+                        "maxItems": 4,
+                        "items": [
+                            {
+                                "description": "Entry ID",
+                                "type": "string",
+                                "pattern": "[0-9]+-[0-9]+"
+                            },
+                            {
+                                "description": "Consumer name",
+                                "type": "string"
+                            },
+                            {
+                                "description": "Idle time",
+                                "type": "integer"
+                            },
+                            {
+                                "description": "Delivery count",
+                                "type": "integer"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "description": "Summary form, in case `start` was not given.",
+                    "type": "array",
+                    "minItems": 4,
+                    "maxItems": 4,
+                    "items": [
+                        {
+                            "description": "Total number of pending messages",
+                            "type": "integer"
+                        },
+                        {
+                            "description": "Minimal pending entry ID",
+                            "type": "string",
+                            "pattern": "[0-9]+-[0-9]+"
+                        },
+                        {
+                            "description": "Maximal pending entry ID",
+                            "type": "string",
+                            "pattern": "[0-9]+-[0-9]+"
+                        },
+                        {
+                            "description": "Consumers with pending messages",
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": [
+                                    {
+                                        "description": "Consumer name",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "description": "Number of pending messages",
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string"
+            },
+            {
+                "name": "filters",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "IDLE",
+                        "name": "min-idle-time",
+                        "type": "integer",
+                        "optional": true,
+                        "since": "6.2.0"
+                    },
+                    {
+                        "name": "start",
+                        "type": "string"
+                    },
+                    {
+                        "name": "end",
+                        "type": "string"
+                    },
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "consumer",
+                        "type": "string",
+                        "optional": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/xrange.json
+++ b/vendor/redis-7.2.6-commands/xrange.json
@@ -1,0 +1,87 @@
+{
+    "XRANGE": {
+        "summary": "Returns the messages from a stream within a range of IDs.",
+        "complexity": "O(N) with N being the number of elements being returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -4,
+        "function": "xrangeCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added exclusive ranges."
+            ]
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Stream entries with IDs matching the specified range.",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "items": [
+                    {
+                        "description": "Entry ID",
+                        "type": "string",
+                        "pattern": "[0-9]+-[0-9]+"
+                    },
+                    {
+                        "description": "Data",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "string"
+            },
+            {
+                "name": "end",
+                "type": "string"
+            },
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/xread.json
+++ b/vendor/redis-7.2.6-commands/xread.json
@@ -1,0 +1,108 @@
+{
+    "XREAD": {
+        "summary": "Returns messages from multiple streams with IDs greater than the ones requested. Blocks until a message is available otherwise.",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -4,
+        "function": "xreadCommand",
+        "get_keys_function": "xreadGetKeys",
+        "command_flags": [
+            "BLOCKING",
+            "READONLY",
+            "BLOCKING"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "keyword": {
+                        "keyword": "STREAMS",
+                        "startfrom": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 2
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "token": "BLOCK",
+                "name": "milliseconds",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "name": "streams",
+                "token": "STREAMS",
+                "type": "block",
+                "arguments": [
+                    {
+                        "name": "key",
+                        "type": "key",
+                        "key_spec_index": 0,
+                        "multiple": true
+                    },
+                    {
+                        "name": "ID",
+                        "type": "string",
+                        "multiple": true
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "A map of key-value elements when each element composed of key name and the entries reported for that key",
+                    "type": "object",
+                    "patternProperties": {
+                        "^.*$": {
+                            "description": "The entries reported for that key",
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": [
+                                    {
+                                        "description": "entry id",
+                                        "type": "string",
+                                        "pattern": "[0-9]+-[0-9]+"
+                                    },
+                                    {
+                                        "description": "array of field-value pairs",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "description": "If BLOCK option is given, and a timeout occurs, or there is no stream we can serve",
+                    "type": "null"
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xreadgroup.json
+++ b/vendor/redis-7.2.6-commands/xreadgroup.json
@@ -1,0 +1,134 @@
+{
+    "XREADGROUP": {
+        "summary": "Returns new or historical messages from a stream for a consumer in a group. Blocks until a message is available otherwise.",
+        "complexity": "For each stream mentioned: O(M) with M being the number of elements returned. If M is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1). On the other side when XREADGROUP blocks, XADD will pay the O(N) time in order to serve the N clients blocked on the stream getting new data.",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -7,
+        "function": "xreadCommand",
+        "get_keys_function": "xreadGetKeys",
+        "command_flags": [
+            "BLOCKING",
+            "WRITE"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "keyword": {
+                        "keyword": "STREAMS",
+                        "startfrom": 4
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 2
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "token": "GROUP",
+                "name": "group-block",
+                "type": "block",
+                "arguments": [
+                    {
+                        "name": "group",
+                        "type": "string"
+                    },
+                    {
+                        "name": "consumer",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "token": "BLOCK",
+                "name": "milliseconds",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "name": "noack",
+                "token": "NOACK",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "name": "streams",
+                "token": "STREAMS",
+                "type": "block",
+                "arguments": [
+                    {
+                        "name": "key",
+                        "type": "key",
+                        "key_spec_index": 0,
+                        "multiple": true
+                    },
+                    {
+                        "name": "ID",
+                        "type": "string",
+                        "multiple": true
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "If BLOCK option is specified and the timeout expired",
+                    "type": "null"
+                },
+                {
+                    "description": "A map of key-value elements when each element composed of key name and the entries reported for that key",
+                    "type": "object",
+                    "additionalProperties": {
+                        "description": "The entries reported for that key",
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "minItems": 2,
+                            "maxItems": 2,
+                            "items": [
+                                {
+                                    "description": "Stream id",
+                                    "type": "string",
+                                    "pattern": "[0-9]+-[0-9]+"
+                                },
+                                {
+                                    "oneOf": [
+                                        {
+                                            "description": "Array of field-value pairs",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xrevrange.json
+++ b/vendor/redis-7.2.6-commands/xrevrange.json
@@ -1,0 +1,86 @@
+{
+    "XREVRANGE": {
+        "summary": "Returns the messages from a stream within a range of IDs in reverse order.",
+        "complexity": "O(N) with N being the number of elements returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -4,
+        "function": "xrevrangeCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added exclusive ranges."
+            ]
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "end",
+                "type": "string"
+            },
+            {
+                "name": "start",
+                "type": "string"
+            },
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "An array of the entries with IDs matching the specified range",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "items": [
+                    {
+                        "description": "Stream id",
+                        "type": "string",
+                        "pattern": "[0-9]+-[0-9]+"
+                    },
+                    {
+                        "description": "Array of field-value pairs",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xsetid.json
+++ b/vendor/redis-7.2.6-commands/xsetid.json
@@ -1,0 +1,72 @@
+{
+    "XSETID": {
+        "summary": "An internal command for replicating stream values.",
+        "complexity": "O(1)",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -3,
+        "function": "xsetidCommand",
+        "history": [
+            [
+                "7.0.0",
+                "Added the `entries_added` and `max_deleted_entry_id` arguments."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "last-id",
+                "type": "string"
+            },
+            {
+                "name": "entries-added",
+                "token": "ENTRIESADDED",
+                "type": "integer",
+                "optional": true,
+                "since": "7.0.0"
+            },
+            {
+                "name": "max-deleted-id",
+                "token": "MAXDELETEDID",
+                "type": "string",
+                "optional": true,
+                "since": "7.0.0"
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/xtrim.json
+++ b/vendor/redis-7.2.6-commands/xtrim.json
@@ -1,0 +1,108 @@
+{
+    "XTRIM": {
+        "summary": "Deletes messages from the beginning of a stream.",
+        "complexity": "O(N), with N being the number of evicted entries. Constant times are very small however, since entries are organized in macro nodes containing multiple entries that can be released with a single deallocation.",
+        "group": "stream",
+        "since": "5.0.0",
+        "arity": -4,
+        "function": "xtrimCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added the `MINID` trimming strategy and the `LIMIT` option."
+            ]
+        ],
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "trim",
+                "type": "block",
+                "arguments": [
+                    {
+                        "name": "strategy",
+                        "type": "oneof",
+                        "arguments": [
+                            {
+                                "name": "maxlen",
+                                "type": "pure-token",
+                                "token": "MAXLEN"
+                            },
+                            {
+                                "name": "minid",
+                                "type": "pure-token",
+                                "token": "MINID",
+                                "since": "6.2.0"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "operator",
+                        "type": "oneof",
+                        "optional": true,
+                        "arguments": [
+                            {
+                                "name": "equal",
+                                "type": "pure-token",
+                                "token": "="
+                            },
+                            {
+                                "name": "approximately",
+                                "type": "pure-token",
+                                "token": "~"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "threshold",
+                        "type": "string"
+                    },
+                    {
+                        "token": "LIMIT",
+                        "name": "count",
+                        "type": "integer",
+                        "optional": true,
+                        "since": "6.2.0"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of entries deleted from the stream.",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/zadd.json
+++ b/vendor/redis-7.2.6-commands/zadd.json
@@ -1,0 +1,144 @@
+{
+    "ZADD": {
+        "summary": "Adds one or more members to a sorted set, or updates their scores. Creates the key if it doesn't exist.",
+        "complexity": "O(log(N)) for each item added, where N is the number of elements in the sorted set.",
+        "group": "sorted_set",
+        "since": "1.2.0",
+        "arity": -4,
+        "function": "zaddCommand",
+        "history": [
+            [
+                "2.4.0",
+                "Accepts multiple elements."
+            ],
+            [
+                "3.0.2",
+                "Added the `XX`, `NX`, `CH` and `INCR` options."
+            ],
+            [
+                "6.2.0",
+                "Added the `GT` and `LT` options."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf":[
+                {
+                    "description": "Operation was aborted (conflict with one of the `XX`/`NX`/`LT`/`GT` options).",
+                    "type": "null"
+                },
+                {
+                    "description": "The number of new members (when the `CH` option is not used)",
+                    "type": "integer"
+                },
+                {
+                    "description": "The number of new or updated members (when the `CH` option is used)",
+                    "type": "integer"
+                },
+                {
+                    "description": "The updated score of the member (when the `INCR` option is used)",
+                    "type": "number"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "since": "3.0.2",
+                "arguments": [
+                    {
+                        "name": "nx",
+                        "type": "pure-token",
+                        "token": "NX"
+                    },
+                    {
+                        "name": "xx",
+                        "type": "pure-token",
+                        "token": "XX"
+                    }
+                ]
+            },
+            {
+                "name": "comparison",
+                "type": "oneof",
+                "optional": true,
+                "since": "6.2.0",
+                "arguments": [
+                    {
+                        "name": "gt",
+                        "type": "pure-token",
+                        "token": "GT"
+                    },
+                    {
+                        "name": "lt",
+                        "type": "pure-token",
+                        "token": "LT"
+                    }
+                ]
+            },
+            {
+                "name": "change",
+                "token": "CH",
+                "type": "pure-token",
+                "optional": true,
+                "since": "3.0.2"
+            },
+            {
+                "name": "increment",
+                "token": "INCR",
+                "type": "pure-token",
+                "optional": true,
+                "since": "3.0.2"
+            },
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "score",
+                        "type": "double"
+                    },
+                    {
+                        "name": "member",
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zcard.json
+++ b/vendor/redis-7.2.6-commands/zcard.json
@@ -1,0 +1,47 @@
+{
+    "ZCARD": {
+        "summary": "Returns the number of members in a sorted set.",
+        "complexity": "O(1)",
+        "group": "sorted_set",
+        "since": "1.2.0",
+        "arity": 2,
+        "function": "zcardCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The cardinality (number of elements) of the sorted set, or 0 if key does not exist",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zcount.json
+++ b/vendor/redis-7.2.6-commands/zcount.json
@@ -1,0 +1,56 @@
+{
+    "ZCOUNT": {
+        "summary": "Returns the count of members in a sorted set that have scores within a range.",
+        "complexity": "O(log(N)) with N being the number of elements in the sorted set.",
+        "group": "sorted_set",
+        "since": "2.0.0",
+        "arity": 4,
+        "function": "zcountCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of elements in the specified score range",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "min",
+                "type": "double"
+            },
+            {
+                "name": "max",
+                "type": "double"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zdiff.json
+++ b/vendor/redis-7.2.6-commands/zdiff.json
@@ -1,0 +1,85 @@
+{
+    "ZDIFF": {
+        "summary": "Returns the difference between multiple sorted sets.",
+        "complexity": "O(L + (N-K)log(N)) worst case where L is the total number of elements in all the sets, N is the size of the first set, and K is the size of the result set.",
+        "group": "sorted_set",
+        "since": "6.2.0",
+        "arity": -3,
+        "function": "zdiffCommand",
+        "get_keys_function": "zunionInterDiffGetKeys",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "description": "A list of members. Returned in case `WITHSCORES` was not used.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "description": "Members and their scores. Returned in case `WITHSCORES` was used. In RESP2 this is returned as a flat array",
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "description": "Member",
+                                "type": "string"
+                            },
+                            {
+                                "description": "Score",
+                                "type": "number"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "name": "withscores",
+                "token": "WITHSCORES",
+                "type": "pure-token",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zdiffstore.json
+++ b/vendor/redis-7.2.6-commands/zdiffstore.json
@@ -1,0 +1,77 @@
+{
+    "ZDIFFSTORE": {
+        "summary": "Stores the difference of multiple sorted sets in a key.",
+        "complexity": "O(L + (N-K)log(N)) worst case where L is the total number of elements in all the sets, N is the size of the first set, and K is the size of the result set.",
+        "group": "sorted_set",
+        "since": "6.2.0",
+        "arity": -4,
+        "function": "zdiffstoreCommand",
+        "get_keys_function": "zunionInterDiffStoreGetKeys",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of elements in the resulting sorted set at `destination`",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 1,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zincrby.json
+++ b/vendor/redis-7.2.6-commands/zincrby.json
@@ -1,0 +1,58 @@
+{
+    "ZINCRBY": {
+        "summary": "Increments the score of a member in a sorted set.",
+        "complexity": "O(log(N)) where N is the number of elements in the sorted set.",
+        "group": "sorted_set",
+        "since": "1.2.0",
+        "arity": 4,
+        "function": "zincrbyCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The new score of `member`",
+            "type": "number"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "increment",
+                "type": "integer"
+            },
+            {
+                "name": "member",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zinter.json
+++ b/vendor/redis-7.2.6-commands/zinter.json
@@ -1,0 +1,115 @@
+{
+    "ZINTER": {
+        "summary": "Returns the intersect of multiple sorted sets.",
+        "complexity": "O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted set, K being the number of input sorted sets and M being the number of elements in the resulting sorted set.",
+        "group": "sorted_set",
+        "since": "6.2.0",
+        "arity": -3,
+        "function": "zinterCommand",
+        "get_keys_function": "zunionInterDiffGetKeys",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "description": "Result of intersection, containing only the member names. Returned in case `WITHSCORES` was not used.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "description": "Result of intersection, containing members and their scores. Returned in case `WITHSCORES` was used. In RESP2 this is returned as a flat array",
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "description": "Member",
+                                "type": "string"
+                            },
+                            {
+                                "description": "Score",
+                                "type": "number"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "token": "WEIGHTS",
+                "name": "weight",
+                "type": "integer",
+                "optional": true,
+                "multiple": true
+            },
+            {
+                "token": "AGGREGATE",
+                "name": "aggregate",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "sum",
+                        "type": "pure-token",
+                        "token": "SUM"
+                    },
+                    {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                    },
+                    {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                    }
+                ]
+            },
+            {
+                "name": "withscores",
+                "token": "WITHSCORES",
+                "type": "pure-token",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zintercard.json
+++ b/vendor/redis-7.2.6-commands/zintercard.json
@@ -1,0 +1,60 @@
+{
+    "ZINTERCARD": {
+        "summary": "Returns the number of members of the intersect of multiple sorted sets.",
+        "complexity": "O(N*K) worst case with N being the smallest input sorted set, K being the number of input sorted sets.",
+        "group": "sorted_set",
+        "since": "7.0.0",
+        "arity": -3,
+        "function": "zinterCardCommand",
+        "get_keys_function": "zunionInterDiffGetKeys",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of elements in the resulting intersection.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "token": "LIMIT",
+                "name": "limit",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zinterstore.json
+++ b/vendor/redis-7.2.6-commands/zinterstore.json
@@ -1,0 +1,108 @@
+{
+    "ZINTERSTORE": {
+        "summary": "Stores the intersect of multiple sorted sets in a key.",
+        "complexity": "O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted set, K being the number of input sorted sets and M being the number of elements in the resulting sorted set.",
+        "group": "sorted_set",
+        "since": "2.0.0",
+        "arity": -4,
+        "function": "zinterstoreCommand",
+        "get_keys_function": "zunionInterDiffStoreGetKeys",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of elements in the resulting sorted set.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 1,
+                "multiple": true
+            },
+            {
+                "token": "WEIGHTS",
+                "name": "weight",
+                "type": "integer",
+                "optional": true,
+                "multiple": true
+            },
+            {
+                "token": "AGGREGATE",
+                "name": "aggregate",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "sum",
+                        "type": "pure-token",
+                        "token": "SUM"
+                    },
+                    {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                    },
+                    {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zlexcount.json
+++ b/vendor/redis-7.2.6-commands/zlexcount.json
@@ -1,0 +1,57 @@
+{
+    "ZLEXCOUNT": {
+        "summary": "Returns the number of members in a sorted set within a lexicographical range.",
+        "complexity": "O(log(N)) with N being the number of elements in the sorted set.",
+        "group": "sorted_set",
+        "since": "2.8.9",
+        "arity": 4,
+        "function": "zlexcountCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of elements in the specified score range.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "min",
+                "type": "string"
+            },
+            {
+                "name": "max",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zmpop.json
+++ b/vendor/redis-7.2.6-commands/zmpop.json
@@ -1,0 +1,111 @@
+{
+    "ZMPOP": {
+        "summary": "Returns the highest- or lowest-scoring members from one or more sorted sets after removing them. Deletes the sorted set if the last member was popped.",
+        "complexity": "O(K) + O(M*log(N)) where K is the number of provided keys, N being the number of elements in the sorted set, and M being the number of elements popped.",
+        "group": "sorted_set",
+        "since": "7.0.0",
+        "arity": -4,
+        "function": "zmpopCommand",
+        "get_keys_function": "zmpopGetKeys",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "No element could be popped.",
+                    "type": "null"
+                },
+                {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "type": "string",
+                            "description": "Name of the key that elements were popped."
+                        },
+                        {
+                            "type": "array",
+                            "description": "Popped elements.",
+                            "items": {
+                                "type": "array",
+                                "uniqueItems": true,
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": [
+                                    {
+                                        "type": "string",
+                                        "description": "Name of the member."
+                                    },
+                                    {
+                                        "type": "number",
+                                        "description": "Score."
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "name": "where",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                    },
+                    {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                    }
+                ]
+            },
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zmscore.json
+++ b/vendor/redis-7.2.6-commands/zmscore.json
@@ -1,0 +1,65 @@
+{
+    "ZMSCORE": {
+        "summary": "Returns the score of one or more members in a sorted set.",
+        "complexity": "O(N) where N is the number of members being requested.",
+        "group": "sorted_set",
+        "since": "6.2.0",
+        "arity": -3,
+        "function": "zmscoreCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "number",
+                        "description": "The score of the member (a double precision floating point number). In RESP2, this is returned as string."
+                    },
+                    {
+                        "type": "null",
+                        "description": "Member does not exist in the sorted set."
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zpopmax.json
+++ b/vendor/redis-7.2.6-commands/zpopmax.json
@@ -1,0 +1,89 @@
+{
+    "ZPOPMAX": {
+        "summary": "Returns the highest-scoring members from a sorted set after removing them. Deletes the sorted set if the last member was popped.",
+        "complexity": "O(log(N)*M) with N being the number of elements in the sorted set, and M being the number of elements popped.",
+        "group": "sorted_set",
+        "since": "5.0.0",
+        "arity": -2,
+        "function": "zpopmaxCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "description": "List of popped elements and scores when 'COUNT' isn't specified.",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "type": "string",
+                            "description": "Popped element."
+                        },
+                        {
+                            "type": "number",
+                            "description": "Score."
+                        }
+                    ]
+                },
+                {
+                    "type": "array",
+                    "description": "List of popped elements and scores when 'COUNT' is specified.",
+                    "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "type": "string",
+                                "description": "Popped element."
+                            },
+                            {
+                                "type": "number",
+                                "description": "Score."
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zpopmin.json
+++ b/vendor/redis-7.2.6-commands/zpopmin.json
@@ -1,0 +1,89 @@
+{
+    "ZPOPMIN": {
+        "summary": "Returns the lowest-scoring members from a sorted set after removing them. Deletes the sorted set if the last member was popped.",
+        "complexity": "O(log(N)*M) with N being the number of elements in the sorted set, and M being the number of elements popped.",
+        "group": "sorted_set",
+        "since": "5.0.0",
+        "arity": -2,
+        "function": "zpopminCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "description": "List of popped elements and scores when 'COUNT' isn't specified.",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "type": "string",
+                            "description": "Popped element."
+                        },
+                        {
+                            "type": "number",
+                            "description": "Score."
+                        }
+                    ]
+                },
+                {
+                    "type": "array",
+                    "description": "List of popped elements and scores when 'COUNT' is specified.",
+                    "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "type": "string",
+                                "description": "Popped element."
+                            },
+                            {
+                                "type": "number",
+                                "description": "Score."
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zrandmember.json
+++ b/vendor/redis-7.2.6-commands/zrandmember.json
@@ -1,0 +1,101 @@
+{
+    "ZRANDMEMBER": {
+        "summary": "Returns one or more random members from a sorted set.",
+        "complexity": "O(N) where N is the number of members returned",
+        "group": "sorted_set",
+        "since": "6.2.0",
+        "arity": -2,
+        "function": "zrandmemberCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "type": "null",
+                    "description": "Key does not exist."
+                },
+                {
+                    "type": "string",
+                    "description": "Randomly selected element when 'COUNT' is not used."
+                },
+                {
+                    "type": "array",
+                    "description": "Randomly selected elements when 'COUNT' is used.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "type": "array",
+                    "description": "Randomly selected elements when 'COUNT' and 'WITHSCORES' modifiers are used.",
+                    "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "type": "string",
+                                "description": "Element."
+                            },
+                            {
+                                "type": "number",
+                                "description": "Score."
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "options",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "withscores",
+                        "token": "WITHSCORES",
+                        "type": "pure-token",
+                        "optional": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zrange.json
+++ b/vendor/redis-7.2.6-commands/zrange.json
@@ -1,0 +1,137 @@
+{
+    "ZRANGE": {
+        "summary": "Returns members in a sorted set within a range of indexes.",
+        "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements returned.",
+        "group": "sorted_set",
+        "since": "1.2.0",
+        "arity": -4,
+        "function": "zrangeCommand",
+        "history": [
+            [
+                "6.2.0",
+                "Added the `REV`, `BYSCORE`, `BYLEX` and `LIMIT` options."
+            ]
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "description": "A list of member elements",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "description": "Members and their scores. Returned in case `WITHSCORES` was used. In RESP2 this is returned as a flat array",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "description": "Member",
+                                "type": "string"
+                            },
+                            {
+                                "description": "Score",
+                                "type": "number"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "string"
+            },
+            {
+                "name": "stop",
+                "type": "string"
+            },
+            {
+                "name": "sortby",
+                "type": "oneof",
+                "optional": true,
+                "since": "6.2.0",
+                "arguments": [
+                    {
+                        "name": "byscore",
+                        "type": "pure-token",
+                        "token": "BYSCORE"
+                    },
+                    {
+                        "name": "bylex",
+                        "type": "pure-token",
+                        "token": "BYLEX"
+                    }
+                ]
+            },
+            {
+                "name": "rev",
+                "token": "REV",
+                "type": "pure-token",
+                "optional": true,
+                "since": "6.2.0"
+            },
+            {
+                "token": "LIMIT",
+                "name": "limit",
+                "type": "block",
+                "optional": true,
+                "since": "6.2.0",
+                "arguments": [
+                    {
+                        "name": "offset",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    }
+                ]
+            },
+            {
+                "name": "withscores",
+                "token": "WITHSCORES",
+                "type": "pure-token",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zrangebylex.json
+++ b/vendor/redis-7.2.6-commands/zrangebylex.json
@@ -1,0 +1,80 @@
+{
+    "ZRANGEBYLEX": {
+        "summary": "Returns members in a sorted set within a lexicographical range.",
+        "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
+        "group": "sorted_set",
+        "since": "2.8.9",
+        "arity": -4,
+        "function": "zrangebylexCommand",
+        "deprecated_since": "6.2.0",
+        "replaced_by": "`ZRANGE` with the `BYLEX` argument",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List of elements in the specified score range.",
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "min",
+                "type": "string"
+            },
+            {
+                "name": "max",
+                "type": "string"
+            },
+            {
+                "token": "LIMIT",
+                "name": "limit",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "offset",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zrangebyscore.json
+++ b/vendor/redis-7.2.6-commands/zrangebyscore.json
@@ -1,0 +1,119 @@
+{
+    "ZRANGEBYSCORE": {
+        "summary": "Returns members in a sorted set within a range of scores.",
+        "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
+        "group": "sorted_set",
+        "since": "1.0.5",
+        "arity": -4,
+        "function": "zrangebyscoreCommand",
+        "history": [
+            [
+                "2.0.0",
+                "Added the `WITHSCORES` modifier."
+            ]
+        ],
+        "deprecated_since": "6.2.0",
+        "replaced_by": "`ZRANGE` with the `BYSCORE` argument",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "description": "List of the elements in the specified score range, as not WITHSCORES",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "description": "Element"
+                    }
+                },
+                {
+                    "type": "array",
+                    "description": "List of the elements and their scores in the specified score range, as WITHSCORES used",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "array",
+                        "description": "Tuple of element and its score",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "description": "element",
+                                "type": "string"
+                            },
+                            {
+                                "description": "score",
+                                "type": "number"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "min",
+                "type": "double"
+            },
+            {
+                "name": "max",
+                "type": "double"
+            },
+            {
+                "name": "withscores",
+                "token": "WITHSCORES",
+                "type": "pure-token",
+                "optional": true,
+                "since": "2.0.0"
+            },
+            {
+                "token": "LIMIT",
+                "name": "limit",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "offset",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zrangestore.json
+++ b/vendor/redis-7.2.6-commands/zrangestore.json
@@ -1,0 +1,118 @@
+{
+    "ZRANGESTORE": {
+        "summary": "Stores a range of members from sorted set in a key.",
+        "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements stored into the destination key.",
+        "group": "sorted_set",
+        "since": "6.2.0",
+        "arity": -5,
+        "function": "zrangestoreCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "Number of elements in the resulting sorted set."
+        },
+        "arguments": [
+            {
+                "name": "dst",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "src",
+                "type": "key",
+                "key_spec_index": 1
+            },
+            {
+                "name": "min",
+                "type": "string"
+            },
+            {
+                "name": "max",
+                "type": "string"
+            },
+            {
+                "name": "sortby",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "byscore",
+                        "type": "pure-token",
+                        "token": "BYSCORE"
+                    },
+                    {
+                        "name": "bylex",
+                        "type": "pure-token",
+                        "token": "BYLEX"
+                    }
+                ]
+            },
+            {
+                "name": "rev",
+                "token": "REV",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "token": "LIMIT",
+                "name": "limit",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "offset",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zrank.json
+++ b/vendor/redis-7.2.6-commands/zrank.json
@@ -1,0 +1,86 @@
+{
+    "ZRANK": {
+        "summary": "Returns the index of a member in a sorted set ordered by ascending scores.",
+        "complexity": "O(log(N))",
+        "group": "sorted_set",
+        "since": "2.0.0",
+        "arity": -3,
+        "function": "zrankCommand",
+        "history": [
+            [
+                "7.2.0",
+                "Added the optional `WITHSCORE` argument."
+            ]
+        ],
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "null",
+                    "description": "Key does not exist or the member does not exist in the sorted set."
+                },
+                {
+                    "type": "integer",
+                    "description": "The rank of the member when 'WITHSCORE' is not used."
+                },
+                {
+                    "type": "array",
+                    "description": "The rank and score of the member when 'WITHSCORE' is used.",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string"
+            },
+            {
+                "name": "withscore",
+                "token": "WITHSCORE",
+                "type": "pure-token",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zrem.json
+++ b/vendor/redis-7.2.6-commands/zrem.json
@@ -1,0 +1,60 @@
+{
+    "ZREM": {
+        "summary": "Removes one or more members from a sorted set. Deletes the sorted set if all members were removed.",
+        "complexity": "O(M*log(N)) with N being the number of elements in the sorted set and M the number of elements to be removed.",
+        "group": "sorted_set",
+        "since": "1.2.0",
+        "arity": -3,
+        "function": "zremCommand",
+        "history": [
+            [
+                "2.4.0",
+                "Accepts multiple elements."
+            ]
+        ],
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of members removed from the sorted set, not including non existing members.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zremrangebylex.json
+++ b/vendor/redis-7.2.6-commands/zremrangebylex.json
@@ -1,0 +1,55 @@
+{
+    "ZREMRANGEBYLEX": {
+        "summary": "Removes members in a sorted set within a lexicographical range. Deletes the sorted set if all members were removed.",
+        "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.",
+        "group": "sorted_set",
+        "since": "2.8.9",
+        "arity": 4,
+        "function": "zremrangebylexCommand",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "Number of elements removed."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "min",
+                "type": "string"
+            },
+            {
+                "name": "max",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zremrangebyrank.json
+++ b/vendor/redis-7.2.6-commands/zremrangebyrank.json
@@ -1,0 +1,55 @@
+{
+    "ZREMRANGEBYRANK": {
+        "summary": "Removes members in a sorted set within a range of indexes. Deletes the sorted set if all members were removed.",
+        "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.",
+        "group": "sorted_set",
+        "since": "2.0.0",
+        "arity": 4,
+        "function": "zremrangebyrankCommand",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "Number of elements removed."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer"
+            },
+            {
+                "name": "stop",
+                "type": "integer"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zremrangebyscore.json
+++ b/vendor/redis-7.2.6-commands/zremrangebyscore.json
@@ -1,0 +1,55 @@
+{
+    "ZREMRANGEBYSCORE": {
+        "summary": "Removes members in a sorted set within a range of scores. Deletes the sorted set if all members were removed.",
+        "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.",
+        "group": "sorted_set",
+        "since": "1.2.0",
+        "arity": 4,
+        "function": "zremrangebyscoreCommand",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "integer",
+            "description": "Number of elements removed."
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "min",
+                "type": "double"
+            },
+            {
+                "name": "max",
+                "type": "double"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zrevrange.json
+++ b/vendor/redis-7.2.6-commands/zrevrange.json
@@ -1,0 +1,94 @@
+{
+    "ZREVRANGE": {
+        "summary": "Returns members in a sorted set within a range of indexes in reverse order.",
+        "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements returned.",
+        "group": "sorted_set",
+        "since": "1.2.0",
+        "arity": -4,
+        "function": "zrevrangeCommand",
+        "deprecated_since": "6.2.0",
+        "replaced_by": "`ZRANGE` with the `REV` argument",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "description": "List of member elements.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "description": "List of the members and their scores. Returned in case `WITHSCORES` was used.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "description": "member",
+                                "type": "string"
+                            },
+                            {
+                                "description": "score",
+                                "type": "number"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer"
+            },
+            {
+                "name": "stop",
+                "type": "integer"
+            },
+            {
+                "name": "withscores",
+                "token": "WITHSCORES",
+                "type": "pure-token",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zrevrangebylex.json
+++ b/vendor/redis-7.2.6-commands/zrevrangebylex.json
@@ -1,0 +1,80 @@
+{
+    "ZREVRANGEBYLEX": {
+        "summary": "Returns members in a sorted set within a lexicographical range in reverse order.",
+        "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
+        "group": "sorted_set",
+        "since": "2.8.9",
+        "arity": -4,
+        "function": "zrevrangebylexCommand",
+        "deprecated_since": "6.2.0",
+        "replaced_by": "`ZRANGE` with the `REV` and `BYLEX` arguments",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "description": "List of the elements in the specified score range.",
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "max",
+                "type": "string"
+            },
+            {
+                "name": "min",
+                "type": "string"
+            },
+            {
+                "token": "LIMIT",
+                "name": "limit",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "offset",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zrevrangebyscore.json
+++ b/vendor/redis-7.2.6-commands/zrevrangebyscore.json
@@ -1,0 +1,118 @@
+{
+    "ZREVRANGEBYSCORE": {
+        "summary": "Returns members in a sorted set within a range of scores in reverse order.",
+        "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
+        "group": "sorted_set",
+        "since": "2.2.0",
+        "arity": -4,
+        "function": "zrevrangebyscoreCommand",
+        "history": [
+            [
+                "2.1.6",
+                "`min` and `max` can be exclusive."
+            ]
+        ],
+        "deprecated_since": "6.2.0",
+        "replaced_by": "`ZRANGE` with the `REV` and `BYSCORE` arguments",
+        "doc_flags": [
+            "DEPRECATED"
+        ],
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "description": "List of the elements in the specified score range, as not WITHSCORES",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "description": "Element"
+                    }
+                },
+                {
+                    "type": "array",
+                    "description": "List of the elements and their scores in the specified score range, as WITHSCORES used",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "array",
+                        "description": "Tuple of element and its score",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "type": "string",
+                                "description": "element"
+                            },
+                            {
+                                "type": "number",
+                                "description": "score"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "max",
+                "type": "double"
+            },
+            {
+                "name": "min",
+                "type": "double"
+            },
+            {
+                "name": "withscores",
+                "token": "WITHSCORES",
+                "type": "pure-token",
+                "optional": true
+            },
+            {
+                "token": "LIMIT",
+                "name": "limit",
+                "type": "block",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "offset",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zrevrank.json
+++ b/vendor/redis-7.2.6-commands/zrevrank.json
@@ -1,0 +1,86 @@
+{
+    "ZREVRANK": {
+        "summary": "Returns the index of a member in a sorted set ordered by descending scores.",
+        "complexity": "O(log(N))",
+        "group": "sorted_set",
+        "since": "2.0.0",
+        "arity": -3,
+        "function": "zrevrankCommand",
+        "history": [
+            [
+                "7.2.0",
+                "Added the optional `WITHSCORE` argument."
+            ]
+        ],
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "null",
+                    "description": "Key does not exist or the member does not exist in the sorted set."
+                },
+                {
+                    "type": "integer",
+                    "description": "The rank of the member when 'WITHSCORE' is not used."
+                },
+                {
+                    "type": "array",
+                    "description": "The rank and score of the member when 'WITHSCORE' is used.",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string"
+            },
+            {
+                "name": "withscore",
+                "token": "WITHSCORE",
+                "type": "pure-token",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zscan.json
+++ b/vendor/redis-7.2.6-commands/zscan.json
@@ -1,0 +1,81 @@
+{
+    "ZSCAN": {
+        "summary": "Iterates over members and scores of a sorted set.",
+        "complexity": "O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.",
+        "group": "sorted_set",
+        "since": "2.8.0",
+        "arity": -3,
+        "function": "zscanCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "cursor",
+                "type": "integer"
+            },
+            {
+                "token": "MATCH",
+                "name": "pattern",
+                "type": "pattern",
+                "optional": true
+            },
+            {
+                "token": "COUNT",
+                "name": "count",
+                "type": "integer",
+                "optional": true
+            }
+        ],
+        "reply_schema": {
+            "description": "cursor and scan response in array form",
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": [
+                {
+                    "description": "cursor",
+                    "type": "string"
+                },
+                {
+                    "description": "list of elements of the sorted set, where each even element is the member, and each odd value is its associated score",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/vendor/redis-7.2.6-commands/zscore.json
+++ b/vendor/redis-7.2.6-commands/zscore.json
@@ -1,0 +1,60 @@
+{
+    "ZSCORE": {
+        "summary": "Returns the score of a member in a sorted set.",
+        "complexity": "O(1)",
+        "group": "sorted_set",
+        "since": "1.2.0",
+        "arity": 3,
+        "function": "zscoreCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "type": "number",
+                    "description": "The score of the member (a double precision floating point number). In RESP2, this is returned as string."
+                },
+                {
+                    "type": "null",
+                    "description": "Member does not exist in the sorted set, or key does not exist."
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "member",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zunion.json
+++ b/vendor/redis-7.2.6-commands/zunion.json
@@ -1,0 +1,115 @@
+{
+    "ZUNION": {
+        "summary": "Returns the union of multiple sorted sets.",
+        "complexity": "O(N)+O(M*log(M)) with N being the sum of the sizes of the input sorted sets, and M being the number of elements in the resulting sorted set.",
+        "group": "sorted_set",
+        "since": "6.2.0",
+        "arity": -3,
+        "function": "zunionCommand",
+        "get_keys_function": "zunionInterDiffGetKeys",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "anyOf": [
+                {
+                    "description": "The result of union when 'WITHSCORES' is not used.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "description": "The result of union when 'WITHSCORES' is used.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "token": "WEIGHTS",
+                "name": "weight",
+                "type": "integer",
+                "optional": true,
+                "multiple": true
+            },
+            {
+                "token": "AGGREGATE",
+                "name": "aggregate",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "sum",
+                        "type": "pure-token",
+                        "token": "SUM"
+                    },
+                    {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                    },
+                    {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                    }
+                ]
+            },
+            {
+                "name": "withscores",
+                "token": "WITHSCORES",
+                "type": "pure-token",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/vendor/redis-7.2.6-commands/zunionstore.json
+++ b/vendor/redis-7.2.6-commands/zunionstore.json
@@ -1,0 +1,107 @@
+{
+    "ZUNIONSTORE": {
+        "summary": "Stores the union of multiple sorted sets in a key.",
+        "complexity": "O(N)+O(M log(M)) with N being the sum of the sizes of the input sorted sets, and M being the number of elements in the resulting sorted set.",
+        "group": "sorted_set",
+        "since": "2.0.0",
+        "arity": -4,
+        "function": "zunionstoreCommand",
+        "get_keys_function": "zunionInterDiffStoreGetKeys",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "OW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of elements in the resulting sorted set.",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 1,
+                "multiple": true
+            },
+            {
+                "token": "WEIGHTS",
+                "name": "weight",
+                "type": "integer",
+                "optional": true,
+                "multiple": true
+            },
+            {
+                "token": "AGGREGATE",
+                "name": "aggregate",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "sum",
+                        "type": "pure-token",
+                        "token": "SUM"
+                    },
+                    {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                    },
+                    {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Closes #92

Clean-room implementation from origin/main.

## What changed
- Generated Redis 7.2.6 command routing artifact from immutable source SHA ae6a2aa95cd094b032e7a69b8b59f64dd1ed085f
- Added deterministic generator + semantic audit tooling
- Replaced static routing lists with generated grammar-aware classifier and subcommand validation
- Updated smart proxy keyed path to forward raw RESP request bytes through cluster retry/redirect machinery
- Added routing grammar tests for malformed and valid forms (including SET/MEMORY/OBJECT/Z* options/XREAD/EVAL/FCALL/GEO)
- Documented update/audit workflow

## Validation
- scripts/audit_cluster_routing.sh
- deliberate generated-artifact mutation => audit failure
- cabal test ClusterRoutingSpec
- make test
- nix-build --no-out-link
