### PR TITLE
test: add smart proxy cluster E2E coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Detect if nix-shell is available
 HAS_NIX := $(shell command -v nix-shell >/dev/null 2>&1 && echo yes || echo no)
 
-.PHONY: help build test test-unit test-metadata test-credentials test-e2e-runner test-tls-fixtures test-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e clean redis-start redis-stop redis-cluster-start redis-cluster-stop profile setup
+.PHONY: help build test test-unit test-metadata test-credentials test-e2e-runner test-cluster-e2e-runner test-tls-fixtures test-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e clean redis-start redis-stop redis-cluster-start redis-cluster-stop profile setup
 
 # Default target
 help:
@@ -46,7 +46,7 @@ endif
 test: test-unit test-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e
 
 # Run unit tests (hask-redis-mux tests run via nix dependency build; FillHelpersSpec from redis-client)
-test-unit: test-metadata test-credentials test-e2e-runner
+test-unit: test-metadata test-credentials test-e2e-runner test-cluster-e2e-runner
 ifeq ($(HAS_NIX),yes)
 	nix-shell --run "cabal build all && cabal test all"
 else
@@ -66,6 +66,9 @@ endif
 
 test-e2e-runner:
 	./scripts/test-run-e2e-tests.sh
+
+test-cluster-e2e-runner:
+	./scripts/test-run-cluster-e2e-tests.sh
 
 # Validate ephemeral TLS credential generation without starting Docker.
 test-tls-fixtures:

--- a/docker/cluster-e2e/docker-compose.yml
+++ b/docker/cluster-e2e/docker-compose.yml
@@ -1,0 +1,179 @@
+services:
+  redis1:
+    image: redis:7.2.12
+    hostname: redis1.local
+    command: &redis-command
+      - redis-server
+      - --save
+      - ""
+      - --appendonly
+      - "no"
+      - --bind
+      - 0.0.0.0
+      - --port
+      - "6379"
+      - --cluster-enabled
+      - "yes"
+      - --cluster-config-file
+      - /data/nodes.conf
+      - --cluster-node-timeout
+      - "5000"
+      - --cluster-announce-port
+      - "6379"
+      - --cluster-announce-bus-port
+      - "16379"
+      - --cluster-announce-ip
+      - redis1.local
+    environment:
+      REDIS_PORT: "6379"
+    healthcheck: &redis-healthcheck
+      test: ["CMD-SHELL", "redis-cli -p \"$${REDIS_PORT}\" ping | grep -qx PONG"]
+      interval: 1s
+      timeout: 1s
+      retries: 30
+      start_period: 2s
+
+  redis2:
+    image: redis:7.2.12
+    hostname: redis2.local
+    command:
+      - redis-server
+      - --save
+      - ""
+      - --appendonly
+      - "no"
+      - --bind
+      - 0.0.0.0
+      - --port
+      - "6380"
+      - --cluster-enabled
+      - "yes"
+      - --cluster-config-file
+      - /data/nodes.conf
+      - --cluster-node-timeout
+      - "5000"
+      - --cluster-announce-port
+      - "6380"
+      - --cluster-announce-bus-port
+      - "16380"
+      - --cluster-announce-ip
+      - redis2.local
+    environment:
+      REDIS_PORT: "6380"
+    healthcheck: *redis-healthcheck
+
+  redis3:
+    image: redis:7.2.12
+    hostname: redis3.local
+    command:
+      - redis-server
+      - --save
+      - ""
+      - --appendonly
+      - "no"
+      - --bind
+      - 0.0.0.0
+      - --port
+      - "6381"
+      - --cluster-enabled
+      - "yes"
+      - --cluster-config-file
+      - /data/nodes.conf
+      - --cluster-node-timeout
+      - "5000"
+      - --cluster-announce-port
+      - "6381"
+      - --cluster-announce-bus-port
+      - "16381"
+      - --cluster-announce-ip
+      - redis3.local
+    environment:
+      REDIS_PORT: "6381"
+    healthcheck: *redis-healthcheck
+
+  redis4:
+    image: redis:7.2.12
+    hostname: redis4.local
+    command:
+      - redis-server
+      - --save
+      - ""
+      - --appendonly
+      - "no"
+      - --bind
+      - 0.0.0.0
+      - --port
+      - "6382"
+      - --cluster-enabled
+      - "yes"
+      - --cluster-config-file
+      - /data/nodes.conf
+      - --cluster-node-timeout
+      - "5000"
+      - --cluster-announce-port
+      - "6382"
+      - --cluster-announce-bus-port
+      - "16382"
+      - --cluster-announce-ip
+      - redis4.local
+    environment:
+      REDIS_PORT: "6382"
+    healthcheck: *redis-healthcheck
+
+  redis5:
+    image: redis:7.2.12
+    hostname: redis5.local
+    command:
+      - redis-server
+      - --save
+      - ""
+      - --appendonly
+      - "no"
+      - --bind
+      - 0.0.0.0
+      - --port
+      - "6383"
+      - --cluster-enabled
+      - "yes"
+      - --cluster-config-file
+      - /data/nodes.conf
+      - --cluster-node-timeout
+      - "5000"
+      - --cluster-announce-port
+      - "6383"
+      - --cluster-announce-bus-port
+      - "16383"
+      - --cluster-announce-ip
+      - redis5.local
+    environment:
+      REDIS_PORT: "6383"
+    healthcheck: *redis-healthcheck
+
+  redis6:
+    image: redis:7.2.12
+    hostname: redis6.local
+    command:
+      - redis-server
+      - --save
+      - ""
+      - --appendonly
+      - "no"
+      - --bind
+      - 0.0.0.0
+      - --port
+      - "6384"
+      - --cluster-enabled
+      - "yes"
+      - --cluster-config-file
+      - /data/nodes.conf
+      - --cluster-node-timeout
+      - "5000"
+      - --cluster-announce-port
+      - "6384"
+      - --cluster-announce-bus-port
+      - "16384"
+      - --cluster-announce-ip
+      - redis6.local
+    environment:
+      REDIS_PORT: "6384"
+    healthcheck: *redis-healthcheck

--- a/nix/cluster-e2e-docker.nix
+++ b/nix/cluster-e2e-docker.nix
@@ -1,10 +1,17 @@
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import <nixpkgs> { }
+, imageName ? "clusterE2eTests"
+, imageTag ? "latest"
+, imageOwner ? ""
+}:
 let pack = (import ../default.nix { }).justStaticClusterEndToEnd;
 in pkgs.dockerTools.buildImage {
-  name = "clusterE2eTests";
-  tag = "latest";
+  name = imageName;
+  tag = imageTag;
   contents = [ pack ];
   config = {
     Cmd = [ "${pack}/bin/ClusterEndToEnd" ];
+    Labels = {
+      "com.redis-client.e2e.owner" = imageOwner;
+    };
   };
 }

