### PR TITLE
Integrate validated smart-proxy routing

### DIFF
--- a/.squad/decisions/inbox/protocol-smart-proxy-raw-routing.md
+++ b/.squad/decisions/inbox/protocol-smart-proxy-raw-routing.md
@@ -1,0 +1,4 @@
+### 2026-09-05T09:05:48-07:00: Smart proxy routes validated frames through the raw executor
+**By:** Protocol
+**What:** The smart proxy validates bulk-string command frames with the metadata grammar, then passes the original `RespData` and either its extracted routing key or keyless route to `RawCommand`. The `cluster` sublibrary is public solely so the executable can consume this existing internal protocol-adapter API; root and client facades remain unchanged.
+**Why:** Reconstructing command arguments would alter frames and bypass the raw executor's proven retry/redirect semantics. The grammar rejects malformed, dynamic, unknown, and cross-slot inputs before the raw executor can acquire a connection.

--- a/app/ClusterTunnel.hs
+++ b/app/ClusterTunnel.hs
@@ -5,52 +5,61 @@
 module ClusterTunnel
   ( serveSmartProxy
   , servePinnedProxy
+  , routeSmartProxyCommandWith
   , rewriteClusterResponse
   ) where
 
-import           Control.Concurrent              (MVar, forkIO, newEmptyMVar,
-                                                  putMVar, takeMVar)
-import           Control.Concurrent.STM          (readTVarIO)
-import           Control.Exception               (SomeException, bracket,
-                                                  finally, throwIO, try)
-import           Control.Monad                   (forever, void, when)
-import qualified Control.Monad.State.Strict      as State
-import qualified Data.ByteString                 as BS
-import qualified Data.ByteString.Builder         as Builder
-import qualified Data.ByteString.Char8           as BS8
-import qualified Data.ByteString.Lazy            as LBS
-import           Data.Char                       (isAlphaNum)
-import           Data.List                       (isPrefixOf)
-import qualified Data.Map.Strict                 as Map
-import           Data.Word                       (Word8)
-import           Database.Redis.Client           (Client (..),
-                                                  ConnectionStatus (..))
-import           Database.Redis.Cluster          (ClusterNode (..),
-                                                  ClusterTopology (..),
-                                                  NodeAddress (..),
-                                                  NodeRole (..))
-import           Database.Redis.Cluster.Client   (ClusterClient (..),
-                                                  ClusterError (..))
-import qualified Database.Redis.Cluster.Client   as ClusterCommandClient
-import           Database.Redis.Cluster.Commands (CommandRouting (..),
-                                                  classifyCommand)
-import           Database.Redis.Command          (ClientState (..),
-                                                  RedisCommandClient, parseWith)
-import           Database.Redis.Connector        (Connector)
-import           Database.Redis.Resp             (Encodable (encode),
-                                                  RespData (..))
-import qualified Database.Redis.Resp             as Resp
-import           Network.Socket                  (Family (..), SockAddr (..),
-                                                  Socket, SocketOption (..),
-                                                  SocketType (..), bind,
-                                                  defaultProtocol, listen,
-                                                  setSocketOption, socket,
-                                                  tupleToHostAddress)
-import qualified Network.Socket                  as S
-import           Network.Socket.ByteString       (recv, sendAll)
-import           System.IO                       (BufferMode (LineBuffering),
-                                                  hFlush, hSetBuffering, stdout)
-import           Text.Printf                     (printf)
+import           Control.Concurrent                         (MVar, forkIO,
+                                                             newEmptyMVar,
+                                                             putMVar, takeMVar)
+import           Control.Concurrent.STM                     (readTVarIO)
+import           Control.Exception                          (SomeException,
+                                                             bracket, finally,
+                                                             throwIO, try)
+import           Control.Monad                              (forever, void,
+                                                             when)
+import qualified Data.ByteString                            as BS
+import qualified Data.ByteString.Builder                    as Builder
+import qualified Data.ByteString.Char8                      as BS8
+import qualified Data.ByteString.Lazy                       as LBS
+import           Data.Char                                  (isAlphaNum)
+import           Data.List                                  (isPrefixOf)
+import qualified Data.Map.Strict                            as Map
+import           Data.Word                                  (Word8)
+import           Database.Redis.Client                      (Client (..),
+                                                             ConnectionStatus (..))
+import           Database.Redis.Cluster                     (ClusterNode (..),
+                                                             ClusterTopology (..),
+                                                             NodeAddress (..),
+                                                             NodeRole (..))
+import           Database.Redis.Cluster.Client              (ClusterClient (..),
+                                                             ClusterError (..))
+import           Database.Redis.Cluster.Commands            (CommandRouting (..),
+                                                             classifyCommand)
+import           Database.Redis.Cluster.Internal.RawCommand (RawClusterRoute (..),
+                                                             executeRawClusterCommand)
+import           Database.Redis.Connector                   (Connector)
+import           Database.Redis.Resp                        (Encodable (encode),
+                                                             RespData (..))
+import qualified Database.Redis.Resp                        as Resp
+import           Network.Socket                             (Family (..),
+                                                             SockAddr (..),
+                                                             Socket,
+                                                             SocketOption (..),
+                                                             SocketType (..),
+                                                             bind,
+                                                             defaultProtocol,
+                                                             listen,
+                                                             setSocketOption,
+                                                             socket,
+                                                             tupleToHostAddress)
+import qualified Network.Socket                             as S
+import           Network.Socket.ByteString                  (recv, sendAll)
+import           System.IO                                  (BufferMode (LineBuffering),
+                                                             hFlush,
+                                                             hSetBuffering,
+                                                             stdout)
+import           Text.Printf                                (printf)
 
 -- | Smart proxy mode: Makes cluster appear as single Redis instance
 -- Creates single listening socket and routes commands to appropriate nodes
