### PR TITLE
Automate terminal issue status labels

### DIFF
--- a/.github/ISSUE_STATUS_POLICY.md
+++ b/.github/ISSUE_STATUS_POLICY.md
@@ -1,0 +1,20 @@
+# Issue status policy
+
+Issue lifecycle automation treats `status:ready`, `status:in-progress`, and
+`status:needs-review` as active workflow statuses.
+
+- Closing an issue removes every active workflow status. This applies whether
+  the issue is closed directly or automatically when a linked pull request is
+  merged.
+- Reopening an issue with a `squad:<member>` owner removes stale active statuses
+  and assigns `status:ready`.
+- Reopening an issue without a member owner removes stale active statuses and
+  ensures the `squad` triage-inbox label is present.
+- Other labels, including ownership, priority, type, wave, retrospective, and
+  `status:blocked`, are not changed by closed-issue reconciliation.
+
+The `Issue status state` workflow exposes closed-issue reconciliation through
+manual dispatch. Every dispatch runs and logs a dry-run first. Live application
+also requires `apply_reconciliation` and an exact `owner/repository` value in
+`confirm_repository`; normal close and reopen events only update their
+triggering issue.

--- a/.github/workflows/issue-status.yml
+++ b/.github/workflows/issue-status.yml
@@ -1,0 +1,57 @@
+name: Issue status state
+
+on:
+  issues:
+    types: [closed, reopened]
+  workflow_dispatch:
+    inputs:
+      apply_reconciliation:
+        description: Remove active statuses from all closed issues
+        required: true
+        type: boolean
+        default: false
+      confirm_repository:
+        description: Exact owner/repository required when applying reconciliation
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: issue-status-${{ github.event.issue.number || 'reconciliation' }}
+  cancel-in-progress: false
+
+jobs:
+  transition:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Apply issue status transition
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 scripts/github_issue_status.py
+          --event-file "$GITHUB_EVENT_PATH"
+          --apply
+
+  reconcile:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Preview closed issue reconciliation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 scripts/github_issue_status.py --reconcile
+      - name: Apply closed issue reconciliation
+        if: inputs.apply_reconciliation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 scripts/github_issue_status.py
+          --reconcile
+          --apply
+          --confirm-repository '${{ inputs.confirm_repository }}'

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Detect if nix-shell is available
 HAS_NIX := $(shell command -v nix-shell >/dev/null 2>&1 && echo yes || echo no)
 
-.PHONY: help build test test-unit test-metadata test-credentials test-e2e-runner test-cluster-e2e-runner test-tls-fixtures test-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e clean redis-start redis-stop redis-cluster-start redis-cluster-stop profile setup
+.PHONY: help build test test-unit test-metadata test-credentials test-workflow-status test-e2e-runner test-cluster-e2e-runner test-tls-fixtures test-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e clean redis-start redis-stop redis-cluster-start redis-cluster-stop profile setup
 
 # Default target
 help:
@@ -46,7 +46,7 @@ endif
 test: test-unit test-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e
 
 # Run unit tests (hask-redis-mux tests run via nix dependency build; FillHelpersSpec from redis-client)
-test-unit: test-metadata test-credentials test-e2e-runner test-cluster-e2e-runner
+test-unit: test-metadata test-credentials test-workflow-status test-e2e-runner test-cluster-e2e-runner
 ifeq ($(HAS_NIX),yes)
 	nix-shell --run "cabal build all && cabal test all"
 else
@@ -63,6 +63,9 @@ ifeq ($(HAS_NIX),yes)
 else
 	cabal build redis-client && cabal test CredentialSpec && ./scripts/test-credential-handling.sh
 endif
+
+test-workflow-status:
+	python3 -m unittest scripts/test_github_issue_status.py
 
 test-e2e-runner:
 	./scripts/test-run-e2e-tests.sh

