### PR TITLE
Require path-based PR acceptance evidence

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+Closes #
+
+## Summary
+
+<!-- What changed, and why? -->
+
+## Path acceptance
+
+- [ ] **Cross-cutting change:** replace every applicable matrix prompt with impact and validation evidence.
+- [ ] **Narrow or docs-only change:** the entire matrix is **N/A** unless a row is explicitly overridden; no additional N/A explanation is required.
+
+| Path or gate | Impact and evidence, or **N/A** |
+| --- | --- |
+| Public API and exports | _Impact/evidence, or **N/A**_ |
+| Keyed paths | _Impact/evidence, or **N/A**_ |
+| Keyless paths | _Impact/evidence, or **N/A**_ |
+| Standalone paths | _Impact/evidence, or **N/A**_ |
+| Cluster paths | _Impact/evidence, or **N/A**_ |
+| Reconnect behavior | _Impact/evidence, or **N/A**_ |
+| Redirect behavior | _Impact/evidence, or **N/A**_ |
+| Live-fixture needs | _Fixture/evidence, or **N/A**_ |
+| Required specialist reviewers | _Lead, Protocol, Performance, Tester, Docs, Fact Checker, Rai, or **N/A**_ |
+| Intentionally untested paths | _List with rationale, or **N/A**_ |
+| Nix-first build | _Command/result, or **N/A**_ |
+| Targeted tests | _Command/result, or **N/A**_ |
+| Full `make test` | _Command/result, or **N/A**_ |
+| Profiling | _Comparable command/result, or **N/A**_ |

--- a/.github/tests/test_pull_request_template.py
+++ b/.github/tests/test_pull_request_template.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import re
+import unittest
+from pathlib import Path
+
+
+TEMPLATE = Path(__file__).parents[1] / "pull_request_template.md"
+REQUIRED_ROWS = (
+    "Public API and exports",
+    "Keyed paths",
+    "Keyless paths",
+    "Standalone paths",
+    "Cluster paths",
+    "Reconnect behavior",
+    "Redirect behavior",
+    "Live-fixture needs",
+    "Required specialist reviewers",
+    "Intentionally untested paths",
+    "Nix-first build",
+    "Targeted tests",
+    "Full `make test`",
+    "Profiling",
+)
+
+
+class PullRequestTemplateTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.template = TEMPLATE.read_text(encoding="utf-8")
+        cls.rows = {
+            cells[0]: cells[1]
+            for line in cls.template.splitlines()
+            if len(cells := [cell.strip() for cell in line.strip().strip("|").split("|")])
+            == 2
+        }
+
+    def test_uses_the_discoverable_github_template_location(self):
+        self.assertEqual(TEMPLATE.relative_to(TEMPLATE.parents[1]).as_posix(),
+                         ".github/pull_request_template.md")
+
+    def test_has_cross_cutting_and_low_ceremony_narrow_change_modes(self):
+        self.assertRegex(
+            self.template,
+            r"- \[ \] \*\*Cross-cutting change:\*\*",
+        )
+        self.assertRegex(
+            self.template,
+            r"- \[ \] \*\*Narrow or docs-only change:\*\*.*entire matrix is "
+            r"\*\*N/A\*\*.*no additional N/A explanation is required",
+        )
+
+    def test_every_required_prompt_is_a_two_column_row_with_na_support(self):
+        self.assertEqual(set(REQUIRED_ROWS), set(self.rows) - {"Path or gate", "---"})
+        for prompt in REQUIRED_ROWS:
+            with self.subTest(prompt=prompt):
+                self.assertRegex(self.rows[prompt], re.compile(r"\bN/A\b"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -17,5 +17,8 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-25.05
 
+    - name: Validate pull request template
+      run: python3 .github/tests/test_pull_request_template.py
+
     - name: Test
       run: make test


### PR DESCRIPTION
Closes #113

Working as Tester (Quality Engineer)

## Summary
- Adds the standard, discoverable `.github/pull_request_template.md` with a conditional path-acceptance matrix.
- Lets narrow or documentation-only changes mark the complete matrix N/A with one checkbox and no repeated explanation.
- Adds a structural regression test and runs it in the existing Tests CI workflow.

## Review requests
- **Lead:** process-scope review of the conditional evidence gate.
- **Docs:** discoverability and contributor-usability review.

## Validation evidence
- `python3 .github/tests/test_pull_request_template.py`: 3 tests passed.
- `git diff --check`: passed.
- The structural test proves the GitHub-standard template location, cross-cutting and narrow/docs-only modes, all 14 required prompts, a two-column rendered table shape, and explicit N/A support for every prompt.

## Intentional N/A gates
- `nix-build`: N/A; this changes only Markdown, its Python structural check, and CI wiring.
- Product profiling: N/A; no runtime or performance-sensitive code changed.
- `make test`: N/A locally for this template-only change; exact-head Tests CI remains required and will run the full suite.
- Live Redis/Docker fixtures: N/A; no product execution path changed.