@@ -119,52 +128,61 @@ routeSmartProxyCommand :: (Client client) =>
   ClusterClient client ->
   RespData ->
   IO (Either String RespData)
-routeSmartProxyCommand clusterClient respData = do
-  case respData of
-    RespArray (RespBulkString cmd : args) -> do
-      let argKeys = [k | RespBulkString k <- args]
-      case classifyCommand cmd argKeys of
-        KeylessRoute   -> executeKeylessCommand clusterClient respData
-        KeyedRoute key -> executeKeyedCommand clusterClient key (cmd : argKeys)
-        CommandError e -> return $ Left e
-    _ -> return $ Left "Expected array command"
+routeSmartProxyCommand clusterClient =
+  routeSmartProxyCommandWith (executeRawClusterCommand clusterClient)
 
--- | Execute a keyless command (route to any master)
-executeKeylessCommand :: (Client client) =>
-  ClusterClient client ->
+-- | Route a parsed client frame after validating it with the generated command
+-- grammar.  The dispatch seam keeps grammar failures before any cluster I/O.
+routeSmartProxyCommandWith ::
+  SmartProxyDispatch ->
   RespData ->
   IO (Either String RespData)
-executeKeylessCommand clusterClient respData = do
-  result <- ClusterCommandClient.executeKeylessClusterCommand
-              clusterClient
-              (sendRespCommand respData)
+routeSmartProxyCommandWith dispatch respData =
+  case classifySmartProxyFrame respData of
+    Left errorMessage         -> pure $ Left errorMessage
+    Right RawRouteKeyless     -> executeKeylessCommand dispatch respData
+    Right (RawRouteByKey key) -> executeKeyedCommand dispatch key respData
+
+type SmartProxyDispatch =
+  RawClusterRoute ->
+  RespData ->
+  IO (Either ClusterError RespData)
+
+classifySmartProxyFrame :: RespData -> Either String RawClusterRoute
+classifySmartProxyFrame (RespArray (RespBulkString command : arguments)) = do
+  commandArguments <- traverse bulkString arguments
+  case classifyCommand command commandArguments of
+    KeylessRoute              -> Right RawRouteKeyless
+    KeyedRoute key            -> Right $ RawRouteByKey key
+    CommandError errorMessage -> Left errorMessage
+  where
+    bulkString (RespBulkString argument) = Right argument
+    bulkString _ = Left "Expected array command with bulk string arguments"
+classifySmartProxyFrame _ = Left "Expected array command with bulk string arguments"
+
+-- | Execute a keyless command (route to any master)
+executeKeylessCommand ::
+  SmartProxyDispatch ->
+  RespData ->
+  IO (Either String RespData)
+executeKeylessCommand dispatch respData = do
+  result <- dispatch RawRouteKeyless respData
   return $ case result of
     Left err   -> Left (show err)
     Right resp -> Right resp
 
 -- | Execute a keyed command (route by slot via multiplexer)