--- a/scripts/run-cluster-e2e-tests.sh
+++ b/scripts/run-cluster-e2e-tests.sh
@@ -1,99 +1,235 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash -p redis
 
-set -e
+set -Eeuo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker/cluster-e2e/docker-compose.yml"
+RUN_TOKEN=""
+PROJECT_NAME=""
+E2E_IMAGE_NAME=""
+E2E_IMAGE_TAG="latest"
+E2E_IMAGE=""
+IMAGE_OWNER_LABEL="com.redis-client.e2e.owner"
+IMAGE_OWNERSHIP_ESTABLISHED=0
+COMPOSE_OWNERSHIP_ESTABLISHED=0
+COMPOSE=()
+
+reserve_run_identity() {
+  local candidate
+  local attempts=0
+
+  while [[ "$attempts" -lt 10 ]]; do
+    candidate="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+    if [[ "$candidate" =~ ^[0-9a-f]{32}$ ]]; then
+      RUN_TOKEN="$candidate"
+      PROJECT_NAME="redis-client-cluster-e2e-$RUN_TOKEN"
+      E2E_IMAGE_NAME="redis-client-cluster-e2e-tests-$RUN_TOKEN"
+      E2E_IMAGE="$E2E_IMAGE_NAME:$E2E_IMAGE_TAG"
+      COMPOSE=(docker compose --project-name "$PROJECT_NAME" --file "$COMPOSE_FILE")
+      return 0
+    fi
+    attempts=$((attempts + 1))
+  done
+
+  echo "Error: failed to reserve a unique cluster E2E ownership token." >&2
+  return 1
+}
+
+assert_image_identity_available() {
+  local owned_images
+
+  owned_images="$(
+    docker image ls --quiet --no-trunc \
+      --filter "label=$IMAGE_OWNER_LABEL=$RUN_TOKEN"
+  )"
+  if [[ -n "$owned_images" ]] \
+    || docker image inspect "$E2E_IMAGE" >/dev/null 2>&1; then
+    echo "Error: cluster E2E image identity already exists; refusing to adopt it." >&2
+    return 1
+  fi
+
+  IMAGE_OWNERSHIP_ESTABLISHED=1
+}
+
+assert_compose_identity_available() {
+  local project_filter="label=com.docker.compose.project=$PROJECT_NAME"
+  local containers
+  local networks
+  local volumes
+
+  containers="$(docker container ls --all --quiet --filter "$project_filter")"
+  networks="$(docker network ls --quiet --filter "$project_filter")"
+  volumes="$(docker volume ls --quiet --filter "$project_filter")"
+  if [[ -n "$containers" || -n "$networks" || -n "$volumes" ]]; then
+    echo "Error: cluster E2E Compose identity already exists; refusing to adopt it." >&2
+    return 1
+  fi
+
+  COMPOSE_OWNERSHIP_ESTABLISHED=1
+}
+
+diagnostics() {
+  echo "Cluster E2E diagnostics for project $PROJECT_NAME:"
+  "${COMPOSE[@]}" ps || true
+  for node in redis1 redis2 redis3 redis4 redis5 redis6; do
+    echo "--- $node ---"
+    "${COMPOSE[@]}" logs --no-color "$node" || true
+  done
+}
 
 cleanup() {
-  echo "Cleaning up containers..."
-  docker compose -f "$SCRIPT_DIR/docker/cluster/docker-compose.yml" down 2>/dev/null || true
-  # shellcheck disable=SC2046
-  docker rmi $(docker images "clustere2etests:*" -q) 2>/dev/null || true
-  rm -f "$SCRIPT_DIR/result"
+  local primary_status=$?
+  local cleanup_status=0
+  local command_status
+  local image_ids
+  local image_owner
+  local image_id
+
+  trap - EXIT INT TERM HUP
+  set +e
+
+  if [[ "$primary_status" -ne 0 && "$COMPOSE_OWNERSHIP_ESTABLISHED" -eq 1 ]]; then
+    diagnostics
+  fi
+
+  if [[ "$COMPOSE_OWNERSHIP_ESTABLISHED" -eq 1 ]]; then
+    "${COMPOSE[@]}" down --volumes --remove-orphans >/dev/null 2>&1
+    command_status=$?
+    if [[ "$command_status" -ne 0 ]]; then
+      echo "Warning: failed to stop the cluster E2E Compose project (exit $command_status)." >&2
+      cleanup_status=$command_status
+    fi
+  fi
+
+  if [[ "$IMAGE_OWNERSHIP_ESTABLISHED" -eq 1 ]]; then
+    image_ids="$(
+      docker image ls --quiet --no-trunc \
+        --filter "label=$IMAGE_OWNER_LABEL=$RUN_TOKEN" 2>/dev/null
+    )"
+    command_status=$?
+    if [[ "$command_status" -ne 0 ]]; then
+      echo "Warning: failed to discover the cluster E2E image (exit $command_status)." >&2
+      if [[ "$cleanup_status" -eq 0 ]]; then
+        cleanup_status=$command_status
+      fi
+    else
+      while IFS= read -r image_id; do
+        [[ -z "$image_id" ]] && continue
+        image_owner="$(
+          docker image inspect \
+            --format '{{ index .Config.Labels "com.redis-client.e2e.owner" }}' \
+            "$image_id" 2>/dev/null
+        )"
+        command_status=$?
+        if [[ "$command_status" -ne 0 ]]; then
+          continue
+        fi
+        if [[ "$image_owner" != "$RUN_TOKEN" ]]; then
+          echo "Warning: refusing to remove a cluster E2E image with mismatched ownership." >&2
+          if [[ "$cleanup_status" -eq 0 ]]; then
+            cleanup_status=1
+          fi
+          continue
+        fi
+        docker image rm "$image_id" >/dev/null 2>&1
+        command_status=$?
+        if [[ "$command_status" -ne 0 ]]; then
+          echo "Warning: failed to remove the cluster E2E image (exit $command_status)." >&2
+          if [[ "$cleanup_status" -eq 0 ]]; then
+            cleanup_status=$command_status
+          fi
+        fi
+      done <<<"$image_ids"
+    fi
+  fi
+
+  if [[ "$primary_status" -ne 0 ]]; then
+    exit "$primary_status"
+  fi
+  exit "$cleanup_status"
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 
-echo "Starting Redis Cluster E2E Tests..."
-
-# Navigate to docker/cluster directory
-cd docker/cluster
-
-# Start the cluster
-echo "Starting Redis cluster nodes..."
-docker compose up -d
-
-# Wait for nodes to be ready
-echo "Waiting for Redis nodes to be ready..."
-sleep 5
-
-# Create the cluster
-echo "Creating Redis cluster..."
-./make_cluster.sh || {
-    echo "Cluster creation failed."
-    exit 1
+wait_for_healthy_nodes() {
+  for attempt in $(seq 1 30); do
+    healthy=0
+    for node in redis1 redis2 redis3 redis4 redis5 redis6; do
+      status=$("${COMPOSE[@]}" ps --format json "$node" 2>/dev/null | \
+        sed -n 's/.*"Health":"\([^"]*\)".*/\1/p')
+      [ "$status" = "healthy" ] && healthy=$((healthy + 1))
+    done
+    [ "$healthy" -eq 6 ] && return 0
+    sleep 1
+  done
+  return 1
 }
 
-# Give cluster time to stabilize and verify it's ready
-echo "Waiting for cluster to stabilize..."
-MAX_RETRIES=10
-RETRY_COUNT=0
-CLUSTER_READY=false
+wait_for_cluster() {
+  for attempt in $(seq 1 30); do
+    if "${COMPOSE[@]}" exec -T redis1 redis-cli -p 6379 cluster info 2>/dev/null | \
+        grep -q '^cluster_state:ok'; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
 
-while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-  sleep 2
-  
-  # Check cluster state
-  if redis-cli -p 6379 cluster info | grep -q "cluster_state:ok"; then
-    echo "Cluster is ready!"
-    CLUSTER_READY=true
-    break
-  fi
-  
-  RETRY_COUNT=$((RETRY_COUNT + 1))
-  echo "Cluster not ready yet (attempt $RETRY_COUNT/$MAX_RETRIES)..."
-done
+reserve_run_identity
+assert_image_identity_available
 
-if [ "$CLUSTER_READY" = false ]; then
-  echo "ERROR: Cluster failed to reach 'ok' state after $MAX_RETRIES attempts"
-  echo "Cluster info:"
-  redis-cli -p 6379 cluster info
-  echo ""
-  echo "Cluster nodes:"
-  redis-cli -p 6379 cluster nodes
-  docker compose down
+echo "Building isolated cluster E2E image..."
+image_archive="$(
+  cd "$SCRIPT_DIR"
+  nix-build --no-out-link nix/cluster-e2e-docker.nix \
+    --argstr imageName "$E2E_IMAGE_NAME" \
+    --argstr imageTag "$E2E_IMAGE_TAG" \
+    --argstr imageOwner "$RUN_TOKEN"
+)"
+docker load <"$image_archive"
+
+loaded_owner="$(
+  docker image inspect \
+    --format '{{ index .Config.Labels "com.redis-client.e2e.owner" }}' \
+    "$E2E_IMAGE"
+)"
+if [[ "$loaded_owner" != "$RUN_TOKEN" ]]; then
+  echo "Error: loaded cluster E2E image has unexpected ownership." >&2
   exit 1
 fi
 
