### PR TITLE
test: await stalled cluster auth abort

### DIFF
--- a/hask-redis-mux/test/ClusterCommandSpec.hs
+++ b/hask-redis-mux/test/ClusterCommandSpec.hs
@@ -1366,6 +1366,8 @@ clusterAuthenticationSpec =
       timeout 1000000 (takeMVar workerFinished) `shouldReturn` Just ()
       records <- getRecords
       let record = findAuthRecord records node1 0
+      timeout 1000000 (awaitIORefValue (authRecordAborts record) 1)
+        `shouldReturn` Just ()
       readIORef (authRecordCloses record) `shouldReturn` 0
       readIORef (authRecordAborts record) `shouldReturn` 1
 


### PR DESCRIPTION
## Summary

- await the existing stalled receive worker completion before boundedly observing its abort count
- retain the existing close `0` / abort `1` assertions
- test-only synchronization; no production behavior or public API change

Closes #146

## Invariant

After the stalled authentication worker finishes, the test waits (bounded by one second) until the same connection's abort count is `1` before asserting cleanup. This observes the existing asynchronous cleanup causally, without new sleeps or post-return polling.

## Evidence

This fixes the first-main-attempt failure after merge `4e9598f...`: run https://github.com/sspeaks/redis-client/actions/runs/33979867517, seed `514715473`, `ClusterCommandSpec.hs:1370`, expected abort `1`, got `0`. It is independent of production behavior and #143.

## Validation

- exact regression: 600/600 (100 repeats × N1/N2/N4 × default/`-C0.001`), 0 failures
- full `ClusterCommandSpec`: 24/24 (seeds `514715473`, `101`, `202`, `404` × same six variants), 0 failures
- `nix-build --no-out-link`
- `make test`
- profiling not applicable: test-only observation change; artifacts removed.