### PR TITLE
Close per-job cluster fill connections

### DIFF
--- a/.squad/decisions/inbox/protocol-pr142-lifecycle-precedence.md
+++ b/.squad/decisions/inbox/protocol-pr142-lifecycle-precedence.md
@@ -1,0 +1,4 @@
+### 2026-09-05: Preserve primary worker failures while exposing cleanup failures
+**By:** Protocol
+**What:** Cluster fill workers own direct transports with `bracket`; a body failure remains primary, same-resource close failure follows `bracket` precedence, and non-cancellation sibling cleanup failures are retained in `ConcurrentFailure`. Fill parents wait for all child exits and propagate the first non-zero exit by child index.
+**Why:** This keeps resource ownership exact without hiding close failures, while retaining the failure that caused sibling cancellation as the actionable root cause.

--- a/app/ClusterFiller.hs
+++ b/app/ClusterFiller.hs
@@ -3,20 +3,17 @@
 
 module ClusterFiller
   ( fillClusterWithData
+  , withClusterFillConnection
   ) where
 
-import           Control.Concurrent                 (MVar, forkIO, newEmptyMVar,
-                                                     putMVar, takeMVar,
-                                                     threadDelay)
+import           Control.Concurrent                 (threadDelay)
 import           Control.Concurrent.STM             (readTVarIO)
-import           Control.Exception                  (SomeException, bracket,
-                                                     catch)
-import           Control.Monad                      (when)
+import           Control.Exception                  (bracket, throwIO)
+import           Control.Monad                      (unless, when)
 import qualified Control.Monad.State                as State
 import qualified Data.ByteString                    as BS
 import qualified Data.ByteString.Builder            as Builder
 import           Data.ByteString.Char8              (ByteString)
-import qualified Data.ByteString.Char8              as BS8
 import qualified Data.ByteString.Lazy               as LBS
 import           Data.List                          (find)
 import           Data.Map.Strict                    (Map)
@@ -43,6 +40,7 @@ import           Filler                             (sendChunkedFill)
 import           FillHelpers                        (generateBytes,
                                                      generateBytesWithHashTag,
                                                      nextLCG, threadSeedSpacing)
+import           StructuredConcurrency              (runConcurrentlyFailFast)
 import           System.Timeout                     (timeout)
 import           Text.Printf                        (printf)
 
@@ -67,8 +65,7 @@ fillClusterWithData clusterClient _connector totalGB threadsPerNode baseSeed key
       numMasters = length masterNodes
 
   when (numMasters == 0) $ do
-    putStrLn "Error: No master nodes found in cluster"
-    return ()
+    ioError $ userError "No master nodes found in cluster"
 
   -- Calculate slot distribution for each master
   let slotRanges = calculateSlotRangesPerMaster topology masterNodes
@@ -87,12 +84,11 @@ fillClusterWithData clusterClient _connector totalGB threadsPerNode baseSeed key
   let jobs = concatMap (createJobsForNode baseMBPerNode mbRemainder threadsPerNode)
                        (zip [0..] masterNodes)
 
-  -- Execute jobs in parallel
-  mvars <- mapM
-    (executeJob clusterClient (clusterConnector clusterClient)
-      slotRanges baseSeed keySize valueSize pipelineBatchSize)
-    jobs
-  mapM_ takeMVar mvars
+  runConcurrentlyFailFast
+    [ executeJob clusterClient (clusterConnector clusterClient)
+        slotRanges baseSeed keySize valueSize pipelineBatchSize job
+    | job <- jobs
+    ]
 
   putStrLn "Cluster fill complete!"
   where
@@ -130,63 +126,42 @@ executeJob ::
   Int ->                              -- Value size in bytes
   Int ->                              -- Pipeline batch size
   (NodeAddress, Int, Int) ->  -- (address, threadIdx, mbToFill)
-  IO (MVar ())
-executeJob clusterClient connector slotRanges baseSeed keySize valueSize pipelineBatchSize (addr, threadIdx, mbToFill) = do
-  -- If this thread has no work, return immediately
-  if mbToFill <= 0
-    then do
-      mvar <- newEmptyMVar
-      putMVar mvar ()
-      return mvar
-    else do
-      mvar <- newEmptyMVar
-      _ <- forkIO $ do
-        -- Wrap the entire thread work in exception handler to ensure mvar is always filled
-        catch (do
-          -- Suppress per-thread logging to reduce spam with many processes/threads
-          -- Only log if something goes wrong
+  IO ()
+executeJob clusterClient connector slotRanges baseSeed keySize valueSize pipelineBatchSize (addr, threadIdx, mbToFill)
+  | mbToFill <= 0 = pure ()
+  | otherwise = do
+      threadDelay (threadIdx * 50000)
+      withClusterFillConnection connector addr $ \conn -> do
+        topology <- readTVarIO (clusterTopology clusterClient)
+        let masters = [node | node <- Map.elems (topologyNodes topology), nodeRole node == Master]
+            maybeNode = findNodeByAddress masters addr
 
-          -- Stagger connection creation to avoid overwhelming TLS handshakes
-          -- With many processes/threads hitting the same nodes simultaneously,
-          -- we can get "bad record mac" errors if TLS handshakes collide
-          threadDelay (threadIdx * 50000)  -- 50ms per thread index
-
-          -- Create a unique connection for this thread using connector directly
-          -- This avoids connection pool contention where threads share connections
-          bracket (connector addr) close $ \conn -> do
-            -- Find which slots this node owns
-            topology <- readTVarIO (clusterTopology clusterClient)
-            let masters = [node | node <- Map.elems (topologyNodes topology), nodeRole node == Master]
-                maybeNode = findNodeByAddress masters addr
-
-            case maybeNode of
-              Nothing -> do
-                printf "Warning: Could not find node for address %s:%d\n"
-                       (nodeHost addr) (nodePort addr)
-              Just node -> do
-                let nId = nodeId node
-                    slots = Map.findWithDefault [] nId slotRanges
-
-                when (null slots) $ do
-                  printf "Warning: Node %s has no assigned slots\n" (BS8.unpack nId)
-
-                -- Fill data for this node using its slots
-                fillNodeWithData conn slots mbToFill baseSeed threadIdx keySize valueSize pipelineBatchSize
-          ) (\e -> do
-            -- If any exception occurs, log it and continue
-            printf "Error in thread %d for node %s:%d: %s\n"
-                   threadIdx (nodeHost addr) (nodePort addr) (show (e :: SomeException))
-          )
-
-        -- Always signal completion, even if there was an error
-        putMVar mvar ()
-
-      return mvar
+        case maybeNode of
+          Nothing ->
+            ioError . userError $
+              "Cluster fill worker lost its assigned node "
+                ++ nodeHost addr ++ ":" ++ show (nodePort addr)
+          Just node -> do
+            let nId = nodeId node
+                slots = Map.findWithDefault [] nId slotRanges
+            when (null slots) $
+              ioError . userError $
+                "Cluster fill worker found no slots for node " ++ show nId
+            fillNodeWithData conn slots mbToFill baseSeed threadIdx keySize valueSize pipelineBatchSize
   where
     -- | Find a cluster node by its address
     -- Returns the first node matching the address, or Nothing if not found
     findNodeByAddress :: [ClusterNode] -> NodeAddress -> Maybe ClusterNode
     findNodeByAddress nodes nodeAddr = find (\n -> nodeAddress n == nodeAddr) nodes