-# Go back to root directory
-cd ../..
-
-# Build the Docker image
-echo "Building cluster E2E test Docker image..."
-nix-build nix/cluster-e2e-docker.nix || {
-    echo "Failed to build Docker image"
-    exit 1
-}
-
-# Load the Docker image
-echo "Loading cluster E2E test Docker image..."
-docker load < result
-
-# Get the actual network name created by docker compose
-# Docker compose prefixes the network name with the project name (usually the directory name)
-NETWORK_NAME=$(docker network ls --filter name=redis-cluster-net --format "{{.Name}}" | grep -E 'redis-cluster-net$' | head -n 1)
-
-if [ -z "$NETWORK_NAME" ]; then
-  echo "Error: Could not find redis-cluster-net network"
+assert_compose_identity_available
+echo "Starting isolated Redis 7.2 six-node Cluster E2E fixture ($PROJECT_NAME)..."
+"${COMPOSE[@]}" up --detach
+if ! wait_for_healthy_nodes; then
+  echo "Error: cluster nodes did not become healthy." >&2
   exit 1
 fi
 
-# Run the cluster E2E tests in Docker on the same network as the cluster
-echo "Running cluster E2E tests in Docker container on network $NETWORK_NAME..."
-docker run --rm --network="$NETWORK_NAME" clustere2etests:latest  || {
-    EXIT_CODE=$?
-    echo "Tests failed with exit code $EXIT_CODE"
-    exit $EXIT_CODE
-}
+echo "Creating three-primary, three-replica cluster..."
+"${COMPOSE[@]}" exec -T redis1 redis-cli --cluster create --cluster-replicas 1 --cluster-yes \
+  redis1.local:6379 redis2.local:6380 redis3.local:6381 \
+  redis4.local:6382 redis5.local:6383 redis6.local:6384
+if ! wait_for_cluster; then
+  echo "Error: cluster did not reach cluster_state:ok." >&2
+  exit 1
+fi
 
-echo "Cluster E2E tests completed successfully!"
+NETWORK_NAME="${PROJECT_NAME}_default"
+network_owner="$(
+  docker network inspect \
+    --format '{{ index .Labels "com.docker.compose.project" }}' \
+    "$NETWORK_NAME"
+)"
+if [[ "$network_owner" != "$PROJECT_NAME" ]]; then
+  echo "Error: cluster E2E network has unexpected ownership." >&2
+  exit 1
+fi
+
+echo "Running cluster E2E tests on $NETWORK_NAME..."
+docker run --rm --network "$NETWORK_NAME" "$E2E_IMAGE"
+echo "Cluster E2E tests completed successfully."

--- a/scripts/run-cluster-e2e-tests.sh
+++ b/scripts/run-cluster-e2e-tests.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p redis
+#! nix-shell -i bash -p redis coreutils
 
 set -Eeuo pipefail
 
@@ -211,7 +211,7 @@ if ! wait_for_healthy_nodes; then
 fi
 
 echo "Creating three-primary, three-replica cluster..."
-"${COMPOSE[@]}" exec -T redis1 redis-cli --cluster create --cluster-replicas 1 --cluster-yes \
+timeout 120 "${COMPOSE[@]}" exec -T redis1 redis-cli --cluster create --cluster-replicas 1 --cluster-yes \
   redis1.local:6379 redis2.local:6380 redis3.local:6381 \
   redis4.local:6382 redis5.local:6383 redis6.local:6384
 if ! wait_for_cluster; then

