### PR TITLE
Document contributor bootstrap and repository layout

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,17 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "build",
+            "label": "build workspace (Nix-first)",
+            "type": "shell",
+            "command": "make build",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "build redis-client executable only (Cabal)",
             "type": "shell",
             "command": "cabal build redis-client",
             "problemMatcher": []

--- a/README.md
+++ b/README.md
@@ -351,12 +351,16 @@ make build
 ```
 
 `make build` builds both the root `redis-client` executable package and the
-`hask-redis-mux` library package, including the E2E executables when Nix is
-available. The direct system-Cabal equivalent is:
+`hask-redis-mux` library package. With Nix available it also enables the E2E
+executables by running:
 
 ```sh
 cabal build all -fe2e
 ```
+
+Without Nix, `make build` falls back to the system GHC and Cabal on `PATH` and
+runs `cabal build all`; this builds both packages without enabling the E2E
+executables.
 
 ### Running Tests
 
@@ -373,20 +377,21 @@ cabal test all
 ```
 
 `make test-unit` is broader: in addition to all Cabal test suites, it checks
-generated Redis command metadata, credential handling, and the E2E runner
-scripts.
+generated Redis command metadata, credential handling, GitHub issue workflow
+status, and the E2E runner scripts.
 
 **Full test suite** (requires Docker, the Docker Compose plugin, and Nix):
 ```sh
 make test
 ```
 
-The full target runs the unit/repository checks plus the standalone, cluster,
-authenticated-cluster, and library end-to-end suites. Individual Docker suites
-remain available when narrowing a failure:
+The full target runs the unit/repository checks plus the standalone, direct TLS,
+cluster, authenticated-cluster, and library end-to-end suites. Individual
+Docker suites remain available when narrowing a failure:
 
 ```sh
 make test-e2e
+make test-direct-tls-e2e
 make test-cluster-e2e
 make test-authenticated-cluster-e2e
 make test-library-e2e

--- a/README.md
+++ b/README.md
@@ -289,33 +289,107 @@ in
 
 ## Development
 
-### Building
+### Contributor prerequisites
+
+The supported development environment is Nix-first. Before the first build,
+install:
+
+- Git, Make, and [Nix](https://nixos.org/download/) with flakes enabled.
+- Docker with the Compose plugin if you will run the full end-to-end suite.
+- [direnv](https://direnv.net/) is optional; the tracked `.envrc` enters the
+  same flake development shell as `nix develop`.
+
+The Nix development shell supplies GHC, Cabal, Haskell Language Server,
+`stylish-haskell`, and native dependencies such as zlib. The executable also
+links against readline. If you cannot use Nix, install a C toolchain, GHC,
+Cabal, readline development headers, and zlib development headers before
+building (for example, `build-essential libreadline-dev zlib1g-dev` on
+Debian/Ubuntu).
+
+### First-time setup
+
+Clone the repository, enter the development environment, and run the repository
+setup target once:
 
 ```sh
-# Using Makefile (handles Nix if available)
+git clone https://github.com/sspeaks/redis-client.git
+cd redis-client
+
+# Choose one environment entry point:
+nix develop
+# Or, with direnv installed:
+direnv allow
+
+make setup
+```
+
+`nix develop` provides the reproducible compiler, tools, and native libraries;
+`direnv allow` automatically enters that same shell when you change into the
+repository. `make setup` is a separate one-time repository bootstrap: it points
+Git at the tracked `.githooks/` directory and updates Cabal's package index.
+Entering the Nix shell also configures the hook path, but `make setup` remains
+the explicit bootstrap command and prepares Cabal for workspace builds.
+
+For a system-Cabal setup without Nix, install the native dependencies above and
+then run `make setup`. On Debian/Ubuntu the target can install
+`libreadline-dev`; install the remaining compiler and zlib prerequisites
+yourself first. In this fallback, `make` targets use the GHC and Cabal available
+on `PATH`.
+
+### Build
+
+For the reproducible Nix package build:
+
+```sh
+nix-build --no-out-link
+```
+
+For a faster workspace build while developing:
+
+```sh
 make build
+```
 
-# Or directly with Cabal
-cabal build
+`make build` builds both the root `redis-client` executable package and the
+`hask-redis-mux` library package, including the E2E executables when Nix is
+available. The direct system-Cabal equivalent is:
 
-# Or with Nix
-nix-build
+```sh
+cabal build all -fe2e
 ```
 
 ### Running Tests
 
-**Unit tests** (no Redis required):
+**Unit and repository checks** (no running Redis required):
 ```sh
 make test-unit
-# or
-cabal test RespSpec ClusterSpec ClusterCommandSpec MultiplexerSpec MultiplexPoolSpec
 ```
 
-**End-to-end tests** (requires Docker and Nix):
+The system-Cabal fallback for the Haskell unit suites is:
+
 ```sh