-executeKeyedCommand :: (Client client) =>
-  ClusterClient client ->
+executeKeyedCommand ::
+  SmartProxyDispatch ->
   BS.ByteString ->
-  [BS.ByteString] ->
+  RespData ->
   IO (Either String RespData)
-executeKeyedCommand clusterClient key cmdArgs = do
-  result <- ClusterCommandClient.executeKeyedClusterCommand
-              clusterClient
-              key
-              cmdArgs
+executeKeyedCommand dispatch key respData = do
+  result <- dispatch (RawRouteByKey key) respData
   return $ case result of
     Left (CrossSlotError msg) -> Left $ "CROSSSLOT error: " ++ msg
     Left err                  -> Left (show err)
     Right resp                -> Right resp
-
--- | Send RESP command via RedisCommandClient
-sendRespCommand :: (Client client) => RespData -> RedisCommandClient client RespData
-sendRespCommand respData = do
-  ClientState client _ <- State.get
-  let encoded = Builder.toLazyByteString $ encode respData
-  send client encoded
-  parseWith (receive client)
 
 -- | Pinned proxy mode: One listener per cluster node
 -- Each listener forwards to its corresponding cluster node

--- a/hask-redis-mux/hask-redis-mux.cabal
+++ b/hask-redis-mux/hask-redis-mux.cabal
@@ -115,6 +115,7 @@ library redis-command-client
 
 library cluster
     import:           defaults
+    visibility:       public
     hs-source-dirs:   lib/cluster
     exposed-modules:  Database.Redis.Cluster
                     , Database.Redis.Cluster.Client

--- a/redis-client.cabal
+++ b/redis-client.cabal
@@ -87,6 +87,7 @@ test-suite ClusterTunnelSpec
     build-depends:    bytestring
                     , containers
                     , hask-redis-mux
+                    , hask-redis-mux:cluster
                     , mtl
                     , network
                     , stm
@@ -254,6 +255,7 @@ executable redis-client
                     , bytestring
                     , containers
                     , hask-redis-mux
+                    , hask-redis-mux:cluster
                     , mtl
                     , network
                     , process

--- a/test/ClusterTunnelSpec.hs
+++ b/test/ClusterTunnelSpec.hs
@@ -2,11 +2,71 @@
 
 module Main (main) where
 
-import           ClusterTunnel (rewriteClusterResponse)
+import           ClusterTunnel                              (rewriteClusterResponse,
+                                                             routeSmartProxyCommandWith)
+import qualified Data.ByteString                            as BS
+import           Data.IORef                                 (modifyIORef',
+                                                             newIORef,
+                                                             readIORef)
+import           Database.Redis.Cluster.Internal.RawCommand (RawClusterRoute (..))
+import           Database.Redis.Resp
 import           Test.Hspec
 
 main :: IO ()
 main = hspec $ do