--- a/scripts/test-run-cluster-e2e-tests.sh
+++ b/scripts/test-run-cluster-e2e-tests.sh
@@ -1,0 +1,212 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -p bash coreutils gnugrep -i bash
+# shellcheck shell=bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORK_DIR="$REPO_ROOT/.cluster-e2e-timeout-regression-$$"
+
+fail() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM HUP
+  rm -rf -- "$WORK_DIR"
+  exit "$status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+[[ ! -e "$WORK_DIR" ]] || fail "refusing to reuse regression fixture $WORK_DIR"
+mkdir -m 700 "$WORK_DIR"
+
+FIXTURE="$WORK_DIR/fixture"
+BIN_DIR="$FIXTURE/bin"
+STATE_DIR="$FIXTURE/docker-state"
+LOG_FILE="$FIXTURE/commands.log"
+OUTPUT_FILE="$FIXTURE/runner.out"
+ARCHIVE_FILE="$FIXTURE/e2e-image.tar"
+
+mkdir -p "$BIN_DIR" "$STATE_DIR" "$FIXTURE/scripts" \
+  "$FIXTURE/docker/cluster-e2e" "$FIXTURE/nix"
+cp "$SCRIPT_DIR/run-cluster-e2e-tests.sh" "$FIXTURE/scripts/run-cluster-e2e-tests.sh"
+chmod 700 "$FIXTURE/scripts/run-cluster-e2e-tests.sh"
+: >"$FIXTURE/docker/cluster-e2e/docker-compose.yml"
+: >"$FIXTURE/nix/cluster-e2e-docker.nix"
+: >"$ARCHIVE_FILE"
+: >"$LOG_FILE"
+
+cat >"$BIN_DIR/nix-build" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+printf 'nix-build %s\n' "$*" >>"$STUB_LOG"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --argstr)
+      case "$2" in
+        imageName) printf '%s\n' "$3" >"$STUB_STATE/image-name" ;;
+        imageOwner) printf '%s\n' "$3" >"$STUB_STATE/image-owner" ;;
+      esac
+      shift 3
+      ;;
+    *) shift ;;
+  esac
+done
+
+printf '%s\n' "$STUB_ARCHIVE"
+EOF
+
+cat >"$BIN_DIR/timeout" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+printf 'timeout %s\n' "$*" >>"$STUB_LOG"
+[[ "${1:-}" == "120" ]] || {
+  echo "Unexpected cluster-create timeout: ${1:-<missing>}" >&2
+  exit 97
+}
+shift
+
+# Shorten only this disposable hung-command probe while exercising the
+# production runner's 120-second timeout invocation.
+exec "$REAL_TIMEOUT" 1 "$@"
+EOF
+
+cat >"$BIN_DIR/docker" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+printf 'docker %s\n' "$*" >>"$STUB_LOG"
+
+state_dir="$STUB_STATE"
+image_name="$(cat "$state_dir/image-name" 2>/dev/null || true):latest"
+image_owner="$(cat "$state_dir/image-owner" 2>/dev/null || true)"
+image_id="sha256:owned-$image_owner"
+
+if [[ "${1:-}" == "load" ]]; then
+  cat >/dev/null
+  touch "$state_dir/image-present"
+  exit 0
+fi
+
+if [[ "${1:-}" == "image" && "${2:-}" == "ls" ]]; then
+  if [[ -e "$state_dir/image-present" ]]; then
+    printf '%s\n' "$image_id"
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "image" && "${2:-}" == "inspect" ]]; then
+  if [[ -e "$state_dir/image-present" ]]; then
+    printf '%s\n' "$image_owner"
+    exit 0
+  fi
+  exit 1
+fi
+
+if [[ "${1:-}" == "container" && "${2:-}" == "ls" ]] \
+  || [[ "${1:-}" == "network" && "${2:-}" == "ls" ]] \
+  || [[ "${1:-}" == "volume" && "${2:-}" == "ls" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "image" && "${2:-}" == "rm" ]]; then
+  args=("$@")
+  target="${args[${#args[@]} - 1]}"
+  [[ "$target" == "$image_id" ]] || exit 98
+  rm -f "$state_dir/image-present"
+  touch "$state_dir/image-removed"
+  exit 0
+fi
+
+if [[ "${1:-}" == "compose" ]]; then
+  command_line=" $* "
+  project_name=""
+  previous=""
+  for argument in "$@"; do
+    if [[ "$previous" == "--project-name" ]]; then
+      project_name="$argument"
+      break
+    fi
+    previous="$argument"
+  done
+
+  if [[ "$command_line" == *" up --detach "* ]]; then
+    printf '%s\n' "$project_name" >"$state_dir/project-name"
+    touch "$state_dir/compose-present"
+    exit 0
+  fi
+
+  if [[ "$command_line" == *" ps --format json "* ]]; then
+    printf '%s\n' '{"Health":"healthy"}'
+    exit 0
+  fi
+
+  if [[ "$command_line" == *" exec -T redis1 redis-cli --cluster create "* ]]; then
+    printf '%s\n' "$project_name" >"$state_dir/cluster-create-project"
+    touch "$state_dir/cluster-create-entered"
+    exec sleep 30
+  fi
+
+  if [[ "$command_line" == *" down --volumes --remove-orphans "* ]]; then
+    rm -f "$state_dir/compose-present"
+    touch "$state_dir/compose-removed"
+    exit 0
+  fi
+
+  if [[ "$command_line" == *" ps "* || "$command_line" == *" logs "* ]]; then
+    exit 0
+  fi
+fi
+
+echo "Unsupported Docker invocation: $*" >&2
+exit 99
+EOF
+
+chmod 700 "$BIN_DIR/nix-build" "$BIN_DIR/timeout" "$BIN_DIR/docker"
+
+REAL_TIMEOUT="$(command -v timeout)"
+[[ -n "$REAL_TIMEOUT" ]] || fail "GNU timeout is unavailable"
+
+set +e
+SECONDS=0
+PATH="$BIN_DIR:$PATH" \
+  STUB_ARCHIVE="$ARCHIVE_FILE" \
+  STUB_LOG="$LOG_FILE" \
+  STUB_STATE="$STATE_DIR" \
+  REAL_TIMEOUT="$REAL_TIMEOUT" \
+  /bin/bash "$FIXTURE/scripts/run-cluster-e2e-tests.sh" >"$OUTPUT_FILE" 2>&1
+runner_status=$?
+elapsed_seconds=$SECONDS
+set -e
+
+[[ "$runner_status" -eq 124 ]] ||
+  fail "hung cluster creation returned $runner_status; expected timeout status 124"
+[[ "$elapsed_seconds" -le 5 ]] ||
+  fail "hung cluster creation exceeded the 1-second regression deadline ($elapsed_seconds seconds)"
+grep -Fq -- "timeout 120 docker compose" "$LOG_FILE" ||
+  fail "cluster creation did not invoke the production 120-second timeout"
+[[ -e "$STATE_DIR/cluster-create-entered" ]] ||
+  fail "hung cluster-create operation was not reached"
+[[ -e "$STATE_DIR/compose-removed" && -e "$STATE_DIR/image-removed" ]] ||
+  fail "EXIT cleanup did not remove both exact-owned fixture resources"
+[[ ! -e "$STATE_DIR/compose-present" && ! -e "$STATE_DIR/image-present" ]] ||
+  fail "exact-owned fixture resources survived timeout cleanup"
+
+project_name="$(cat "$STATE_DIR/project-name")"
+[[ "$project_name" =~ ^redis-client-cluster-e2e-[0-9a-f]{32}$ ]] ||
+  fail "unexpected Compose ownership identity: $project_name"
+[[ "$(cat "$STATE_DIR/cluster-create-project")" == "$project_name" ]] ||
+  fail "cluster create and cleanup did not use the same Compose ownership identity"
+
+printf '%s\n' \
+  "Cluster E2E cluster-create timeout regression passed: status 124, 1-second probe deadline, exact-owned resources removed."