-make test-e2e               # Standalone Redis E2E
-make test-cluster-e2e       # Cluster E2E
-make test                   # Run all tests
+cabal build all
+cabal test all
+```
+
+`make test-unit` is broader: in addition to all Cabal test suites, it checks
+generated Redis command metadata, credential handling, and the E2E runner
+scripts.
+
+**Full test suite** (requires Docker, the Docker Compose plugin, and Nix):
+```sh
+make test
+```
+
+The full target runs the unit/repository checks plus the standalone, cluster,
+authenticated-cluster, and library end-to-end suites. Individual Docker suites
+remain available when narrowing a failure:
+
+```sh
+make test-e2e
+make test-cluster-e2e
+make test-authenticated-cluster-e2e
+make test-library-e2e
 ```
 
 **Manual testing with local Redis:**
@@ -366,13 +440,24 @@ rm -f *.hp *.prof *.ps *.aux *.stat
 
 ## Project Structure
 
-- `app/` - Main executable (cli, fill, tunnel modes)
-- `lib/resp/` - RESP protocol implementation
-- `lib/client/` - Connection management (plaintext and TLS)
-- `lib/redis-command-client/` - Redis command execution
-- `lib/cluster/` - Cluster support, connection pooling, multiplexer, and standalone client
-- `lib/crc16/` - CRC16 for hash slot calculation
-- `test/` - Unit and E2E tests
+- `redis-client.cabal` - Root executable package definition.
+- `app/` - `redis-client` executable sources for CLI, fill, and tunnel modes.
+- `test/` - Root executable unit tests and Docker E2E test programs.
+- `hask-redis-mux/hask-redis-mux.cabal` - Public Redis client library package.
+- `hask-redis-mux/lib/resp/` - RESP protocol implementation.
+- `hask-redis-mux/lib/client/` - Plaintext and TLS connection management.
+- `hask-redis-mux/lib/redis-command-client/` - Redis command execution.
+- `hask-redis-mux/lib/cluster/` - Cluster routing, pools, multiplexers, and
+  standalone client support.
+- `hask-redis-mux/lib/crc16/` - CRC16 hash-slot implementation.
+- `hask-redis-mux/lib/redis/` - Public `Database.Redis` facade.
+- `hask-redis-mux/test/` and `hask-redis-mux/bench/` - Library tests and
+  benchmarks.
+- `Makefile`, `flake.nix`, `shell.nix`, and `default.nix` - Supported
+  development and Nix packaging entry points.
+- `scripts/` and `docker/` - Repository checks and owned Docker E2E fixtures.
+- `.githooks/` - Tracked contributor hooks enabled by `make setup` and the Nix
+  development shell.
 
 ## License
 


### PR DESCRIPTION
## Summary
- start contributor onboarding with actual prerequisites and the first-time `make setup` bootstrap
- distinguish `nix develop`/direnv, Nix package builds, workspace builds, and the system-Cabal fallback
- document unit/repository checks and every Docker/Nix E2E path
- correct the repository map for the root executable package and `hask-redis-mux` sources
- make the VS Code default build run the supported Nix-first workspace target while retaining an explicitly narrow executable-only task
- correct the final contributor guidance for the merged direct-TLS E2E target, workflow-status check, and actual non-Nix `make build` fallback

## Exact-head evidence
- Actual merge base with current `origin/main`: `25dd702be8778b9ec35fa2a7fb787995f94e290e`
- Revision head: `4cf938973afe684c52e3c6fa95d197fd76c54bc3`
- Relative PR diff remains exclusively `README.md` and `.vscode/tasks.json`.
- This revision is README-only: `README.md` has 12 insertions and 7 deletions; accepted setup, package-layout, and VS Code task changes are unchanged.

## Validation
- `make -n build` expands to the Nix path `nix-shell --run "cabal build all -fe2e"`.
- `make HAS_NIX=no -n build` expands to the documented system-Cabal fallback `cabal build all`.
- `make -n test-unit` includes metadata, credential, workflow-status, E2E-runner, cluster-E2E-runner, and Cabal test commands.
- `make -n test` includes standalone, direct-TLS, cluster, authenticated-cluster, and library E2E runners.
- `make test-workflow-status` passed: 9 tests.
- `make test-tls-fixtures` passed.
- `python3 .github/tests/test_pull_request_template.py` passed: 3 tests.
- The prior exact-head `nix-build --no-out-link` and full local `make test` evidence remains applicable because this revision changes only README prose.
- Exact-new-head CI passed: [GitHub Actions run `34297812286`, job `102298119965`](https://github.com/sspeaks/redis-client/actions/runs/34297812286/job/102298119965), 10m53s.

## Review
- Lead re-review requested for exact head `4cf938973afe684c52e3c6fa95d197fd76c54bc3`.
- Protocol, Docs, Tester, and Fact Checker are locked out of this artifact and did not participate in this revision.
- PR remains draft and unmerged.

Closes #86