+  describe "smart proxy command routing" $ do
+    it "hands the original keyed GET frame to raw dispatch" $ do
+      let frame = commandFrame ["GET", "profile:key"]
+      assertDispatch frame (RawRouteByKey "profile:key")
+
+    it "preserves binary keys, values, command case, and option order" $ do
+      let binaryKey = "\NUL{binary}\255"
+          frame = commandFrame ["sEt", binaryKey, "\255value", "NX", "PX", "10"]
+      assertDispatch frame (RawRouteByKey binaryKey)
+
+    it "routes a keyless command with arguments through raw keyless dispatch" $ do
+      let frame = commandFrame ["PING", "payload"]
+      assertDispatch frame RawRouteKeyless
+
+    it "uses metadata keys for subcommands and key-count commands" $ do
+      assertDispatch
+        (commandFrame ["CLIENT", "NO-EVICT", "ON"])
+        RawRouteKeyless
+      assertDispatch
+        (commandFrame ["EVAL", "return 1", "2", "{slot}:one", "{slot}:two"])
+        (RawRouteByKey "{slot}:one")
+
+    it "uses metadata keys for stream, store, and multi-key commands" $ do
+      assertDispatch
+        (commandFrame ["XREAD", "COUNT", "1", "STREAMS", "{slot}:one", "{slot}:two", "0-0", "0-0"])
+        (RawRouteByKey "{slot}:one")
+      assertDispatch
+        (commandFrame ["XREADGROUP", "GROUP", "group", "consumer", "STREAMS", "{slot}:one", ">"])
+        (RawRouteByKey "{slot}:one")
+      assertDispatch
+        (commandFrame ["ZUNIONSTORE", "{slot}:destination", "2", "{slot}:one", "{slot}:two"])
+        (RawRouteByKey "{slot}:destination")
+      assertDispatch
+        (commandFrame ["MGET", "{slot}:one", "{slot}:two"])
+        (RawRouteByKey "{slot}:one")
+
+    it "does not dispatch cross-slot, malformed, dynamic, unknown, or non-bulk frames" $ do
+      assertNoDispatch
+        (commandFrame ["MGET", "first", "second"])
+        "CROSSSLOT Keys in request don't hash to the same slot"
+      assertNoDispatch
+        (commandFrame ["GET"])
+        "GET has invalid arity: expected 2 argument(s), got 1"
+      assertNoDispatch
+        (commandFrame ["SORT", "key", "BY", "pattern"])
+        "SORT uses an unsupported dynamic key specification"
+      assertNoDispatch
+        (commandFrame ["NOTACOMMAND", "key"])
+        "unknown command"
+      assertNoDispatch
+        (RespArray [RespBulkString "GET", RespInteger 1])
+        "Expected array command with bulk string arguments"
+
   describe "rewriteClusterResponse" $ do
     it "rewrites exactly one complete RESP response" $ do
       rewriteClusterResponse "-MOVED 3999 redis.example:6381\r\n"
@@ -19,3 +79,30 @@ main = hspec $ do
     it "leaves malformed framing unchanged" $ do
       let malformed = "-MOVED 3999 redis.example:6381\rX"
       rewriteClusterResponse malformed `shouldBe` malformed
+
+commandFrame :: [BS.ByteString] -> RespData
+commandFrame = RespArray . fmap RespBulkString
+
+assertDispatch :: RespData -> RawClusterRoute -> Expectation
+assertDispatch frame expectedRoute = do
+  dispatched <- newIORef []
+  result <- routeSmartProxyCommandWith
+    (\route originalFrame -> do
+      modifyIORef' dispatched (<> [(route, originalFrame)])
+      pure $ Right (RespSimpleString "OK"))
+    frame
+  result `shouldBe` Right (RespSimpleString "OK")
+  observed <- readIORef dispatched
+  observed `shouldBe` [(expectedRoute, frame)]
+
+assertNoDispatch :: RespData -> String -> Expectation
+assertNoDispatch frame expectedError = do
+  dispatchCount <- newIORef (0 :: Int)
+  result <- routeSmartProxyCommandWith
+    (\_ _ -> do
+      modifyIORef' dispatchCount (+ 1)
+      pure $ Right (RespSimpleString "unexpected"))
+    frame
+  result `shouldBe` Left expectedError
+  observedDispatches <- readIORef dispatchCount
+  observedDispatches `shouldBe` 0


### PR DESCRIPTION
Closes #131

Working as Protocol (Redis Protocol Engineer).

Routes validated metadata-derived keyless/keyed classifications through the raw RESP executor while preserving the original `RespData` frame. Invalid, dynamic, unknown, non-bulk, and cross-slot frames fail before dispatch.

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

Validation: `cabal check`, `nix-build --no-out-link`, focused ClusterTunnel/grammar/raw/public-API tests, and `make test`.