--- a/test/ClusterE2E/Tunnel.hs
+++ b/test/ClusterE2E/Tunnel.hs
@@ -1,24 +1,38 @@
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module ClusterE2E.Tunnel (spec) where
 
 import           ClusterE2E.Utils
+import           Control.Concurrent            (threadDelay)
 import           Control.Concurrent.STM        (readTVarIO)
-import           Control.Exception             (bracket)
+import           Control.Exception             (bracket, finally)
 import           Control.Monad                 (forM_, when)
+import qualified Control.Monad.State           as State
+import qualified Data.ByteString               as BS
+import qualified Data.ByteString.Builder       as Builder
 import qualified Data.ByteString.Char8         as BS8
-import           Data.List                     (isInfixOf)
+import           Data.List                     (find, isInfixOf)
 import qualified Data.Map.Strict               as Map
-import           Database.Redis.Client         (PlainTextClient (NotConnectedPlainTextClient),
+import           Database.Redis.Client         (Client (..),
+                                                ConnectionStatus (Connected),
+                                                PlainTextClient (NotConnectedPlainTextClient),
                                                 close, connect)
 import           Database.Redis.Cluster        (ClusterNode (..),
                                                 ClusterTopology (..),
-                                                NodeAddress (..), NodeRole (..))
-import           Database.Redis.Cluster.Client (closeClusterClient,
-                                                clusterTopology)
-import           Database.Redis.Command        (RedisCommands (..))
-import           Database.Redis.Resp           (RespData (..))
+                                                NodeAddress (..), NodeRole (..),
+                                                calculateSlot,
+                                                findNodeAddressForSlot)
+import           Database.Redis.Cluster.Client (ClusterClient,
+                                                closeClusterClient,
+                                                clusterTopology,
+                                                refreshTopology)
+import           Database.Redis.Command        (ClientState (..),
+                                                RedisCommandClient (..),
+                                                RedisCommands (..), parseWith)
+import           Database.Redis.Resp           (Encodable (encode),
+                                                RespData (..))
 import           SlotMappingHelpers            (getKeyForNode)
 import           Test.Hspec
 
@@ -125,6 +139,146 @@ spec = describe "Cluster Tunnel Mode" $ do
           _ <- runCmd_ client (del ["multi:key2"])
           pure ()
 