+
+-- | A fill worker owns its direct transport for the duration of its job.
+withClusterFillConnection
+  :: (Client client)
+  => Connector client
+  -> NodeAddress
+  -> (client 'Connected -> IO a)
+  -> IO a
+withClusterFillConnection connector addr = bracket (connector addr) close
 
 -- | Fill a specific node with data using its assigned slots
 -- Uses MB for finer-grained allocation, matching standalone mode behavior
@@ -201,18 +176,15 @@ fillNodeWithData ::
   Int ->       -- Value size in bytes
   Int ->       -- Pipeline batch size
   IO ()
-fillNodeWithData conn slots mbToFill baseSeed threadIdx keySize valueSize pipelineBatchSize = do
-  when (null slots) $ return ()
-
+fillNodeWithData conn slots mbToFill baseSeed threadIdx keySize valueSize pipelineBatchSize =
+  unless (null slots) $ do
   -- Convert slots list to Vector for O(1) access in the hot loop
-  let !slotsVec = VU.fromList slots
+    let !slotsVec = VU.fromList slots
 
   -- Deterministic seed for this thread
-  let threadSeed = baseSeed + (fromIntegral threadIdx * threadSeedSpacing)
-      genChunk batchSize seed = generateClusterChunk slotsVec batchSize keySize valueSize seed
+    let threadSeed = baseSeed + (fromIntegral threadIdx * threadSeedSpacing)
+        genChunk batchSize seed = generateClusterChunk slotsVec batchSize keySize valueSize seed
 
-  -- Wrap in exception handler and timeout
-  catch (do
     let clientState = ClientState conn BS.empty
         fillAction = do
           _ <- clientReply OFF
@@ -221,14 +193,12 @@ fillNodeWithData conn slots mbToFill baseSeed threadIdx keySize valueSize pipeli
           (_ :: RespData) <- dbsize
           return ()
 
-    result <- timeout (600 * 1000000) $ State.evalStateT (runRedisCommandClient fillAction) clientState
+    result <- timeout (600 * 1000000) $
+      State.evalStateT (runRedisCommandClient fillAction) clientState
     case result of
-      Just _ -> return ()
-      Nothing -> printf "Thread %d for slots timed out after 10 minutes\n" threadIdx
-    ) (\e -> do
-      printf "Thread %d failed with error: %s\n" threadIdx (show (e :: SomeException))
-    )
-  return ()
+      Just _  -> pure ()
+      Nothing -> throwIO $ userError $
+        "Cluster fill worker timed out after 10 minutes (thread " ++ show threadIdx ++ ")"
 
 -- | Generate a chunk of SET commands using hash tags for proper slot routing
 -- Uses Vector for O(1) slot lookup instead of list indexing

--- a/app/ClusterFiller.hs
+++ b/app/ClusterFiller.hs
@@ -4,6 +4,7 @@
 module ClusterFiller
   ( fillClusterWithData
   , withClusterFillConnection
+  , fillNodeWithDataWithTimeout
   ) where
 
 import           Control.Concurrent                 (threadDelay)
@@ -177,6 +178,23 @@ fillNodeWithData ::
   Int ->       -- Pipeline batch size
   IO ()
 fillNodeWithData conn slots mbToFill baseSeed threadIdx keySize valueSize pipelineBatchSize =
+  fillNodeWithDataWithTimeout 600 conn slots mbToFill baseSeed threadIdx keySize valueSize pipelineBatchSize
+
+-- | The production worker uses a ten-minute deadline.  Keeping the deadline
+-- explicit makes the same worker path testable with a short deterministic one.
+fillNodeWithDataWithTimeout ::
+  (Client client) =>
+  Int ->       -- timeout in seconds
+  client 'Connected ->
+  [Word16] ->
+  Int ->       -- mbToFill (megabytes to fill)
+  Word64 ->
+  Int ->
+  Int ->       -- Key size in bytes
+  Int ->       -- Value size in bytes
+  Int ->       -- Pipeline batch size
+  IO ()
+fillNodeWithDataWithTimeout timeoutSeconds conn slots mbToFill baseSeed threadIdx keySize valueSize pipelineBatchSize =
   unless (null slots) $ do
   -- Convert slots list to Vector for O(1) access in the hot loop
     let !slotsVec = VU.fromList slots
@@ -193,12 +211,13 @@ fillNodeWithData conn slots mbToFill baseSeed threadIdx keySize valueSize pipeli
           (_ :: RespData) <- dbsize
           return ()
 
-    result <- timeout (600 * 1000000) $
+    result <- timeout (timeoutSeconds * 1000000) $
       State.evalStateT (runRedisCommandClient fillAction) clientState
     case result of
       Just _  -> pure ()
       Nothing -> throwIO $ userError $
-        "Cluster fill worker timed out after 10 minutes (thread " ++ show threadIdx ++ ")"
+        "Cluster fill worker timed out after " ++ show timeoutSeconds
+          ++ " seconds (thread " ++ show threadIdx ++ ")"
 
 -- | Generate a chunk of SET commands using hash tags for proper slot routing
 -- Uses Vector for O(1) slot lookup instead of list indexing

--- a/app/ClusterFiller.hs
+++ b/app/ClusterFiller.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module ClusterFiller
-  ( fillClusterWithData
+  ( executeClusterFillJob
+  , fillClusterWithData
+  , withClusterFillClient
   , withClusterFillConnection
   , fillNodeWithDataWithTimeout
   ) where
@@ -29,7 +31,8 @@ import           Database.Redis.Cluster             (ClusterNode (..),
                                                      NodeAddress (..),
                                                      NodeRole (..),
                                                      SlotRange (..))
-import           Database.Redis.Cluster.Client      (ClusterClient (..))
+import           Database.Redis.Cluster.Client      (ClusterClient (..),
+                                                     closeClusterClient)
 import           Database.Redis.Cluster.SlotMapping (slotMappings)
 import           Database.Redis.Command             (ClientReplyValues (..),
                                                      ClientState (..),
@@ -86,7 +89,7 @@ fillClusterWithData clusterClient _connector totalGB threadsPerNode baseSeed key
                        (zip [0..] masterNodes)
 
   runConcurrentlyFailFast
-    [ executeJob clusterClient (clusterConnector clusterClient)
+    [ executeClusterFillJob clusterClient (clusterConnector clusterClient)
         slotRanges baseSeed keySize valueSize pipelineBatchSize job
     | job <- jobs
     ]
@@ -117,7 +120,7 @@ fillClusterWithData clusterClient _connector totalGB threadsPerNode baseSeed key
     expandSlotRanges = concatMap (\r -> [slotStart r .. slotEnd r])
 
 -- | Execute a single fill job on a specific node
-executeJob ::
+executeClusterFillJob ::
   (Client client) =>
   ClusterClient client ->
   Connector client ->
@@ -128,7 +131,7 @@ executeJob ::
   Int ->                              -- Pipeline batch size
   (NodeAddress, Int, Int) ->  -- (address, threadIdx, mbToFill)
   IO ()
-executeJob clusterClient connector slotRanges baseSeed keySize valueSize pipelineBatchSize (addr, threadIdx, mbToFill)
+executeClusterFillJob clusterClient connector slotRanges baseSeed keySize valueSize pipelineBatchSize (addr, threadIdx, mbToFill)
   | mbToFill <= 0 = pure ()
   | otherwise = do
       threadDelay (threadIdx * 50000)
@@ -154,6 +157,14 @@ executeJob clusterClient connector slotRanges baseSeed keySize valueSize pipelin
     -- Returns the first node matching the address, or Nothing if not found
     findNodeByAddress :: [ClusterNode] -> NodeAddress -> Maybe ClusterNode
     findNodeByAddress nodes nodeAddr = find (\n -> nodeAddress n == nodeAddr) nodes
+
+-- | Scope the parent cluster client, including both backing pools.
+withClusterFillClient
+  :: (Client client)
+  => IO (ClusterClient client)
+  -> (ClusterClient client -> IO a)
+  -> IO a
+withClusterFillClient acquire = bracket acquire closeClusterClient
 
 -- | A fill worker owns its direct transport for the duration of its job.
 withClusterFillConnection

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -71,6 +71,7 @@ import           FillProcess                           (buildChildArgs)
 import           FlushConfirmation                     (canonicalFlushTarget,
                                                         confirmFlush)
 import           Numeric                               (showHex)
+import           ProcessLifecycle                      (waitForChildProcesses)
 import           StructuredConcurrency                 (runConcurrentlyFailFast,
                                                         withSubmittedSlots)
 import           System.Console.GetOpt                 (ArgDescr (..),
@@ -86,8 +87,7 @@ import           System.IO                             (hIsTerminalDevice,
                                                         hPutStrLn, isEOF,
                                                         stderr, stdin)
 import           System.Process                        (ProcessHandle,
-                                                        createProcess, proc,
-                                                        waitForProcess)
+                                                        createProcess, proc)
 import           System.Random                         (randomIO)
 import           Text.Printf                           (printf)
 
@@ -327,8 +327,8 @@ spawnFillProcesses state nprocs = do
   -- Spawn child processes
   handles <- mapM (spawnChildProcess exePath state baseGB remainder) [0..nprocs-1]
 
-  -- Wait for all processes to complete
-  mapM_ waitForProcess handles
+  -- Wait for all children and propagate the first non-zero child status.
+  waitForChildProcesses handles
   printf "All %d processes completed\n" nprocs
 
 -- | Spawn a single child process with its portion of data
@@ -348,13 +348,13 @@ flushCache state
       printf "Flushing all primary cluster nodes (seed node: '%s')\n" (host state)
       if useTLS state
         then do
-          clusterClient <- createClusterClientFromState state (createTLSConnector state)
-          flushAllClusterNodes clusterClient (createTLSConnector state)
-          closeClusterClient clusterClient
+          let connector = createTLSConnector state
+          bracket (createClusterClientFromState state connector) closeClusterClient $ \clusterClient ->
+            flushAllClusterNodes clusterClient connector
         else do
-          clusterClient <- createClusterClientFromState state (createPlaintextConnector state)
-          flushAllClusterNodes clusterClient (createPlaintextConnector state)
-          closeClusterClient clusterClient
+          let connector = createPlaintextConnector state
+          bracket (createClusterClientFromState state connector) closeClusterClient $ \clusterClient ->
+            flushAllClusterNodes clusterClient connector
   | otherwise = do
       printf "Flushing cache '%s'\n" (host state)
       if useTLS state

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,7 +3,8 @@
 
 module Main where
 
-import           ClusterFiller                         (fillClusterWithData)
+import           ClusterFiller                         (fillClusterWithData,
+                                                        withClusterFillClient)
 import           Database.Redis.Client                 (Client (receive, send),
                                                         TLSClient (..), serve)
 import           Database.Redis.Cluster.Client         (ClusterClient (..),
@@ -413,12 +414,12 @@ fillCluster state = do
     if useTLS state
       then do
         let connector = createTLSConnector state
-        bracket (createClusterClientFromState state connector) closeClusterClient $ \clusterClient ->
+        withClusterFillClient (createClusterClientFromState state connector) $ \clusterClient ->
           fillClusterWithData clusterClient connector
             (dataGBs state) threadsPerNode baseSeed (keySize state) (valueSize state) (pipelineBatchSize state)
       else do
         let connector = createPlaintextConnector state
-        bracket (createClusterClientFromState state connector) closeClusterClient $ \clusterClient ->
+        withClusterFillClient (createClusterClientFromState state connector) $ \clusterClient ->
           fillClusterWithData clusterClient connector
             (dataGBs state) threadsPerNode baseSeed (keySize state) (valueSize state) (pipelineBatchSize state)
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -412,15 +412,15 @@ fillCluster state = do
     -- Create cluster client and fill data
     if useTLS state
       then do
-        clusterClient <- createClusterClientFromState state (createTLSConnector state)
-        fillClusterWithData clusterClient (createTLSConnector state)
-                           (dataGBs state) threadsPerNode baseSeed (keySize state) (valueSize state) (pipelineBatchSize state)
-        closeClusterClient clusterClient
+        let connector = createTLSConnector state
+        bracket (createClusterClientFromState state connector) closeClusterClient $ \clusterClient ->
+          fillClusterWithData clusterClient connector
+            (dataGBs state) threadsPerNode baseSeed (keySize state) (valueSize state) (pipelineBatchSize state)
       else do
-        clusterClient <- createClusterClientFromState state (createPlaintextConnector state)
-        fillClusterWithData clusterClient (createPlaintextConnector state)
-                           (dataGBs state) threadsPerNode baseSeed (keySize state) (valueSize state) (pipelineBatchSize state)
-        closeClusterClient clusterClient
+        let connector = createPlaintextConnector state
+        bracket (createClusterClientFromState state connector) closeClusterClient $ \clusterClient ->
+          fillClusterWithData clusterClient connector
+            (dataGBs state) threadsPerNode baseSeed (keySize state) (valueSize state) (pipelineBatchSize state)
 
 cli :: RunState -> IO ()
 cli state = do

--- a/app/ProcessLifecycle.hs
+++ b/app/ProcessLifecycle.hs
@@ -1,0 +1,26 @@
+module ProcessLifecycle
+  ( ChildProcessFailure (..)
+  , waitForChildProcesses
+  ) where
+
+import           Control.Exception (Exception, throwIO)
+import           Data.Typeable     (Typeable)
+import           System.Exit       (ExitCode (ExitSuccess))
+import           System.Process    (ProcessHandle, waitForProcess)
+
+-- | A fill parent only reports completion after every child has exited.
+-- The first non-success status in process-index order is propagated.
+data ChildProcessFailure = ChildProcessFailure Int ExitCode
+  deriving (Show, Typeable)
+
+instance Exception ChildProcessFailure
+
+waitForChildProcesses :: [ProcessHandle] -> IO ()
+waitForChildProcesses handles = do
+  exitCodes <- mapM waitForProcess handles
+  case [ (index, exitCode)
+       | (index, exitCode) <- zip [0..] exitCodes
+       , exitCode /= ExitSuccess
+       ] of
+    []                      -> pure ()
+    ((index, exitCode) : _) -> throwIO $ ChildProcessFailure index exitCode

--- a/app/StructuredConcurrency.hs
+++ b/app/StructuredConcurrency.hs
@@ -1,43 +1,95 @@
 module StructuredConcurrency
-  ( runConcurrentlyFailFast
+  ( ConcurrentFailure (..)
+  , runConcurrentlyFailFast
   , withSubmittedSlots
   ) where
 
 import           Control.Concurrent       (forkIO)
-import           Control.Concurrent.Async (Async, async, cancel, waitAnyCatch,
-                                           waitCatch)
-import           Control.Exception        (SomeException, mask, onException,
-                                           throwIO)
+import           Control.Concurrent.Async (Async, AsyncCancelled, async, cancel,
+                                           waitAnyCatch, waitCatch)
+import           Control.Exception        (AsyncException, Exception,
+                                           SomeException, fromException, mask,
+                                           onException, throwIO, toException,
+                                           try)
 import           Control.Monad            (void)
 import           Data.IORef               (atomicModifyIORef', newIORef,
                                            readIORef)
+import           Data.Typeable            (Typeable)
+
+-- | A worker body failure remains the primary error.  Failures raised by
+-- cancelled siblings (for example, while closing their resources) are retained
+-- rather than discarded and are available as secondary diagnostics.
+data ConcurrentFailure = ConcurrentFailure
+  { concurrentPrimaryFailure         :: SomeException
+  , concurrentSiblingCleanupFailures :: [SomeException]
+  } deriving (Typeable)
+
+instance Show ConcurrentFailure where
+  show (ConcurrentFailure primary cleanupFailures) =
+    "concurrent worker failed: " ++ show primary
+      ++ "; sibling cleanup failures: " ++ show cleanupFailures
+
+instance Exception ConcurrentFailure
 
 -- | Run workers as one cancellation scope.  A failing worker cancels and joins
--- every sibling before its exception is propagated to the caller.
+-- every sibling before its exception is propagated to the caller.  The first
+-- completed failing worker is primary; non-cancellation failures from sibling
+-- cleanup are reported in 'ConcurrentFailure'.  If only one failure occurs,
+-- its original exception type is rethrown.
 runConcurrentlyFailFast :: [IO ()] -> IO ()
 runConcurrentlyFailFast actions = mask $ \restore ->
   let
     spawn [] = pure []
     spawn (action : remaining) = do
       worker <- async (restore action)
-      (worker :) <$> spawn remaining `onException` cancelAndWait [worker]
+      spawned <- try (spawn remaining)
+      case spawned of
+        Right workers -> pure (worker : workers)
+        Left exception -> do
+          cleanupFailures <- cancelAndCollect [worker]
+          throwIO $ combineFailures exception cleanupFailures
 
-    waitForWorkers [] = pure ()
+    waitForWorkers [] = pure (Right ())
     waitForWorkers workers = do
       (completed, result) <- waitAnyCatch workers
       case result of
         Left exception -> do
-          cancelAndWait workers
-          throwIO (exception :: SomeException)
+          cleanupFailures <- cancelAndCollect (filter (/= completed) workers)
+          pure $ Left $ combineFailures exception cleanupFailures
         Right () -> waitForWorkers (filter (/= completed) workers)
   in do
     workers <- spawn actions
-    restore (waitForWorkers workers) `onException` cancelAndWait workers
+    result <- try (restore (waitForWorkers workers))
+    case result of
+      Right (Right ()) -> pure ()
+      Right (Left exception) -> throwIO exception
+      Left exception -> do
+        cleanupFailures <- cancelAndCollect workers
+        throwIO $ combineFailures exception cleanupFailures
 
-cancelAndWait :: [Async ()] -> IO ()
-cancelAndWait workers = do
+cancelAndCollect :: [Async ()] -> IO [SomeException]
+cancelAndCollect workers = do
   mapM_ cancel workers
-  mapM_ waitCatch workers
+  results <- mapM waitCatch workers
+  pure
+    [ exception
+    | Left exception <- results
+    , not (isExpectedCancellation exception)
+    ]
+
+combineFailures :: SomeException -> [SomeException] -> SomeException
+combineFailures primary [] = primary
+combineFailures primary cleanupFailures =
+  toException $ ConcurrentFailure primary cleanupFailures
+
+isExpectedCancellation :: SomeException -> Bool
+isExpectedCancellation exception =
+  case fromException exception :: Maybe AsyncCancelled of
+    Just _  -> True
+    Nothing ->
+      case fromException exception :: Maybe AsyncException of
+        Just _  -> True
+        Nothing -> False
 
 -- | Scope asynchronous submissions.  A slot remains in the scope until its
 -- wait starts; if the scope exits first, a cleanup worker owns that wait.

--- a/redis-client.cabal
+++ b/redis-client.cabal
@@ -118,6 +118,7 @@ test-suite StructuredConcurrencySpec
     other-modules:    ClusterFiller
                     , FillHelpers
                     , Filler
+                    , ProcessLifecycle
                     , StructuredConcurrency
     hs-source-dirs:   test
                     , app
@@ -126,6 +127,7 @@ test-suite StructuredConcurrencySpec
                     , containers
                     , hask-redis-mux
                     , mtl
+                    , process
                     , stm
                     , vector
 
@@ -243,6 +245,7 @@ executable redis-client
                     , FillProcess
                     , FlushConfirmation
                     , Filler
+                    , ProcessLifecycle
                     , SlotMappingHelpers
                     , StructuredConcurrency
     build-depends:    attoparsec

--- a/redis-client.cabal
+++ b/redis-client.cabal
@@ -115,10 +115,19 @@ test-suite StructuredConcurrencySpec
     import:           test-defaults
     type:             exitcode-stdio-1.0
     main-is:          StructuredConcurrencySpec.hs
-    other-modules:    StructuredConcurrency
+    other-modules:    ClusterFiller
+                    , FillHelpers
+                    , Filler
+                    , StructuredConcurrency
     hs-source-dirs:   test
                     , app
     build-depends:    async
+                    , bytestring
+                    , containers
+                    , hask-redis-mux
+                    , mtl
+                    , stm
+                    , vector
 
 -- ---------------------------------------------------------------------------
 -- Flags

--- a/redis-client.cabal
+++ b/redis-client.cabal
@@ -129,6 +129,7 @@ test-suite StructuredConcurrencySpec
                     , mtl
                     , process
                     , stm
+                    , time
                     , vector
 
 -- ---------------------------------------------------------------------------

--- a/test/StructuredConcurrencySpec.hs
+++ b/test/StructuredConcurrencySpec.hs
@@ -1,136 +1,272 @@
-{-# LANGUAGE DataKinds      #-}
-{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE KindSignatures    #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Main where
 
-import           ClusterFiller            (fillNodeWithDataWithTimeout,
-                                           withClusterFillConnection)
-import           Control.Concurrent.Async (Async, async, waitCatch)
-import           Control.Concurrent.STM   (TMVar, atomically, newEmptyTMVarIO,
-                                           putTMVar, readTMVar, retry)
-import           Control.Exception        (SomeException, bracket,
-                                           fromException, throwIO, try)
-import           Control.Monad.IO.Class   (liftIO)
-import qualified Data.ByteString.Lazy     as LBS
-import           Data.IORef               (IORef, atomicModifyIORef', newIORef,
-                                           readIORef, writeIORef)
-import           Data.List                (isInfixOf)
-import qualified Data.Map.Strict          as Map
-import qualified Data.Set                 as Set
-import           Database.Redis.Client    (Client (..), ConnectionStatus (..))
-import           Database.Redis.Cluster   (NodeAddress (..))
-import           ProcessLifecycle         (ChildProcessFailure (..),
-                                           waitForChildProcesses)
-import           StructuredConcurrency    (ConcurrentFailure (..),
-                                           runConcurrentlyFailFast)
-import           System.Exit              (ExitCode (ExitFailure))
-import           System.Process           (createProcess, proc)
-import           System.Timeout           (timeout)
+import           ClusterFiller                         (executeClusterFillJob,
+                                                        fillClusterWithData,
+                                                        fillNodeWithDataWithTimeout,
+                                                        withClusterFillClient,
+                                                        withClusterFillConnection)
+import           Control.Concurrent.Async              (Async, async, cancel,
+                                                        waitCatch)
+import           Control.Concurrent.MVar               (newMVar)
+import           Control.Concurrent.STM                (TMVar, TVar, atomically,
+                                                        check, modifyTVar',
+                                                        newEmptyTMVarIO,
+                                                        newTVarIO, putTMVar,
+                                                        readTMVar, readTVar,
+                                                        readTVarIO, retry)
+import           Control.Exception                     (SomeException,
+                                                        fromException, throwIO,
+                                                        try)
+import           Control.Monad                         (when)
+import           Control.Monad.IO.Class                (liftIO)
+import qualified Data.ByteString                       as BS
+import qualified Data.ByteString.Lazy                  as LBS
+import           Data.IORef                            (IORef,
+                                                        atomicModifyIORef',
+                                                        newIORef, readIORef,
+                                                        writeIORef)
+import           Data.List                             (isInfixOf)
+import qualified Data.Map.Strict                       as Map
+import qualified Data.Set                              as Set
+import           Data.Time.Clock                       (getCurrentTime)
+import qualified Data.Vector                           as V
+import           Data.Word                             (Word16)
+import           Database.Redis.Client                 (Client (..),
+                                                        ConnectionStatus (..))
+import           Database.Redis.Cluster                (ClusterNode (..),
+                                                        ClusterTopology (..),
+                                                        NodeAddress (..),
+                                                        NodeRole (..),
+                                                        SlotRange (..))
+import           Database.Redis.Cluster.Client         (ClusterClient (..),
+                                                        ClusterConfig (..))
+import           Database.Redis.Cluster.ConnectionPool (PoolConfig (..))
+import qualified Database.Redis.Cluster.ConnectionPool as CP
+import           Database.Redis.Internal.MultiplexPool (createMultiplexPool)
+import           ProcessLifecycle                      (ChildProcessFailure (..),
+                                                        waitForChildProcesses)
+import           StructuredConcurrency                 (ConcurrentFailure (..),
+                                                        runConcurrentlyFailFast)
+import           System.Exit                           (ExitCode (ExitFailure))
+import           System.Process                        (createProcess,
+                                                        getProcessExitCode,
+                                                        proc)
+import           System.Timeout                        (timeout)
 import           Test.Hspec
 
-phaseTimeout :: Int
-phaseTimeout = 1000000
+diagnosticTimeout :: Int
+diagnosticTimeout = 5000000
 
 main :: IO ()
 main = hspec $ do
   describe "structured worker ownership" $ do
-    it "propagates a body failure after cancelling and joining a blocked sibling" $ do
-      ready <- newPhase
+    it "cancels and closes a real blocked sibling before surfacing the body failure" $ do
+      tracker <- newTracker
       release <- newPhase
+      let primaryConnector =
+            trackedConnector tracker WorkerTransport False SendNormally ReceiveNormally
+          siblingConnector =
+            trackedConnector tracker WorkerTransport False SendBlocked ReceiveNormally
       parent <- async $ runConcurrentlyFailFast
-        [ awaitPhase release >> throwIO (userError "connect failure")
-        , blockingWorker ready
+        [ withClusterFillConnection primaryConnector testAddress $ \_ -> do
+            awaitPhase release
+            throwIO $ userError "primary body failure"
+        , withClusterFillConnection siblingConnector testAddress $ \conn ->
+            send conn LBS.empty
         ]
-      awaitPhase ready
+      awaitRoleAcquired tracker WorkerTransport 2
+      awaitSendCount tracker 1
       signalPhase release
       result <- awaitResult parent
-      result `shouldSatisfy` isFailure
+      show result `shouldSatisfy` isInfixOf "primary body failure"
+      assertAllConnectionsClosedOnce tracker 2
 
-    it "preserves a body failure and reports a sibling close failure" $ do
-      ready <- newPhase
+    it "preserves a body failure and reports a real sibling transport close failure" $ do
+      tracker <- newTracker
       release <- newPhase
+      let primaryConnector =
+            trackedConnector tracker WorkerTransport False SendNormally ReceiveNormally
+          siblingConnector =
+            trackedConnector tracker WorkerTransport True SendBlocked ReceiveNormally
       parent <- async $ runConcurrentlyFailFast
-        [ awaitPhase release >> throwIO (userError "send failure")
-        , bracket (pure ()) (\() -> throwIO (userError "sibling close failure")) $ \() ->
-            blockingWorker ready
+        [ withClusterFillConnection primaryConnector testAddress $ \_ -> do
+            awaitPhase release
+            throwIO $ userError "send failure"
+        , withClusterFillConnection siblingConnector testAddress $ \conn ->
+            send conn LBS.empty
         ]
-      awaitPhase ready
+      awaitRoleAcquired tracker WorkerTransport 2
+      awaitSendCount tracker 1
       signalPhase release
       result <- awaitResult parent
       assertConcurrentFailure "send failure" 1 result
+      assertAllConnectionsClosedOnce tracker 2
 
-    it "reports every simultaneous sibling cleanup failure" $ do
-      readyOne <- newPhase
-      readyTwo <- newPhase
+    it "reports every real sibling transport cleanup failure" $ do
+      tracker <- newTracker
       release <- newPhase
+      let primaryConnector =
+            trackedConnector tracker WorkerTransport False SendNormally ReceiveNormally
+          failingSiblingConnector =
+            trackedConnector tracker WorkerTransport True SendBlocked ReceiveNormally
       parent <- async $ runConcurrentlyFailFast
-        [ awaitPhase release >> throwIO (userError "primary body failure")
-        , failingCleanupWorker readyOne "close one"
-        , failingCleanupWorker readyTwo "close two"
+        [ withClusterFillConnection primaryConnector testAddress $ \_ -> do
+            awaitPhase release
+            throwIO $ userError "primary body failure"
+        , withClusterFillConnection failingSiblingConnector testAddress $ \conn ->
+            send conn LBS.empty
+        , withClusterFillConnection failingSiblingConnector testAddress $ \conn ->
+            send conn LBS.empty
         ]
-      awaitPhase readyOne
-      awaitPhase readyTwo
+      awaitRoleAcquired tracker WorkerTransport 3
+      awaitSendCount tracker 2
       signalPhase release
       result <- awaitResult parent
       assertConcurrentFailure "primary body failure" 2 result
+      assertAllConnectionsClosedOnce tracker 3
 
   describe "cluster fill worker connection ownership" $ do
-    it "closes each acquired direct transport exactly once after success" $ do
-      tracker <- newTracker False False
-      withClusterFillConnection (trackedConnector tracker) testAddress $ \conn ->
-        send conn LBS.empty
+    it "closes an acquired direct transport exactly once after success" $ do
+      tracker <- newTracker
+      withClusterFillConnection
+        (trackedConnector tracker WorkerTransport False SendNormally ReceiveNormally)
+        testAddress $ \conn ->
+          send conn LBS.empty
       assertAllConnectionsClosedOnce tracker 1
 
-    it "does not close when direct transport acquisition fails" $ do
-      tracker <- newTracker False False
-      result <- try (withClusterFillConnection (failingConnector tracker) testAddress (\_ -> pure ())) :: IO (Either SomeException ())
-      result `shouldSatisfy` isFailure
+    it "surfaces acquisition failure without inventing an owned transport" $ do
+      tracker <- newTracker
+      topology <- populatedTopology
+      result <- withSyntheticClusterClient tracker topology
+        (trackedConnector tracker WorkerTransport False SendNormally ReceiveNormally) False $ \client ->
+          try (executeClusterFillJob client failingConnector testSlotRanges 1 8 8 65536
+            (testAddress, 0, 1)) :: IO (Either SomeException ())
+      show result `shouldSatisfy` isInfixOf "acquire failure"
       assertAllConnectionsClosedOnce tracker 0
 
-    it "closes a worker transport after a send/body failure" $ do
-      tracker <- newTracker False False
-      result <- try (withClusterFillConnection (trackedConnector tracker) testAddress $ \conn -> do
-        send conn LBS.empty
-        throwIO (userError "send failure")) :: IO (Either SomeException ())
-      result `shouldSatisfy` isFailure
+    it "closes the production worker transport when live topology loses its node" $ do
+      tracker <- newTracker
+      topology <- emptyTopology
+      result <- withSyntheticClusterClient tracker topology
+        (trackedConnector tracker WorkerTransport False SendNormally ReceiveNormally) False $ \client ->
+          try (executeClusterFillJob client (trackedWorkerConnector tracker)
+            testSlotRanges 1 8 8 65536 (testAddress, 0, 1)) :: IO (Either SomeException ())
+      show result `shouldSatisfy` isInfixOf "lost its assigned node"
       assertAllConnectionsClosedOnce tracker 1
 
-    it "surfaces close failure over a same-resource body failure after closing it" $ do
-      tracker <- newTracker True False
-      result <- try (withClusterFillConnection (trackedConnector tracker) testAddress $ \_ ->
-        throwIO (userError "body failure")) :: IO (Either SomeException ())
+    it "closes the production worker transport when its node has no assigned slots" $ do
+      tracker <- newTracker
+      topology <- populatedTopology
+      result <- withSyntheticClusterClient tracker topology
+        (trackedConnector tracker WorkerTransport False SendNormally ReceiveNormally) False $ \client ->
+          try (executeClusterFillJob client (trackedWorkerConnector tracker)
+            Map.empty 1 8 8 65536 (testAddress, 0, 1)) :: IO (Either SomeException ())
+      show result `shouldSatisfy` isInfixOf "found no slots"
+      assertAllConnectionsClosedOnce tracker 1
+
+    it "closes the production worker transport after a send/body failure" $ do
+      tracker <- newTracker
+      topology <- populatedTopology
+      let connector =
+            trackedConnector tracker WorkerTransport False
+              (SendFailure "send failure") ReceiveNormally
+      result <- withSyntheticClusterClient tracker topology connector False $ \client ->
+        try (executeClusterFillJob client connector testSlotRanges 1 8 8 65536
+          (testAddress, 0, 1)) :: IO (Either SomeException ())
+      show result `shouldSatisfy` isInfixOf "send failure"
+      assertAllConnectionsClosedOnce tracker 1
+
+    it "uses bracket cleanup precedence when worker body and close both fail" $ do
+      tracker <- newTracker
+      topology <- populatedTopology
+      let connector =
+            trackedConnector tracker WorkerTransport True
+              (SendFailure "body failure") ReceiveNormally
+      result <- withSyntheticClusterClient tracker topology connector False $ \client ->
+        try (executeClusterFillJob client connector testSlotRanges 1 8 8 65536
+          (testAddress, 0, 1)) :: IO (Either SomeException ())
       show result `shouldSatisfy` isInfixOf "close failure"
+      show result `shouldNotSatisfy` isInfixOf "body failure"
       assertAllConnectionsClosedOnce tracker 1
 
     it "times out through the production fill worker and closes the transport" $ do
-      tracker <- newTracker False True
-      result <- try (withClusterFillConnection (trackedConnector tracker) testAddress $ \conn ->
-        fillNodeWithDataWithTimeout 1 conn [0] 1 1 0 8 8 1) :: IO (Either SomeException ())
+      tracker <- newTracker
+      result <- try (withClusterFillConnection
+        (trackedConnector tracker WorkerTransport False SendNormally ReceiveBlocked)
+        testAddress $ \conn ->
+          fillNodeWithDataWithTimeout 1 conn [0] 1 1 0 8 8 65536)
+        :: IO (Either SomeException ())
       show result `shouldSatisfy` isInfixOf "timed out"
       assertAllConnectionsClosedOnce tracker 1
 
-    it "rejects a production-scoped transport after it has closed" $ do
-      tracker <- newTracker False False
+    it "rejects use of a production-scoped transport after it has closed" $ do
+      tracker <- newTracker
       escaped <- newIORef Nothing
-      withClusterFillConnection (trackedConnector tracker) testAddress $ \conn ->
-        writeIORef escaped (Just conn)
+      withClusterFillConnection
+        (trackedConnector tracker WorkerTransport False SendNormally ReceiveNormally)
+        testAddress $ \conn ->
+          writeIORef escaped (Just conn)
       Just conn <- readIORef escaped
       send conn LBS.empty `shouldThrow` anyException
       assertAllConnectionsClosedOnce tracker 1
 
+  describe "cluster fill parent ownership" $ do
+    it "closes the real parent pool and failed worker transport exactly once" $ do
+      tracker <- newTracker
+      topology <- populatedTopology
+      let connector =
+            trackedConnector tracker WorkerTransport False
+              (SendFailure "worker body failure") ReceiveNormally
+      result <- try $ withSyntheticClusterClient tracker topology connector True $ \client ->
+        executeClusterFillJob client connector testSlotRanges 1 8 8 65536
+          (testAddress, 0, 1)
+      show (result :: Either SomeException ()) `shouldSatisfy`
+        isInfixOf "worker body failure"
+      assertRoleClosedOnce tracker ParentPoolTransport 1
+      assertRoleClosedOnce tracker WorkerTransport 1
+      assertAllConnectionsClosedOnce tracker 2
+
+    it "cancels active workers before closing the real parent pool exactly once" $ do
+      tracker <- newTracker
+      topology <- populatedTopology
+      let connector =
+            trackedConnector tracker WorkerTransport False SendBlocked ReceiveNormally
+      parent <- async $ withSyntheticClusterClient tracker topology connector True $ \client ->
+        fillClusterWithData client connector 1 2 1 8 8 65536
+      awaitRoleAcquired tracker ParentPoolTransport 1
+      awaitRoleAcquired tracker WorkerTransport 2
+      awaitSendCount tracker 2
+      cancel parent
+      result <- awaitResult parent
+      result `shouldSatisfy` isFailure
+      assertRoleClosedOnce tracker ParentPoolTransport 1
+      assertRoleClosedOnce tracker WorkerTransport 2
+      assertAllConnectionsClosedOnce tracker 3
+
   describe "multiprocess fill ownership" $
-    it "waits for every real child then propagates its non-zero exit status" $ do
-      (_, _, _, successfulChild) <- createProcess (proc "/bin/sh" ["-c", "exit 0"])
-      (_, _, _, failingChild) <- createProcess (proc "/bin/sh" ["-c", "exit 7"])
-      result <- try (waitForChildProcesses [successfulChild, failingChild]) :: IO (Either SomeException ())
-      case result of
-        Left exception ->
+    it "waits and reaps every real child before selecting the first indexed failure" $ do
+      (_, _, _, firstChild) <- createProcess (proc "/bin/sh" ["-c", "exit 7"])
+      (_, _, _, secondChild) <- createProcess
+        (proc "/bin/sh" ["-c", "sleep 0.2; exit 9"])
+      bounded <- timeout diagnosticTimeout
+        (try (waitForChildProcesses [firstChild, secondChild])
+          :: IO (Either SomeException ()))
+      case bounded of
+        Nothing -> expectationFailure "child wait exceeded diagnostic bound"
+        Just (Left exception) ->
           case fromException exception :: Maybe ChildProcessFailure of
             Nothing -> expectationFailure $ "unexpected result: " ++ show exception
             Just (ChildProcessFailure index exitCode) -> do
-              index `shouldBe` 1
+              index `shouldBe` 0
               exitCode `shouldBe` ExitFailure 7
-        Right () -> expectationFailure "expected a non-zero child exit to fail the parent"
+        Just (Right ()) ->
+          expectationFailure "expected a non-zero child exit to fail the parent"
+      getProcessExitCode firstChild `shouldReturn` Just (ExitFailure 7)
+      getProcessExitCode secondChild `shouldReturn` Just (ExitFailure 9)
 
 newPhase :: IO (TMVar ())
 newPhase = newEmptyTMVarIO
@@ -139,27 +275,32 @@ signalPhase :: TMVar () -> IO ()
 signalPhase phase = atomically $ putTMVar phase ()
 
 awaitPhase :: TMVar () -> IO ()
-awaitPhase phase = do
-  result <- timeout phaseTimeout (atomically $ readTMVar phase)
-  result `shouldBe` Just ()
+awaitPhase phase = awaitWithin "phase" $ atomically $ readTMVar phase
 
 awaitResult :: Async () -> IO (Either SomeException ())
-awaitResult worker = do
-  result <- timeout phaseTimeout (waitCatch worker)
+awaitResult worker = awaitWithin "worker completion" $ waitCatch worker
+
+awaitRoleAcquired :: Tracker -> TransportRole -> Int -> IO ()
+awaitRoleAcquired tracker role expected =
+  awaitWithin ("acquiring " ++ show expected ++ " " ++ show role ++ " transports") $
+    atomically $ do
+      roles <- readTVar (trackerRoles tracker)
+      check $ length (filter (== role) $ Map.elems roles) >= expected
+
+awaitSendCount :: Tracker -> Int -> IO ()
+awaitSendCount tracker expected =
+  awaitWithin ("starting " ++ show expected ++ " sends") $
+    atomically $ do
+      count <- readTVar (trackerSendCount tracker)
+      check $ count >= expected
+
+awaitWithin :: String -> IO a -> IO a
+awaitWithin description action = do
+  result <- timeout diagnosticTimeout action
   case result of
-    Nothing -> expectationFailure "worker did not finish within the diagnostic phase bound" >> error "unreachable"
-    Just outcome -> pure outcome
-
-failingCleanupWorker :: TMVar () -> String -> IO ()
-failingCleanupWorker ready message =
-  bracket (pure ()) (\() -> throwIO (userError message)) $ \() -> do
-    blockingWorker ready
-
-blockingWorker :: TMVar () -> IO ()
-blockingWorker ready = do
-  never <- newPhase
-  signalPhase ready
-  awaitPhase never
+    Nothing -> expectationFailure (description ++ " exceeded diagnostic bound")
+      >> error "unreachable"
+    Just value -> pure value
 
 assertConcurrentFailure :: String -> Int -> Either SomeException () -> Expectation
 assertConcurrentFailure primary expectedCleanup result =
@@ -176,54 +317,115 @@ isFailure :: Either SomeException () -> Bool
 isFailure (Left _)  = True
 isFailure (Right _) = False
 
+data TransportRole = ParentPoolTransport | WorkerTransport
+  deriving (Eq, Ord, Show)
+
+data SendMode
+  = SendNormally
+  | SendFailure String
+  | SendBlocked
+
+data ReceiveMode
+  = ReceiveNormally
+  | ReceiveBlocked
+
 data Tracker = Tracker
-  { trackerNextId        :: IORef Int
-  , trackerLive          :: IORef (Set.Set Int)
-  , trackerCloseCounts   :: IORef (Map.Map Int Int)
-  , trackerCloseFails    :: Bool
-  , trackerBlocksReceive :: Bool
+  { trackerNextId      :: IORef Int
+  , trackerLive        :: IORef (Set.Set Int)
+  , trackerCloseCounts :: IORef (Map.Map Int Int)
+  , trackerRoles       :: TVar (Map.Map Int TransportRole)
+  , trackerSendCount   :: TVar Int
   }
 
-data TrackingClient (status :: ConnectionStatus) = TrackingClient Tracker Int
+data TrackingClient (status :: ConnectionStatus) = TrackingClient
+  Tracker
+  Int
+  Bool
+  SendMode
+  ReceiveMode
 
 instance Client TrackingClient where
-  connect (TrackingClient tracker connectionId) =
-    liftIO (assertOpen tracker connectionId) >> pure (TrackingClient tracker connectionId)
-  close (TrackingClient tracker connectionId) = liftIO $ do
+  connect (TrackingClient tracker connectionId closeFails sendMode receiveMode) =
+    liftIO (assertOpen tracker connectionId)
+      >> pure (TrackingClient tracker connectionId closeFails sendMode receiveMode)
+
+  close (TrackingClient tracker connectionId closeFails _ _) = liftIO $ do
     assertOpen tracker connectionId
-    atomicModifyIORef' (trackerLive tracker) (\live -> (Set.delete connectionId live, ()))
+    atomicModifyIORef' (trackerLive tracker)
+      (\live -> (Set.delete connectionId live, ()))
     atomicModifyIORef' (trackerCloseCounts tracker)
       (\counts -> (Map.insertWith (+) connectionId 1 counts, ()))
-    if trackerCloseFails tracker
-      then throwIO (userError "close failure")
-      else pure ()
+    when closeFails $ throwIO $ userError "close failure"
+
   abort = close
-  send (TrackingClient tracker connectionId) _ = liftIO $ assertOpen tracker connectionId
-  receive (TrackingClient tracker connectionId) = liftIO $ do
+
+  send (TrackingClient tracker connectionId _ sendMode _) _ = liftIO $ do
     assertOpen tracker connectionId
-    if trackerBlocksReceive tracker then atomically retry else pure mempty
+    atomically $ modifyTVar' (trackerSendCount tracker) (+ 1)
+    case sendMode of
+      SendNormally       -> pure ()
+      SendFailure reason -> throwIO $ userError reason
+      SendBlocked        -> atomically retry
 
-newTracker :: Bool -> Bool -> IO Tracker
-newTracker closeFails blocksReceive =
+  receive (TrackingClient tracker connectionId _ _ receiveMode) = liftIO $ do
+    assertOpen tracker connectionId
+    case receiveMode of
+      ReceiveNormally -> pure "+OK\r\n:0\r\n"
+      ReceiveBlocked  -> atomically retry
+
+newTracker :: IO Tracker
+newTracker =
   Tracker <$> newIORef 0 <*> newIORef Set.empty <*> newIORef Map.empty
-    <*> pure closeFails <*> pure blocksReceive
+    <*> newTVarIO Map.empty <*> newTVarIO 0
 
-trackedConnector :: Tracker -> NodeAddress -> IO (TrackingClient 'Connected)
-trackedConnector tracker _ = do
+trackedConnector
+  :: Tracker
+  -> TransportRole
+  -> Bool
+  -> SendMode
+  -> ReceiveMode
+  -> NodeAddress
+  -> IO (TrackingClient 'Connected)
+trackedConnector tracker role closeFails sendMode receiveMode _ = do
   connectionId <- atomicModifyIORef' (trackerNextId tracker) (\n -> (n + 1, n))
-  atomicModifyIORef' (trackerLive tracker) (\live -> (Set.insert connectionId live, ()))
-  pure $ TrackingClient tracker connectionId
+  atomicModifyIORef' (trackerLive tracker)
+    (\live -> (Set.insert connectionId live, ()))
+  atomically $ modifyTVar' (trackerRoles tracker)
+    (Map.insert connectionId role)
+  pure $ TrackingClient tracker connectionId closeFails sendMode receiveMode
 
-failingConnector :: Tracker -> NodeAddress -> IO (TrackingClient 'Connected)
-failingConnector _ _ = throwIO $ userError "acquire failure"
+trackedWorkerConnector
+  :: Tracker
+  -> NodeAddress
+  -> IO (TrackingClient 'Connected)
+trackedWorkerConnector tracker =
+  trackedConnector tracker WorkerTransport False SendNormally ReceiveNormally
+
+failingConnector :: NodeAddress -> IO (TrackingClient 'Connected)
+failingConnector _ = throwIO $ userError "acquire failure"
 
 assertAllConnectionsClosedOnce :: Tracker -> Int -> IO ()
 assertAllConnectionsClosedOnce tracker expected = do
   live <- readIORef (trackerLive tracker)
+  roles <- readTVarIO (trackerRoles tracker)
   counts <- readIORef (trackerCloseCounts tracker)
   Set.null live `shouldBe` True
+  Map.size roles `shouldBe` expected
   Map.size counts `shouldBe` expected
   mapM_ (`shouldBe` 1) (Map.elems counts)
+
+assertRoleClosedOnce :: Tracker -> TransportRole -> Int -> IO ()
+assertRoleClosedOnce tracker role expected = do
+  roles <- readTVarIO (trackerRoles tracker)
+  counts <- readIORef (trackerCloseCounts tracker)
+  let connectionIds =
+        [ connectionId
+        | (connectionId, connectionRole) <- Map.toList roles
+        , connectionRole == role
+        ]
+  length connectionIds `shouldBe` expected
+  mapM_ (\connectionId -> Map.lookup connectionId counts `shouldBe` Just 1)
+    connectionIds
 
 assertOpen :: Tracker -> Int -> IO ()
 assertOpen tracker connectionId = do
@@ -231,6 +433,87 @@ assertOpen tracker connectionId = do
   if Set.member connectionId live
     then pure ()
     else throwIO $ userError "use after close"
+
+withSyntheticClusterClient
+  :: Tracker
+  -> ClusterTopology
+  -> (NodeAddress -> IO (TrackingClient 'Connected))
+  -> Bool
+  -> (ClusterClient TrackingClient -> IO a)
+  -> IO a
+withSyntheticClusterClient tracker topology workerConnector populateParent action =
+  withClusterFillClient acquire action
+  where
+    acquire = do
+      pool <- CP.createPool testPoolConfig
+      when populateParent $
+        CP.withConnectionBounded pool testAddress
+          (trackedConnector tracker ParentPoolTransport False
+            SendNormally ReceiveNormally)
+          (\_ -> pure ())
+      topologyVar <- newTVarIO topology
+      refreshLock <- newMVar ()
+      muxPool <- createMultiplexPool workerConnector 1
+      pure ClusterClient
+        { clusterTopology = topologyVar
+        , clusterConnectionPool = pool
+        , clusterConfig = testClusterConfig
+        , clusterConnector = workerConnector
+        , clusterRefreshLock = refreshLock
+        , clusterMultiplexPool = muxPool
+        }
+
+populatedTopology :: IO ClusterTopology
+populatedTopology = do
+  currentTime <- getCurrentTime
+  pure ClusterTopology
+    { topologySlots = V.replicate 16384 testNodeId
+    , topologyAddresses = V.replicate 16384 testAddress
+    , topologyNodes = Map.singleton testNodeId testNode
+    , topologyUpdateTime = currentTime
+    }
+
+emptyTopology :: IO ClusterTopology
+emptyTopology = do
+  currentTime <- getCurrentTime
+  pure ClusterTopology
+    { topologySlots = V.empty
+    , topologyAddresses = V.empty
+    , topologyNodes = Map.empty
+    , topologyUpdateTime = currentTime
+    }
+
+testPoolConfig :: PoolConfig
+testPoolConfig = PoolConfig
+  { maxConnectionsPerNode = 4
+  , connectionTimeout = 1
+  , maxRetries = 1
+  , useTLS = False
+  }
+
+testClusterConfig :: ClusterConfig
+testClusterConfig = ClusterConfig
+  { clusterSeedNode = testAddress
+  , clusterPoolConfig = testPoolConfig
+  , clusterMaxRetries = 1
+  , clusterRetryDelay = 1
+  , clusterTopologyRefreshInterval = 600
+  }
+
+testNodeId :: BS.ByteString
+testNodeId = "node-1"
+
+testNode :: ClusterNode
+testNode = ClusterNode
+  { nodeId = testNodeId
+  , nodeAddress = testAddress
+  , nodeRole = Master
+  , nodeSlotsServed = [SlotRange 0 16383 testNodeId []]
+  , nodeReplicas = []
+  }
+
+testSlotRanges :: Map.Map BS.ByteString [Word16]
+testSlotRanges = Map.singleton testNodeId [0]
 
 testAddress :: NodeAddress
 testAddress = NodeAddress "tracked.cluster.test" 6379

--- a/test/StructuredConcurrencySpec.hs
+++ b/test/StructuredConcurrencySpec.hs
@@ -1,15 +1,24 @@
+{-# LANGUAGE DataKinds      #-}
+{-# LANGUAGE KindSignatures #-}
+
 module Main where
 
+import           ClusterFiller            (withClusterFillConnection)
 import           Control.Concurrent.Async (async, cancel, waitCatch)
 import           Control.Concurrent.MVar  (MVar, newEmptyMVar, putMVar,
                                            takeMVar)
 import           Control.Exception        (SomeException, bracket, finally,
-                                           mask, throwIO)
+                                           mask, throwIO, try)
+import           Control.Monad.IO.Class   (liftIO)
+import qualified Data.ByteString.Lazy     as LBS
 import           Data.IORef               (IORef, atomicModifyIORef', newIORef,
-                                           readIORef)
+                                           readIORef, writeIORef)
+import           Database.Redis.Client    (Client (..), ConnectionStatus (..))
+import           Database.Redis.Cluster   (NodeAddress (..))
 import           StructuredConcurrency    (runConcurrentlyFailFast)
-import           Test.Hspec               (describe, hspec, it, shouldReturn,
-                                           shouldSatisfy)
+import           Test.Hspec               (anyException, describe, hspec, it,
+                                           shouldReturn, shouldSatisfy,
+                                           shouldThrow)
 
 main :: IO ()
 main = hspec $ do
@@ -93,6 +102,59 @@ main = hspec $ do
       result `shouldSatisfy` isFailure
       readIORef closed `shouldReturn` 3
 
+  describe "cluster fill connection ownership" $ do
+    it "closes a direct connection exactly once after normal use" $ do
+      tracker <- newTracker
+      withClusterFillConnection (trackedConnector tracker) testAddress $ \conn ->
+        send conn LBS.empty
+      assertClosedExactlyOnce tracker
+
+    it "closes a direct connection when its job fails" $ do
+      tracker <- newTracker
+      result <- try $ withClusterFillConnection (trackedConnector tracker) testAddress $ \conn -> do
+        send conn LBS.empty
+        throwIO $ userError "cluster fill send failed"
+      result `shouldSatisfy` isFailure
+      assertClosedExactlyOnce tracker
+
+    it "cancels a worker blocked awaiting a send response and closes its connection" $ do
+      tracker <- newTracker
+      responseWaitStarted <- newEmptyMVar
+      responseGate <- newEmptyMVar
+      failureGate <- newEmptyMVar
+      parent <- async $ runConcurrentlyFailFast
+        [ withClusterFillConnection (trackedConnector tracker) testAddress $ \conn -> do
+            send conn LBS.empty
+            putMVar responseWaitStarted ()
+            takeMVar responseGate
+        , takeMVar failureGate >> throwIO (userError "sibling send failed")
+        ]
+      takeMVar responseWaitStarted
+      putMVar failureGate ()
+      result <- waitCatch parent
+      result `shouldSatisfy` isFailure
+      assertClosedExactlyOnce tracker
+
+    it "closes a blocked child worker connection when its parent is cancelled" $ do
+      tracker <- newTracker
+      started <- newEmptyMVar
+      waitGate <- newEmptyMVar
+      parent <- async $ withClusterFillConnection (trackedConnector tracker) testAddress $ \conn -> do
+        send conn LBS.empty
+        putMVar started ()
+        takeMVar waitGate
+      takeMVar started
+      cancel parent
+      result <- waitCatch parent
+      result `shouldSatisfy` isFailure
+      assertClosedExactlyOnce tracker
+
+    it "rejects use of a connection after its job scope closes" $ do
+      tracker <- newTracker
+      withClusterFillConnection (trackedConnector tracker) testAddress $ \conn ->
+        send conn LBS.empty
+      send (TrackingClient tracker) LBS.empty `shouldThrow` anyException
+
 assertFailFast :: (MVar () -> MVar () -> IO ()) -> IO ()
 assertFailFast failingWorker = do
   failureGate <- newEmptyMVar
@@ -126,3 +188,46 @@ record ref = atomicModifyIORef' ref (\count -> (count + 1, ()))
 isFailure :: Either SomeException () -> Bool
 isFailure (Left _)   = True
 isFailure (Right ()) = False
+
+data Tracker = Tracker
+  { trackerOpen   :: IORef Bool
+  , trackerClosed :: IORef Int
+  }
+
+data TrackingClient (status :: ConnectionStatus) = TrackingClient Tracker
+
+instance Client TrackingClient where
+  connect (TrackingClient tracker) = liftIO (assertOpen tracker) >> pure (TrackingClient tracker)
+  close (TrackingClient tracker) = liftIO $ do
+    isOpen <- readIORef (trackerOpen tracker)
+    if isOpen
+      then do
+        writeIORef (trackerOpen tracker) False
+        record (trackerClosed tracker)
+      else throwIO $ userError "connection closed more than once"
+  abort = close
+  send (TrackingClient tracker) _ = liftIO $ assertOpen tracker
+  receive (TrackingClient tracker) = liftIO (assertOpen tracker) >> pure mempty
+
+newTracker :: IO Tracker
+newTracker = Tracker <$> newIORef True <*> newCounter
+
+trackedConnector :: Tracker -> NodeAddress -> IO (TrackingClient 'Connected)
+trackedConnector tracker _ = do
+  writeIORef (trackerOpen tracker) True
+  pure $ TrackingClient tracker
+
+assertClosedExactlyOnce :: Tracker -> IO ()
+assertClosedExactlyOnce tracker = do
+  readIORef (trackerClosed tracker) `shouldReturn` 1
+  readIORef (trackerOpen tracker) `shouldReturn` False
+
+assertOpen :: Tracker -> IO ()
+assertOpen tracker = do
+  isOpen <- readIORef (trackerOpen tracker)
+  if isOpen
+    then pure ()
+    else throwIO $ userError "use after close"
+
+testAddress :: NodeAddress
+testAddress = NodeAddress "tracked.cluster.test" 6379

--- a/test/StructuredConcurrencySpec.hs
+++ b/test/StructuredConcurrencySpec.hs
@@ -3,229 +3,232 @@
 
 module Main where
 
-import           ClusterFiller            (withClusterFillConnection)
-import           Control.Concurrent.Async (async, cancel, waitCatch)
-import           Control.Concurrent.MVar  (MVar, newEmptyMVar, putMVar,
-                                           takeMVar)
-import           Control.Exception        (SomeException, bracket, finally,
-                                           mask, throwIO, try)
+import           ClusterFiller            (fillNodeWithDataWithTimeout,
+                                           withClusterFillConnection)
+import           Control.Concurrent.Async (Async, async, waitCatch)
+import           Control.Concurrent.STM   (TMVar, atomically, newEmptyTMVarIO,
+                                           putTMVar, readTMVar, retry)
+import           Control.Exception        (SomeException, bracket,
+                                           fromException, throwIO, try)
 import           Control.Monad.IO.Class   (liftIO)
 import qualified Data.ByteString.Lazy     as LBS
 import           Data.IORef               (IORef, atomicModifyIORef', newIORef,
                                            readIORef, writeIORef)
+import           Data.List                (isInfixOf)
+import qualified Data.Map.Strict          as Map
+import qualified Data.Set                 as Set
 import           Database.Redis.Client    (Client (..), ConnectionStatus (..))
 import           Database.Redis.Cluster   (NodeAddress (..))
-import           StructuredConcurrency    (runConcurrentlyFailFast)
-import           Test.Hspec               (anyException, describe, hspec, it,
-                                           shouldReturn, shouldSatisfy,
-                                           shouldThrow)
+import           ProcessLifecycle         (ChildProcessFailure (..),
+                                           waitForChildProcesses)
+import           StructuredConcurrency    (ConcurrentFailure (..),
+                                           runConcurrentlyFailFast)
+import           System.Exit              (ExitCode (ExitFailure))
+import           System.Process           (createProcess, proc)
+import           System.Timeout           (timeout)
+import           Test.Hspec
+
+phaseTimeout :: Int
+phaseTimeout = 1000000
 
 main :: IO ()
 main = hspec $ do
-  describe "standalone fill workers" $ do
-    it "propagates a failure before connecting after joining a started sibling" $
-      assertFailFast $ \release _ ->
-        takeMVar release >> throwIO (userError "connect failed")
-
-    it "propagates a failure during an actual send after joining a started sibling" $ do
-      sends <- newCounter
-      assertFailFast $ \release _ -> do
-        takeMVar release
-        record sends
-        throwIO (userError "send failed")
-      readIORef sends `shouldReturn` 1
-
-    it "propagates a failure while awaiting a response after joining a started sibling" $ do
-      sends <- newCounter
-      sent <- newEmptyMVar
-      response <- newEmptyMVar
-      siblingGate <- newEmptyMVar
-      siblingStarted <- newEmptyMVar
-      siblingCancelled <- newEmptyMVar
+  describe "structured worker ownership" $ do
+    it "propagates a body failure after cancelling and joining a blocked sibling" $ do
+      ready <- newPhase
+      release <- newPhase
       parent <- async $ runConcurrentlyFailFast
-        [ record sends >> putMVar sent () >> takeMVar response
-            >> throwIO (userError "response wait failed")
-        , putMVar siblingStarted () >> takeMVar siblingGate
-            `finally` putMVar siblingCancelled ()
+        [ awaitPhase release >> throwIO (userError "connect failure")
+        , blockingWorker ready
         ]
-      takeMVar siblingStarted
-      takeMVar sent
-      putMVar response ()
-      result <- waitCatch parent
+      awaitPhase ready
+      signalPhase release
+      result <- awaitResult parent
       result `shouldSatisfy` isFailure
-      readIORef sends `shouldReturn` 1
-      takeMVar siblingCancelled
 
-  describe "benchmark workers" $ do
-    it "fails fast when an actual async submission send fails" $ do
-      sends <- newCounter
-      assertFailFast $ \release _ -> do
-        takeMVar release
-        record sends
-        throwIO (userError "benchmark submit send failed")
-      readIORef sends `shouldReturn` 1
-
-    it "cancels a worker blocked awaiting a submitted response" $ do
-      responseWaiterStarted <- newEmptyMVar
-      failureGate <- newEmptyMVar
-      responseGate <- newEmptyMVar
-      responseWaiterReleased <- newEmptyMVar
+    it "preserves a body failure and reports a sibling close failure" $ do
+      ready <- newPhase
+      release <- newPhase
       parent <- async $ runConcurrentlyFailFast
-        [ putMVar responseWaiterStarted () >> takeMVar responseGate
-            `finally` putMVar responseWaiterReleased ()
-        , takeMVar failureGate >> throwIO (userError "benchmark send failed")
+        [ awaitPhase release >> throwIO (userError "send failure")
+        , bracket (pure ()) (\() -> throwIO (userError "sibling close failure")) $ \() ->
+            blockingWorker ready
         ]
-      takeMVar responseWaiterStarted
-      putMVar failureGate ()
-      result <- waitCatch parent
-      result `shouldSatisfy` isFailure
-      takeMVar responseWaiterReleased
+      awaitPhase ready
+      signalPhase release
+      result <- awaitResult parent
+      assertConcurrentFailure "send failure" 1 result
 
-  describe "cancellation ownership" $ do
-    it "cancels and joins siblings while bracketing connection, pool, and client cleanup" $ do
-      started <- newEmptyMVar
-      siblingStarted <- newEmptyMVar
-      waitForCancel <- newEmptyMVar
-      closed <- newCounter
+    it "reports every simultaneous sibling cleanup failure" $ do
+      readyOne <- newPhase
+      readyTwo <- newPhase
+      release <- newPhase
       parent <- async $ runConcurrentlyFailFast
-        [ bracket (pure ()) (\() -> record closed) $ \() ->
-            bracket (pure ()) (\() -> record closed) $ \() ->
-              bracket (pure ()) (\() -> record closed) $ \() -> do
-                putMVar started ()
-                takeMVar waitForCancel
-        , putMVar siblingStarted () >> takeMVar waitForCancel
+        [ awaitPhase release >> throwIO (userError "primary body failure")
+        , failingCleanupWorker readyOne "close one"
+        , failingCleanupWorker readyTwo "close two"
         ]
-      takeMVar started
-      takeMVar siblingStarted
-      cancel parent
-      result <- waitCatch parent
-      result `shouldSatisfy` isFailure
-      readIORef closed `shouldReturn` 3
+      awaitPhase readyOne
+      awaitPhase readyTwo
+      signalPhase release
+      result <- awaitResult parent
+      assertConcurrentFailure "primary body failure" 2 result
 
-  describe "cluster fill connection ownership" $ do
-    it "closes a direct connection exactly once after normal use" $ do
-      tracker <- newTracker
+  describe "cluster fill worker connection ownership" $ do
+    it "closes each acquired direct transport exactly once after success" $ do
+      tracker <- newTracker False False
       withClusterFillConnection (trackedConnector tracker) testAddress $ \conn ->
         send conn LBS.empty
-      assertClosedExactlyOnce tracker
+      assertAllConnectionsClosedOnce tracker 1
 
-    it "closes a direct connection when its job fails" $ do
-      tracker <- newTracker
-      result <- try $ withClusterFillConnection (trackedConnector tracker) testAddress $ \conn -> do
+    it "does not close when direct transport acquisition fails" $ do
+      tracker <- newTracker False False
+      result <- try (withClusterFillConnection (failingConnector tracker) testAddress (\_ -> pure ())) :: IO (Either SomeException ())
+      result `shouldSatisfy` isFailure
+      assertAllConnectionsClosedOnce tracker 0
+
+    it "closes a worker transport after a send/body failure" $ do
+      tracker <- newTracker False False
+      result <- try (withClusterFillConnection (trackedConnector tracker) testAddress $ \conn -> do
         send conn LBS.empty
-        throwIO $ userError "cluster fill send failed"
+        throwIO (userError "send failure")) :: IO (Either SomeException ())
       result `shouldSatisfy` isFailure
-      assertClosedExactlyOnce tracker
+      assertAllConnectionsClosedOnce tracker 1
 
-    it "cancels a worker blocked awaiting a send response and closes its connection" $ do
-      tracker <- newTracker
-      responseWaitStarted <- newEmptyMVar
-      responseGate <- newEmptyMVar
-      failureGate <- newEmptyMVar
-      parent <- async $ runConcurrentlyFailFast
-        [ withClusterFillConnection (trackedConnector tracker) testAddress $ \conn -> do
-            send conn LBS.empty
-            putMVar responseWaitStarted ()
-            takeMVar responseGate
-        , takeMVar failureGate >> throwIO (userError "sibling send failed")
-        ]
-      takeMVar responseWaitStarted
-      putMVar failureGate ()
-      result <- waitCatch parent
-      result `shouldSatisfy` isFailure
-      assertClosedExactlyOnce tracker
+    it "surfaces close failure over a same-resource body failure after closing it" $ do
+      tracker <- newTracker True False
+      result <- try (withClusterFillConnection (trackedConnector tracker) testAddress $ \_ ->
+        throwIO (userError "body failure")) :: IO (Either SomeException ())
+      show result `shouldSatisfy` isInfixOf "close failure"
+      assertAllConnectionsClosedOnce tracker 1
 
-    it "closes a blocked child worker connection when its parent is cancelled" $ do
-      tracker <- newTracker
-      started <- newEmptyMVar
-      waitGate <- newEmptyMVar
-      parent <- async $ withClusterFillConnection (trackedConnector tracker) testAddress $ \conn -> do
-        send conn LBS.empty
-        putMVar started ()
-        takeMVar waitGate
-      takeMVar started
-      cancel parent
-      result <- waitCatch parent
-      result `shouldSatisfy` isFailure
-      assertClosedExactlyOnce tracker
+    it "times out through the production fill worker and closes the transport" $ do
+      tracker <- newTracker False True
+      result <- try (withClusterFillConnection (trackedConnector tracker) testAddress $ \conn ->
+        fillNodeWithDataWithTimeout 1 conn [0] 1 1 0 8 8 1) :: IO (Either SomeException ())
+      show result `shouldSatisfy` isInfixOf "timed out"
+      assertAllConnectionsClosedOnce tracker 1
 
-    it "rejects use of a connection after its job scope closes" $ do
-      tracker <- newTracker
+    it "rejects a production-scoped transport after it has closed" $ do
+      tracker <- newTracker False False
+      escaped <- newIORef Nothing
       withClusterFillConnection (trackedConnector tracker) testAddress $ \conn ->
-        send conn LBS.empty
-      send (TrackingClient tracker) LBS.empty `shouldThrow` anyException
+        writeIORef escaped (Just conn)
+      Just conn <- readIORef escaped
+      send conn LBS.empty `shouldThrow` anyException
+      assertAllConnectionsClosedOnce tracker 1
 
-assertFailFast :: (MVar () -> MVar () -> IO ()) -> IO ()
-assertFailFast failingWorker = do
-  failureGate <- newEmptyMVar
-  siblingGate <- newEmptyMVar
-  siblingStarted <- newEmptyMVar
-  siblingCancelled <- newEmptyMVar
-  parent <- async $ runConcurrentlyFailFast
-    [ failingWorker failureGate siblingStarted
-    , blockUntilCancelled siblingStarted siblingGate
-        `finally` putMVar siblingCancelled ()
-    ]
-  takeMVar siblingStarted
-  putMVar failureGate ()
-  result <- waitCatch parent
-  result `shouldSatisfy` isFailure
-  takeMVar siblingCancelled
+  describe "multiprocess fill ownership" $
+    it "waits for every real child then propagates its non-zero exit status" $ do
+      (_, _, _, successfulChild) <- createProcess (proc "/bin/sh" ["-c", "exit 0"])
+      (_, _, _, failingChild) <- createProcess (proc "/bin/sh" ["-c", "exit 7"])
+      result <- try (waitForChildProcesses [successfulChild, failingChild]) :: IO (Either SomeException ())
+      case result of
+        Left exception ->
+          case fromException exception :: Maybe ChildProcessFailure of
+            Nothing -> expectationFailure $ "unexpected result: " ++ show exception
+            Just (ChildProcessFailure index exitCode) -> do
+              index `shouldBe` 1
+              exitCode `shouldBe` ExitFailure 7
+        Right () -> expectationFailure "expected a non-zero child exit to fail the parent"
 
--- | Publishing readiness while masked guarantees that cancellation is queued
--- until this worker enters the restored, cancellable blocking operation.
-blockUntilCancelled :: MVar () -> MVar () -> IO ()
-blockUntilCancelled ready gate = mask $ \restore -> do
-  putMVar ready ()
-  restore (takeMVar gate)
+newPhase :: IO (TMVar ())
+newPhase = newEmptyTMVarIO
 
-newCounter :: IO (IORef Int)
-newCounter = newIORef 0
+signalPhase :: TMVar () -> IO ()
+signalPhase phase = atomically $ putTMVar phase ()
 
-record :: IORef Int -> IO ()
-record ref = atomicModifyIORef' ref (\count -> (count + 1, ()))
+awaitPhase :: TMVar () -> IO ()
+awaitPhase phase = do
+  result <- timeout phaseTimeout (atomically $ readTMVar phase)
+  result `shouldBe` Just ()
+
+awaitResult :: Async () -> IO (Either SomeException ())
+awaitResult worker = do
+  result <- timeout phaseTimeout (waitCatch worker)
+  case result of
+    Nothing -> expectationFailure "worker did not finish within the diagnostic phase bound" >> error "unreachable"
+    Just outcome -> pure outcome
+
+failingCleanupWorker :: TMVar () -> String -> IO ()
+failingCleanupWorker ready message =
+  bracket (pure ()) (\() -> throwIO (userError message)) $ \() -> do
+    blockingWorker ready
+
+blockingWorker :: TMVar () -> IO ()
+blockingWorker ready = do
+  never <- newPhase
+  signalPhase ready
+  awaitPhase never
+
+assertConcurrentFailure :: String -> Int -> Either SomeException () -> Expectation
+assertConcurrentFailure primary expectedCleanup result =
+  case result of
+    Left exception ->
+      case fromException exception :: Maybe ConcurrentFailure of
+        Nothing -> expectationFailure $ "expected ConcurrentFailure, got: " ++ show exception
+        Just failure -> do
+          show (concurrentPrimaryFailure failure) `shouldSatisfy` isInfixOf primary
+          length (concurrentSiblingCleanupFailures failure) `shouldBe` expectedCleanup
+    Right () -> expectationFailure "expected worker failure"
 
 isFailure :: Either SomeException () -> Bool
-isFailure (Left _)   = True
-isFailure (Right ()) = False
+isFailure (Left _)  = True
+isFailure (Right _) = False
 
 data Tracker = Tracker
-  { trackerOpen   :: IORef Bool
-  , trackerClosed :: IORef Int
+  { trackerNextId        :: IORef Int
+  , trackerLive          :: IORef (Set.Set Int)
+  , trackerCloseCounts   :: IORef (Map.Map Int Int)
+  , trackerCloseFails    :: Bool
+  , trackerBlocksReceive :: Bool
   }
 
-data TrackingClient (status :: ConnectionStatus) = TrackingClient Tracker
+data TrackingClient (status :: ConnectionStatus) = TrackingClient Tracker Int
 
 instance Client TrackingClient where
-  connect (TrackingClient tracker) = liftIO (assertOpen tracker) >> pure (TrackingClient tracker)
-  close (TrackingClient tracker) = liftIO $ do
-    isOpen <- readIORef (trackerOpen tracker)
-    if isOpen
-      then do
-        writeIORef (trackerOpen tracker) False
-        record (trackerClosed tracker)
-      else throwIO $ userError "connection closed more than once"
+  connect (TrackingClient tracker connectionId) =
+    liftIO (assertOpen tracker connectionId) >> pure (TrackingClient tracker connectionId)
+  close (TrackingClient tracker connectionId) = liftIO $ do
+    assertOpen tracker connectionId
+    atomicModifyIORef' (trackerLive tracker) (\live -> (Set.delete connectionId live, ()))
+    atomicModifyIORef' (trackerCloseCounts tracker)
+      (\counts -> (Map.insertWith (+) connectionId 1 counts, ()))
+    if trackerCloseFails tracker
+      then throwIO (userError "close failure")
+      else pure ()
   abort = close
-  send (TrackingClient tracker) _ = liftIO $ assertOpen tracker
-  receive (TrackingClient tracker) = liftIO (assertOpen tracker) >> pure mempty
+  send (TrackingClient tracker connectionId) _ = liftIO $ assertOpen tracker connectionId
+  receive (TrackingClient tracker connectionId) = liftIO $ do
+    assertOpen tracker connectionId
+    if trackerBlocksReceive tracker then atomically retry else pure mempty
 
-newTracker :: IO Tracker
-newTracker = Tracker <$> newIORef True <*> newCounter
+newTracker :: Bool -> Bool -> IO Tracker
+newTracker closeFails blocksReceive =
+  Tracker <$> newIORef 0 <*> newIORef Set.empty <*> newIORef Map.empty
+    <*> pure closeFails <*> pure blocksReceive
 
 trackedConnector :: Tracker -> NodeAddress -> IO (TrackingClient 'Connected)
 trackedConnector tracker _ = do
-  writeIORef (trackerOpen tracker) True
-  pure $ TrackingClient tracker
+  connectionId <- atomicModifyIORef' (trackerNextId tracker) (\n -> (n + 1, n))
+  atomicModifyIORef' (trackerLive tracker) (\live -> (Set.insert connectionId live, ()))
+  pure $ TrackingClient tracker connectionId
 
-assertClosedExactlyOnce :: Tracker -> IO ()
-assertClosedExactlyOnce tracker = do
-  readIORef (trackerClosed tracker) `shouldReturn` 1
-  readIORef (trackerOpen tracker) `shouldReturn` False
+failingConnector :: Tracker -> NodeAddress -> IO (TrackingClient 'Connected)
+failingConnector _ _ = throwIO $ userError "acquire failure"
 
-assertOpen :: Tracker -> IO ()
-assertOpen tracker = do
-  isOpen <- readIORef (trackerOpen tracker)
-  if isOpen
+assertAllConnectionsClosedOnce :: Tracker -> Int -> IO ()
+assertAllConnectionsClosedOnce tracker expected = do
+  live <- readIORef (trackerLive tracker)
+  counts <- readIORef (trackerCloseCounts tracker)
+  Set.null live `shouldBe` True
+  Map.size counts `shouldBe` expected
+  mapM_ (`shouldBe` 1) (Map.elems counts)
+
+assertOpen :: Tracker -> Int -> IO ()
+assertOpen tracker connectionId = do
+  live <- readIORef (trackerLive tracker)
+  if Set.member connectionId live
     then pure ()
     else throwIO $ userError "use after close"
 


### PR DESCRIPTION
Closes #66

## Summary
- scope each direct cluster fill transport to its job and run jobs in the existing fail-fast cancellation scope
- bracket the parent ClusterClient so pools close on worker failure or cancellation
- make timeout/topology mismatches fail rather than reporting successful completion
- add deterministic tracked-client lifecycle coverage for normal, exception, sibling-cancellation, parent-cancellation, and use-after-close paths

## Validation
- `nix-build --no-out-link`
- `cabal check`
- `cabal test StructuredConcurrencySpec` (default, `+RTS -N1`, `+RTS -N2`)
- `make test`

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.