--- a/scripts/github_issue_status.py
+++ b/scripts/github_issue_status.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+ACTIVE_STATUS_LABELS = frozenset(
+    {"status:ready", "status:in-progress", "status:needs-review"}
+)
+
+
+def label_names(issue):
+    return {
+        label["name"] if isinstance(label, dict) else label
+        for label in issue.get("labels", [])
+    }
+
+
+def plan_transition(issue, action):
+    labels = label_names(issue)
+    remove = sorted(labels & ACTIVE_STATUS_LABELS)
+    add = []
+
+    if action == "reopened":
+        has_owner = any(
+            label.startswith("squad:") and label != "squad:"
+            for label in labels
+        )
+        if has_owner and "status:ready" not in labels:
+            add.append("status:ready")
+        elif not has_owner and "squad" not in labels:
+            add.append("squad")
+        remove = [label for label in remove if label != "status:ready"]
+    elif action != "closed":
+        raise ValueError(f"unsupported issue action: {action}")
+
+    return {"add": add, "remove": remove}
+
+
+class GitHubClient:
+    def __init__(self, repository, token):
+        self.repository = repository
+        self.token = token
+        self.api_root = f"https://api.github.com/repos/{repository}"
+
+    def request(self, method, path, body=None):
+        data = None if body is None else json.dumps(body).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self.api_root}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "redis-client-issue-status-workflow",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request) as response:
+                contents = response.read()
+        except urllib.error.HTTPError as error:
+            details = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"GitHub API {method} {path} failed: {error.code} {details}"
+            ) from error
+        return json.loads(contents) if contents else None
+
+    def closed_issues(self):
+        page = 1
+        while True:
+            query = urllib.parse.urlencode(
+                {"state": "closed", "per_page": 100, "page": page}
+            )
+            issues = self.request("GET", f"/issues?{query}")
+            if not issues:
+                return
+            for issue in issues:
+                if "pull_request" not in issue:
+                    yield issue
+            if len(issues) < 100:
+                return
+            page += 1
+
+    def add_labels(self, issue_number, labels):
+        self.request("POST", f"/issues/{issue_number}/labels", {"labels": labels})
+
+    def remove_label(self, issue_number, label):
+        encoded_label = urllib.parse.quote(label, safe="")
+        self.request("DELETE", f"/issues/{issue_number}/labels/{encoded_label}")
+
+
+def print_plan(issue, action, plan, mode):
+    print(
+        json.dumps(
+            {
+                "action": action,
+                "add": plan["add"],
+                "issue": issue["number"],
+                "mode": mode,
+                "remove": plan["remove"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def apply_plan(client, issue, action, plan, dry_run):
+    print_plan(issue, action, plan, "dry-run" if dry_run else "apply")
+    if dry_run:
+        return
+    if plan["add"]:
+        client.add_labels(issue["number"], plan["add"])
+    for label in plan["remove"]:
+        client.remove_label(issue["number"], label)
+
+
+def reconcile(client, dry_run):
+    for issue in client.closed_issues():
+        plan = plan_transition(issue, "closed")
+        if plan["add"] or plan["remove"]:
+            apply_plan(client, issue, "closed", plan, dry_run)
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="Keep GitHub issue workflow status labels consistent."
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--event-file")
+    mode.add_argument("--reconcile", action="store_true")
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"))
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument(
+        "--confirm-repository",
+        help="Required for live reconciliation; must exactly match --repository.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.repository:
+        parser.error("--repository or GITHUB_REPOSITORY is required")
+    if not args.token:
+        parser.error("--token or GITHUB_TOKEN is required")
+    if args.reconcile and args.apply and args.confirm_repository != args.repository:
+        parser.error(
+            "live reconciliation requires --confirm-repository to exactly match "
+            "--repository"
+        )
+    if args.event_file and args.confirm_repository:
+        parser.error("--confirm-repository is only valid with --reconcile")
+    return args
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    client = GitHubClient(args.repository, args.token)
+
+    if args.reconcile:
+        reconcile(client, dry_run=not args.apply)
+        return 0
+
+    with open(args.event_file, encoding="utf-8") as event_file:
+        event = json.load(event_file)
+    action = event.get("action")
+    issue = event.get("issue")
+    if action not in {"closed", "reopened"} or not issue:
+        raise ValueError("event must be a closed or reopened issue event")
+    plan = plan_transition(issue, action)
+    apply_plan(client, issue, action, plan, dry_run=not args.apply)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/github_issue_status.py
+++ b/scripts/github_issue_status.py
@@ -87,6 +87,9 @@ class GitHubClient:
                 return
             page += 1
 
+    def get_issue(self, issue_number):
+        return self.request("GET", f"/issues/{issue_number}")
+
     def add_labels(self, issue_number, labels):
         self.request("POST", f"/issues/{issue_number}/labels", {"labels": labels})
 
@@ -111,12 +114,16 @@ def print_plan(issue, action, plan, mode):
 
 
 def apply_plan(client, issue, action, plan, dry_run):
-    print_plan(issue, action, plan, "dry-run" if dry_run else "apply")
     if dry_run:
+        print_plan(issue, action, plan, "dry-run")
         return
-    if plan["add"]:
-        client.add_labels(issue["number"], plan["add"])
-    for label in plan["remove"]:
+
+    current_issue = client.get_issue(issue["number"])
+    current_plan = plan_transition(current_issue, action)
+    print_plan(current_issue, action, current_plan, "apply")
+    if current_plan["add"]:
+        client.add_labels(issue["number"], current_plan["add"])
+    for label in current_plan["remove"]:
         client.remove_label(issue["number"], label)
 
 

--- a/scripts/test_github_issue_status.py
+++ b/scripts/test_github_issue_status.py
@@ -22,16 +22,45 @@ def issue(number, labels, **extra):
 class FakeClient:
     def __init__(self, issues=()):
         self.issues = list(issues)
+        self.issue_by_number = {
+            current_issue["number"]: current_issue
+            for current_issue in self.issues
+        }
         self.added = []
         self.removed = []
 
     def closed_issues(self):
         yield from self.issues
 
+    def get_issue(self, issue_number):
+        return self.issue_by_number[issue_number]
+
     def add_labels(self, issue_number, labels):
         self.added.append((issue_number, labels))
+        current_labels = self.issue_by_number[issue_number]["labels"]
+        existing = {
+            label["name"] if isinstance(label, dict) else label
+            for label in current_labels
+        }
+        current_labels.extend(
+            {"name": label} for label in labels if label not in existing
+        )
 
     def remove_label(self, issue_number, label):
+        current_labels = self.issue_by_number[issue_number]["labels"]
+        remaining = [
+            current_label
+            for current_label in current_labels
+            if (
+                current_label["name"]
+                if isinstance(current_label, dict)
+                else current_label
+            )
+            != label
+        ]
+        if len(remaining) == len(current_labels):
+            raise AssertionError(f"label already absent: {label}")
+        self.issue_by_number[issue_number]["labels"] = remaining
         self.removed.append((issue_number, label))
 
 
@@ -113,7 +142,6 @@ class IssueStatusTransitionTests(unittest.TestCase):
         )
 
     def test_apply_preserves_non_status_labels(self):
-        client = FakeClient()
         source_issue = issue(
             16,
             [
@@ -126,6 +154,7 @@ class IssueStatusTransitionTests(unittest.TestCase):
                 "retro-action",
             ],
         )
+        client = FakeClient([source_issue])
         plan = MODULE.plan_transition(source_issue, "closed")
         with redirect_stdout(io.StringIO()):
             MODULE.apply_plan(
@@ -133,6 +162,29 @@ class IssueStatusTransitionTests(unittest.TestCase):
             )
         self.assertEqual(client.added, [])
         self.assertEqual(client.removed, [(16, "status:in-progress")])
+
+    def test_replaying_stale_event_plan_does_not_repeat_deletion(self):
+        source_issue = issue(
+            19,
+            ["status:in-progress", "squad:protocol", "priority:p2"],
+        )
+        client = FakeClient([source_issue])
+        stale_plan = MODULE.plan_transition(source_issue, "closed")
+
+        with redirect_stdout(io.StringIO()):
+            MODULE.apply_plan(
+                client, source_issue, "closed", stale_plan, dry_run=False
+            )
+            MODULE.apply_plan(
+                client, source_issue, "closed", stale_plan, dry_run=False
+            )
+
+        self.assertEqual(client.added, [])
+        self.assertEqual(client.removed, [(19, "status:in-progress")])
+        self.assertEqual(
+            MODULE.label_names(client.get_issue(19)),
+            {"squad:protocol", "priority:p2"},
+        )
 
     def test_reconciliation_dry_run_makes_no_mutations(self):
         client = FakeClient(

--- a/scripts/test_github_issue_status.py
+++ b/scripts/test_github_issue_status.py
@@ -1,0 +1,157 @@
+import importlib.util
+import io
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("github_issue_status.py")
+SPEC = importlib.util.spec_from_file_location("github_issue_status", SCRIPT_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def issue(number, labels, **extra):
+    return {
+        "number": number,
+        "labels": [{"name": label} for label in labels],
+        **extra,
+    }
+
+
+class FakeClient:
+    def __init__(self, issues=()):
+        self.issues = list(issues)
+        self.added = []
+        self.removed = []
+
+    def closed_issues(self):
+        yield from self.issues
+
+    def add_labels(self, issue_number, labels):
+        self.added.append((issue_number, labels))
+
+    def remove_label(self, issue_number, label):
+        self.removed.append((issue_number, label))
+
+
+class IssueStatusTransitionTests(unittest.TestCase):
+    def test_direct_close_removes_all_active_statuses(self):
+        plan = MODULE.plan_transition(
+            issue(
+                10,
+                [
+                    "status:ready",
+                    "status:in-progress",
+                    "status:needs-review",
+                    "squad:lead",
+                    "priority:p2",
+                ],
+            ),
+            "closed",
+        )
+        self.assertEqual(
+            plan,
+            {
+                "add": [],
+                "remove": [
+                    "status:in-progress",
+                    "status:needs-review",
+                    "status:ready",
+                ],
+            },
+        )
+
+    def test_merge_driven_close_uses_the_same_terminal_transition(self):
+        merged_pr_close = issue(
+            11,
+            ["status:needs-review", "type:maintenance", "wave:2"],
+            closed_by={"login": "merge-bot"},
+        )
+        self.assertEqual(
+            MODULE.plan_transition(merged_pr_close, "closed"),
+            {"add": [], "remove": ["status:needs-review"]},
+        )
+
+    def test_reopen_with_owner_restores_ready(self):
+        plan = MODULE.plan_transition(
+            issue(12, ["squad:tester", "priority:p1", "status:needs-review"]),
+            "reopened",
+        )
+        self.assertEqual(
+            plan,
+            {"add": ["status:ready"], "remove": ["status:needs-review"]},
+        )
+
+    def test_reopen_without_owner_is_clearly_untriaged(self):
+        plan = MODULE.plan_transition(
+            issue(13, ["squad", "priority:p2", "status:in-progress"]),
+            "reopened",
+        )
+        self.assertEqual(
+            plan,
+            {"add": [], "remove": ["status:in-progress"]},
+        )
+
+    def test_reopen_without_owner_enters_the_triage_inbox(self):
+        plan = MODULE.plan_transition(
+            issue(14, ["priority:p2", "type:maintenance"]),
+            "reopened",
+        )
+        self.assertEqual(plan, {"add": ["squad"], "remove": []})
+
+    def test_transition_is_idempotent(self):
+        closed = issue(15, ["squad:lead", "priority:p2"])
+        reopened = issue(15, ["squad:lead", "priority:p2", "status:ready"])
+        self.assertEqual(
+            MODULE.plan_transition(closed, "closed"),
+            {"add": [], "remove": []},
+        )
+        self.assertEqual(
+            MODULE.plan_transition(reopened, "reopened"),
+            {"add": [], "remove": []},
+        )
+
+    def test_apply_preserves_non_status_labels(self):
+        client = FakeClient()
+        source_issue = issue(
+            16,
+            [
+                "status:in-progress",
+                "status:blocked",
+                "squad:lead",
+                "priority:p2",
+                "type:maintenance",
+                "wave:2",
+                "retro-action",
+            ],
+        )
+        plan = MODULE.plan_transition(source_issue, "closed")
+        with redirect_stdout(io.StringIO()):
+            MODULE.apply_plan(
+                client, source_issue, "closed", plan, dry_run=False
+            )
+        self.assertEqual(client.added, [])
+        self.assertEqual(client.removed, [(16, "status:in-progress")])
+
+    def test_reconciliation_dry_run_makes_no_mutations(self):
+        client = FakeClient(
+            [
+                issue(17, ["status:ready", "squad:lead", "priority:p2"]),
+                issue(18, ["priority:p1", "type:bug"]),
+            ]
+        )
+        output = io.StringIO()
+        with redirect_stdout(output):
+            MODULE.reconcile(client, dry_run=True)
+        self.assertEqual(client.added, [])
+        self.assertEqual(client.removed, [])
+        self.assertEqual(
+            output.getvalue().strip(),
+            '{"action": "closed", "add": [], "issue": 17, '
+            '"mode": "dry-run", "remove": ["status:ready"]}',
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove active workflow statuses when an issue closes directly or through a merged PR
- restore `status:ready` for owned reopened issues and route unowned reopened issues to the `squad` triage inbox
- provide dry-run-first, confirmation-gated reconciliation for existing closed issues without changing unrelated labels
- re-fetch current labels before applying an event transition so replaying the same stale event converges without duplicate label deletion or GitHub 404

## Validation
- exact base: `9eecb26d5852103b5e308ff2d87cf4e6df175e2b`
- exact head: `5f02e5bd8c2694508aaa07752adf983fdc05e64b`
- `python3 -m unittest scripts/test_github_issue_status.py` — 9 tests passed, including applying the same stale close plan twice
- live repository reconciliation dry-run: 31 planned issue updates, zero mutations
- reconciliation apply without exact repository confirmation: rejected with exit 2
- `nix-shell -p actionlint --run 'actionlint .github/workflows/issue-status.yml'`\n- `nix-build --no-out-link`\n- `make test`\n\n## Review\nIndependent Tester re-review after the operational-idempotence revision: **APPROVED**. Lead remained locked out and did not advise or contribute.\n\nCloses #112