+    it "smart mode routes raw grammar shapes to the topology-selected owner and preserves bytes" $
+      withSmartProxy $
+        bracket createTestClusterClient closeClusterClient $ \client -> do
+          master <- firstMaster client
+          let binaryKey = getKeyForNode master "raw-binary"
+              evalKey = getKeyForNode master "raw-eval"
+              streamKey = getKeyForNode master "raw-stream"
+              groupStreamKey = getKeyForNode master "raw-group-stream"
+              sourceOne = getKeyForNode master "raw-zset-one"
+              sourceTwo = getKeyForNode master "raw-zset-two"
+              destination = getKeyForNode master "raw-zset-destination"
+              multiOne = getKeyForNode master "raw-multi-one"
+              multiTwo = getKeyForNode master "raw-multi-two"
+              binaryValue = BS.pack [0, 255, 10, 13, 42]
+              allKeys = [binaryKey, evalKey, streamKey, groupStreamKey, sourceOne, sourceTwo,
+                         destination, multiOne, multiTwo]
+          owner <- topologyOwnerForKey client evalKey
+          nodeAddress owner `shouldBe` nodeAddress master
+          forM_ allKeys $ \key -> do
+            selectedOwner <- topologyOwnerForKey client key
+            nodeAddress selectedOwner `shouldBe` nodeAddress owner
+          (`finally` deleteFromNode owner allKeys) $ do
+            bracket (connectProxy) close $ \conn -> do
+              runRawProxyCommand conn ["PING", binaryValue]
+                `shouldReturn` RespBulkString binaryValue
+              runRawProxyCommand conn ["ECHO", BS.empty]
+                `shouldReturn` RespBulkString BS.empty
+
+              runRawProxyCommand conn ["SET", binaryKey, binaryValue]
+                `shouldReturn` RespSimpleString "OK"
+              runRawOnNode owner ["GET", binaryKey]
+                `shouldReturn` RespBulkString binaryValue
+
+              evalResponse <- runRawProxyCommand conn
+                [ "EVAL"
+                , "redis.call('SET', KEYS[1], ARGV[1]); return redis.call('GET', KEYS[1])"
+                , "1"
+                , evalKey
+                , binaryValue
+                ]
+              evalResponse `shouldBe` RespBulkString binaryValue
+              runRawOnNode owner ["GET", evalKey]
+                `shouldReturn` RespBulkString binaryValue
+
+              sha <- loadScript owner "return {KEYS[1],ARGV[1]}"
+              runRawProxyCommand conn ["EVALSHA", sha, "1", evalKey, binaryValue]
+                `shouldReturn` RespArray [RespBulkString evalKey, RespBulkString binaryValue]
+
+              _ <- runRawProxyCommand conn ["XADD", streamKey, "*", "field", binaryValue]
+              xreadResponse <- runRawProxyCommand conn ["XREAD", "COUNT", "1", "STREAMS", streamKey, "0-0"]
+              xreadResponse `shouldSatisfy` isNonEmptyArray
+              runRawOnNode owner ["XLEN", streamKey] `shouldReturn` RespInteger 1
+
+              runRawProxyCommand conn ["XGROUP", "CREATE", groupStreamKey, "group", "0", "MKSTREAM"]
+                `shouldReturn` RespSimpleString "OK"
+              _ <- runRawProxyCommand conn ["XADD", groupStreamKey, "*", "field", "value"]
+              xreadGroupResponse <- runRawProxyCommand conn
+                ["XREADGROUP", "GROUP", "group", "consumer", "COUNT", "1", "STREAMS", groupStreamKey, ">"]
+              xreadGroupResponse `shouldSatisfy` isNonEmptyArray
+              runRawOnNode owner ["XLEN", groupStreamKey] `shouldReturn` RespInteger 1
+
+              runRawProxyCommand conn ["ZADD", sourceOne, "1", "one"]
+                `shouldReturn` RespInteger 1
+              runRawProxyCommand conn ["ZADD", sourceTwo, "2", "one"]
+                `shouldReturn` RespInteger 1
+              runRawProxyCommand conn ["ZUNIONSTORE", destination, "2", sourceOne, sourceTwo]
+                `shouldReturn` RespInteger 1
+              runRawOnNode owner ["ZSCORE", destination, "one"]
+                `shouldReturn` RespBulkString "3"
+
+              runRawProxyCommand conn ["MSET", multiOne, "first", multiTwo, "second"]
+                `shouldReturn` RespSimpleString "OK"
+              runRawOnNode owner ["MGET", multiOne, multiTwo]
+                `shouldReturn` RespArray [RespBulkString "first", RespBulkString "second"]
+
+    it "smart mode returns exact local errors and leaves malformed and cross-slot candidates unchanged" $
+      withSmartProxy $
+        bracket createTestClusterClient closeClusterClient $ \client -> do
+          (firstNode, secondNode) <- twoMasters client
+          let firstKey = getKeyForNode firstNode "locally-rejected-first"
+              secondKey = getKeyForNode secondNode "locally-rejected-second"
+          firstOwner <- topologyOwnerForKey client firstKey
+          secondOwner <- topologyOwnerForKey client secondKey
+          calculateSlot firstKey `shouldNotBe` calculateSlot secondKey
+          (`finally` deleteFromNode firstOwner [firstKey]) $
+            (`finally` deleteFromNode secondOwner [secondKey]) $ do
+              runRawOnNode firstOwner ["SET", firstKey, "first-before"]
+                `shouldReturn` RespSimpleString "OK"
+              runRawOnNode secondOwner ["SET", secondKey, "second-before"]
+                `shouldReturn` RespSimpleString "OK"
+              bracket (connectProxy) close $ \conn -> do
+                unknownResponse <-
+                  runRawProxyCommand conn ["NOT_A_REDIS_COMMAND", firstKey]
+                assertExactLocalError unknownResponse "unknown command"
+                malformedEvalResponse <- runRawProxyCommand conn
+                  [ "EVAL"
+                  , "redis.call('SET', KEYS[1], ARGV[1])"
+                  , "not-a-number"
+                  , firstKey
+                  , "would-overwrite"
+                  ]
+                assertExactLocalError malformedEvalResponse "EVAL has an invalid key count"
+                nonBulkResponse <-
+                  runRawProxyFrame conn (RespArray [RespBulkString "SET", RespInteger 1])
+                assertExactLocalError nonBulkResponse "Expected array command with bulk string arguments"
+                malformedMsetResponse <-
+                  runRawProxyCommand conn ["MSET", firstKey, "would-overwrite", secondKey]
+                assertExactLocalError malformedMsetResponse "MSET has malformed arguments"
+                crossSlotResponse <- runRawProxyCommand conn
+                  ["MSET", firstKey, "cross-first", secondKey, "cross-second"]
+                assertExactLocalError crossSlotResponse "CROSSSLOT Keys in request don't hash to the same slot"
+              runRawOnNode firstOwner ["GET", firstKey]
+                `shouldReturn` RespBulkString "first-before"
+              runRawOnNode secondOwner ["GET", secondKey]
+                `shouldReturn` RespBulkString "second-before"
+
+    it "smart mode retries the same raw LPUSH frame after a live MOVED without duplicate mutation" $
+      bracket createTestClusterClient closeClusterClient $ \beforeClient -> do
+        topology <- readTVarIO (clusterTopology beforeClient)
+        previousOwner <- firstMaster beforeClient
+        replica <- replicaForMaster topology previousOwner
+        let key = getKeyForNode previousOwner "failover-single-write"
+            rawMutation = rawFrame ["LPUSH", key, "only-once"]
+            cleanup = deleteFromTopologyOwner key
+        (`finally` cleanup) $
+          withSmartProxy $
+          bracket (connectProxy) close $ \conn -> do
+            runRawOnNode previousOwner ["DEL", key] `shouldReturn` RespInteger 0
+            runRawOnNode replica ["CLUSTER", "FAILOVER", "FORCE"]
+              `shouldReturn` RespSimpleString "OK"
+            waitForMoved previousOwner key
+            bracket createTestClusterClient closeClusterClient $ \afterClient -> do
+              currentOwner <- waitForTopologyOwner afterClient key (nodeAddress previousOwner)
+              mutationResponse <- runRawProxyFrame conn rawMutation
+              mutationResponse `shouldBe` RespInteger 1
+              lengthResponse <- runRawOnNode currentOwner ["LLEN", key]
+              lengthResponse `shouldBe` RespInteger 1
+              listResponse <- runRawOnNode currentOwner ["LRANGE", key, "0", "-1"]
+              listResponse `shouldBe` RespArray [RespBulkString "only-once"]
+
   describe "Pinned Proxy Mode" $ do
     it "pinned mode creates one listener per cluster node and each works correctly" $
       withPinnedProxy $ do
@@ -223,8 +377,8 @@ spec = describe "Cluster Tunnel Mode" $ do
 
           case masterNodes of
             [] -> expectationFailure "No master nodes found in cluster topology"
-            (firstMaster:_) -> do
-              let addr      = nodeAddress firstMaster
+            (firstMasterNode:_) -> do
+              let addr      = nodeAddress firstMasterNode
                   localPort = nodePort addr
 
               conn <- connect (NotConnectedPlainTextClient "localhost" (Just localPort))
