### PR TITLE
test: synchronize raw reconnect mock reply

### DIFF
--- a/hask-redis-mux/test/ClusterCommandSpec.hs
+++ b/hask-redis-mux/test/ClusterCommandSpec.hs
@@ -917,7 +917,11 @@ createPostWriteFailureConnector = do
                     sentCommands <- readTVar sendCount
                     check $ sentCommands == 1
                   throwIO $ userError "injected transport failure after raw write"
-              | otherwise = replyWith $ RespSimpleString "OK"
+              | otherwise = do
+                  atomically $ do
+                    sentCommands <- readTVar sendCount
+                    check $ sentCommands == 1
+                  replyWith $ RespSimpleString "OK"
             record = PostWriteFailureRecord index sent sendCount closes
         atomicModifyIORef' records $ \existing ->
           (existing ++ [record], ())


### PR DESCRIPTION
## Summary

- make the replacement raw-RESP reconnect mock wait atomically for its own first send before returning `OK`
- retain the existing send-count and encoded-frame assertions
- fix test causality only; production behavior and public APIs are unchanged

Closes #137

This regression fix **blocks #136 and #118**: their first exact-SHA CI attempts exposed the same race. Do not rerun their failed consumer-PR checks until this repair merges.

## Evidence

- #136 attempt 1: https://github.com/sspeaks/redis-client/actions/runs/33954954510 (`f6a28d0b...`, seed `36896999`)
- #118 attempt 1: https://github.com/sspeaks/redis-client/actions/runs/33956557996/job/101280835827 (`cd33ae813d6369c4edbe9df27f5c757175c677e4`, seed `953352710`); `MultiplexerSpec` passed 26/0.

## Invariant

The replacement connection cannot produce `OK` until its `sendCount == 1`, matching real Redis causality: a server cannot reply before it receives the request.

## Validation

- focused reconnect regression: 600/600 runs (100 seeds × N1/N2/N4 × default/`-C0.001`), 0 failures
- complete `ClusterCommandSpec`: 60/60 runs (seeds `36896999,1..9` × same six RTS variants), 0 failures
- `nix-build --no-out-link`
- `make test`
- before/after `cabal run redis-client --enable-profiling -- fill -h localhost -d 1 +RTS -p -RTS`: allocation remained within run variance (2.596 GB → 2.586 GB); no artifacts retained.