@@ -240,3 +394,134 @@ spec = describe "Cluster Tunnel Mode" $ do
                 other -> expectationFailure $ "Expected RespArray from CLUSTER SLOTS, got: " ++ show other
 
               close conn
+
+connectProxy :: IO (PlainTextClient 'Connected)
+connectProxy = connect (NotConnectedPlainTextClient "localhost" (Just 6379))
+
+runRawProxyCommand :: PlainTextClient 'Connected -> [BS.ByteString] -> IO RespData
+runRawProxyCommand conn = runRawProxyFrame conn . rawFrame
+
+runRawProxyFrame :: PlainTextClient 'Connected -> RespData -> IO RespData
+runRawProxyFrame conn frame = runRedisCommand conn $ rawCommand frame
+
+runRawOnNode :: ClusterNode -> [BS.ByteString] -> IO RespData
+runRawOnNode node command =
+  bracket
+    (connect $ NotConnectedPlainTextClient (nodeHost address) (Just $ nodePort address))
+    close
+    (\conn -> runRawProxyCommand conn command)
+  where
+    address = nodeAddress node
+
+loadScript :: ClusterNode -> BS.ByteString -> IO BS.ByteString
+loadScript node script = do
+  result <- runRawOnNode node ["SCRIPT", "LOAD", script]
+  case result of
+    RespBulkString sha -> pure sha
+    other              -> expectationFailure ("SCRIPT LOAD failed: " ++ show other) >> error "unreachable"
+
+rawFrame :: [BS.ByteString] -> RespData
+rawFrame = RespArray . map RespBulkString
+
+rawCommand :: RespData -> RedisCommandClient PlainTextClient RespData
+rawCommand frame = RedisCommandClient $ do
+  state <- State.get
+  send (getClient state) (Builder.toLazyByteString $ encode frame)
+  parseWith (receive $ getClient state)
+
+firstMaster :: ClusterClient PlainTextClient -> IO ClusterNode
+firstMaster client = do
+  topology <- readTVarIO (clusterTopology client)
+  case filter ((== Master) . nodeRole) (Map.elems $ topologyNodes topology) of
+    node:_ -> pure node
+    []     -> expectationFailure "No master nodes found in cluster topology" >> error "unreachable"
+
+twoMasters :: ClusterClient PlainTextClient -> IO (ClusterNode, ClusterNode)
+twoMasters client = do
+  topology <- readTVarIO (clusterTopology client)
+  case filter ((== Master) . nodeRole) (Map.elems $ topologyNodes topology) of
+    firstNode:secondNode:_ -> pure (firstNode, secondNode)
+    _ -> expectationFailure "Fixture must provide at least two master nodes" >> error "unreachable"
+
+deleteFromNode :: ClusterNode -> [BS.ByteString] -> IO ()
+deleteFromNode node keys = do
+  _ <- runRawOnNode node ("DEL" : keys)
+  pure ()
+
+deleteFromTopologyOwner :: BS.ByteString -> IO ()
+deleteFromTopologyOwner key =
+  bracket createTestClusterClient closeClusterClient $ \client -> do
+    owner <- topologyOwnerForKey client key
+    deleteFromNode owner [key]
+
+topologyOwnerForKey :: ClusterClient PlainTextClient -> BS.ByteString -> IO ClusterNode
+topologyOwnerForKey client key = do
+  topology <- readTVarIO (clusterTopology client)
+  let slot = calculateSlot key
+  case findNodeAddressForSlot topology slot of
+    Nothing ->
+      expectationFailure ("No topology owner for slot " ++ show slot)
+        >> error "unreachable"
+    Just address ->
+      case find (\node -> nodeAddress node == address && nodeRole node == Master)
+        (Map.elems $ topologyNodes topology) of
+        Just owner -> pure owner
+        Nothing ->
+          expectationFailure
+            ("Topology address " ++ show address ++ " has no matching master")
+            >> error "unreachable"
+
+replicaForMaster :: ClusterTopology -> ClusterNode -> IO ClusterNode
+replicaForMaster topology master =
+  case nodeReplicas master of
+    replicaId:_ ->
+      case Map.lookup replicaId (topologyNodes topology) of
+        Just replica -> pure replica
+        Nothing ->
+          expectationFailure "Master replica is absent from the topology"
+            >> error "unreachable"
+    [] ->
+      expectationFailure "Fixture must provide a replica for every master"
+        >> error "unreachable"
+
+waitForMoved :: ClusterNode -> BS.ByteString -> IO ()
+waitForMoved previousOwner key = go (50 :: Int)
+  where
+    go 0 =
+      expectationFailure "Previous owner never returned a live MOVED response"
+        >> error "unreachable"
+    go attempts = do
+      response <- runRawOnNode previousOwner ["GET", key]
+      case response of
+        RespError message
+          | "MOVED " `BS8.isPrefixOf` message -> pure ()
+        _ -> do
+          threadDelay 200000
+          go (attempts - 1)
+
+waitForTopologyOwner ::
+  ClusterClient PlainTextClient ->
+  BS.ByteString ->
+  NodeAddress ->
+  IO ClusterNode
+waitForTopologyOwner client key previousAddress = go (50 :: Int)
+  where
+    go 0 =
+      expectationFailure "Refreshed topology retained the previous slot owner"
+        >> error "unreachable"
+    go attempts = do
+      refreshTopology client
+      owner <- topologyOwnerForKey client key
+      if nodeAddress owner /= previousAddress
+        then pure owner
+        else do
+          threadDelay 200000
+          go (attempts - 1)
+
+assertExactLocalError :: RespData -> BS.ByteString -> Expectation
+assertExactLocalError response expected =
+  response `shouldBe` RespError ("ERR " <> expected)
+
+isNonEmptyArray :: RespData -> Bool
+isNonEmptyArray (RespArray values) = not $ null values
+isNonEmptyArray _                  = False


### PR DESCRIPTION
Closes #133

Working as Tester (Quality Engineer)

## Summary
- Adds live, raw-RESP smart-proxy coverage for metadata-routed command grammar and retry behavior.
- Replaces the shared cluster fixture path with a six-node, per-run isolated fixture that preserves pinned-proxy listener coverage.
- Ensures cleanup is scoped to the exact Compose project and ownership-labelled image created by this run.

## Acceptance evidence

| Acceptance criterion | Implementation and observed evidence |
| --- | --- |
| Raw RESP helpers and topology-aware owner assertions | `test/ClusterE2E/Tunnel.hs`: `runRawProxyCommand`, `runRawProxyFrame`, and `rawCommand` preserve encoded frames; `topologyOwnerForKey` resolves `calculateSlot` through `findNodeAddressForSlot`; keys use `SlotMappingHelpers.getKeyForNode` and fixture/client lifecycle uses `ClusterE2E.Utils`. |
| EVAL, EVALSHA, XREAD, XREADGROUP, ZUNIONSTORE, same-slot multi-key, and keyless-with-arguments coverage | `smart mode routes raw grammar shapes to the topology-selected owner and preserves bytes` sends all required frames. It verifies stateful effects directly on the topology-selected owner (`GET`, `XLEN`, `ZSCORE`, `MGET`); `PING` carries binary input and `ECHO` carries an empty argument. |
| Exact local rejection and no mutation | `smart mode returns exact local errors and leaves malformed and cross-slot candidates unchanged` asserts exact RESP errors: `ERR unknown command`, `ERR EVAL has an invalid key count`, `ERR Expected array command with bulk string arguments`, `ERR MSET has malformed arguments`, and `ERR CROSSSLOT Keys in request don't hash to the same slot`. Pre-seeded cross-slot candidates retain their exact values when queried directly from their topology-selected owners. |
| Byte preservation | The raw test round-trips `BS.pack [0,255,10,13,42]` through `PING`, `SET`/direct-owner `GET`, `EVAL`, and `EVALSHA`, and separately round-trips `BS.empty` through `ECHO`. |
| Live topology-change retry without duplicate mutation | `smart mode retries the same raw LPUSH frame after a live MOVED without duplicate mutation` starts the smart proxy before forcing its selected replica to fail over, observes a live `MOVED` from the old owner, sends the pre-built raw `LPUSH` frame once, refreshes topology, and observes exactly one list item (`LLEN == 1` and exact `LRANGE`) on the new owner. |
| Existing smart/pinned cases, repeated E2E, and owned cleanup | `docker/cluster-e2e/docker-compose.yml` advertises ports 6379-6384 so pinned listeners are distinct. `scripts/run-cluster-e2e-tests.sh` reserves a random identity, validates Compose/image ownership, labels the image, and only removes matching resources. Three successful cluster runs reported `41 examples, 0 failures`; the final repeated-run cleanup probe found `containers=0 networks=0 volumes=0 images=0` for its exact project. |
| Existing execution path and non-goals | Coverage remains under `make test-cluster-e2e` / `scripts/run-cluster-e2e-tests.sh`. Changes are limited to E2E tests, fixture, image configuration, and harness; no metadata/parser/routing/retry-policy/public-API or production-runtime changes. |

## Validation

- `make test-cluster-e2e` (three runs): each passed `41 examples, 0 failures`; final run completed in 21.0214s and verified zero exact-owned Docker resources afterward.
- `make test` after the committed formatting hook: passed. This included unit suites, standalone E2E (`67 examples, 0 failures`), cluster E2E (`41 examples, 0 failures`), authenticated-cluster E2E (`3 examples, 0 failures`), and library E2E (`47 examples, 0 failures`).
- `nix-build --no-out-link nix/cluster-e2e-docker.nix --argstr imageName redis-client-133-buildcheck --argstr imageOwner buildcheck`: passed.

## Profile comparison

The required identical, warm `cabal run --enable-profiling` flush-only workload used an owned Redis 7.2 container on `127.0.0.1:62315` with `+RTS -p -s` and the short `-f` flush flag plus exact confirmation. This is a bounded zero-data fill-mode workload; no `-d` fill was used.

| Metric | Clean HEAD baseline | Final candidate | Delta |
| --- | ---: | ---: | ---: |
| Wall elapsed | 0.19s | 0.19s | 0.00s |
| RTS heap allocation | 768,192 bytes | 734,792 bytes | -33,400 bytes (-4.35%) |
| Maximum residency | 436,864 bytes | 404,968 bytes | -31,896 bytes (-7.30%) |
| Cost-centre total allocation | 424,968 bytes | 424,456 bytes | -512 bytes (-0.12%) |
| Cost-centre total time | 0.01s | 0.01s | unchanged |

Limit: this is one network round trip and one GC sample, so wall time and RTS residency are noisy at this scale. A warm-up invocation preceded each measured run. The production `redis-client` source/runtime is unchanged by this PR; no behavioral performance claim is made. All owned profile containers, profiling artifacts, and the clean baseline worktree were removed.

## Revision cycle 2 — Protocol timeout correction

Working as Protocol (Redis Protocol Engineer). This independent revision addresses the blocking unbounded `redis-cli --cluster create` path only; the PR remains a draft awaiting Lead review.

- `scripts/run-cluster-e2e-tests.sh` now runs cluster creation as `timeout 120 docker compose ... exec ... redis-cli --cluster create`; its Nix shebang explicitly provides GNU `coreutils`, so the deadline is present in the runner environment. A timeout or genuine create failure stays nonzero: the existing EXIT trap preserves the primary status while cleaning the exact run-owned Compose project and labelled image.
- `scripts/test-run-cluster-e2e-tests.sh` copies the actual runner into a repository-local disposable mock fixture and makes the create command hang. Its timeout shim verifies the production `120` argument then uses a 1-second probe deadline. It proved actual runner control flow: exit **124** in **<=5 seconds**, create reached, identical random Compose identity used for create/cleanup, and both exact-owned Compose/image resources removed.
- Focused validation: `./scripts/test-run-cluster-e2e-tests.sh` and `make test-cluster-e2e-runner` both passed with `status 124, 1-second probe deadline, exact-owned resources removed`. `nix-build --no-out-link nix/cluster-e2e-docker.nix --argstr imageName profile-baseline-cluster-e2e --argstr imageOwner profile-baseline` passed. Final `make test` passed.

### Revision profile comparison

Comparable commands used an owned disposable Redis 7.2.12 container bound to `127.0.0.1:16379`, then `cabal run --enable-profiling redis-client -- fill -h 127.0.0.1 -p 16379 -d 1 -f --confirm-flush redis://127.0.0.1:16379?tls=false&scope=single-node +RTS -p -RTS`. `-f` was supplied and targeted only that exact-owned container. Baseline: **0.66s**, **2,607,777,144 bytes** allocated. Final candidate: **0.76s**, **2,419,612,288 bytes** allocated. This short, single-run 1GB fill profile is noisy and its allocation/time values are not a performance claim; the revision changes only shell harness/test wiring, not production runtime. All profile artifacts and the exact-owned profile containers were removed.

Commit: `86b389a489043d15334472dc67baa82755f27504`.