### PR TITLE
Gate smart-routing API compatibility and performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
     *   MOVED, ASK, TRYAGAIN, CLUSTERDOWN, CROSSSLOT, and ordinary Redis errors now share one strict reply classifier across keyed, keyless, and redirected paths.
     *   TRYAGAIN retries the current route with bounded saturating exponential backoff; CLUSTERDOWN performs a best-effort refresh before bounded backoff without replacing the Redis cause when refresh validation or I/O fails.
     *   CROSSSLOT and ordinary server errors return immediately as typed `ClusterError` values, preserving the complete server error payload.
+*   **Strict smart routing**
+    *   Smart cluster routing now validates commands, subcommands, and argument counts against the pinned Redis 7.2 metadata before dispatch.
+    *   Unknown or malformed commands and cross-slot multi-key requests are rejected instead of falling through to first-argument routing.
+    *   The exported `keylessCommands` and `requiresKeyCommands` routing lists are now generated from the pinned metadata snapshot.
 
 ## 0.6.0.0 -- 2026-02-13
 

--- a/hask-redis-mux/bench/SmartProxyRoutingBench.hs
+++ b/hask-redis-mux/bench/SmartProxyRoutingBench.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import qualified Data.ByteString                 as BS
+import           Database.Redis.Cluster.Commands (CommandRouting (..),
+                                                  classifyCommand)
+import           GHC.Clock                       (getMonotonicTimeNSec)
+import           System.Environment              (getArgs)
+import           Text.Printf                     (printf)
+
+data Scenario = Scenario
+    { scenarioName      :: String
+    , scenarioCommand   :: BS.ByteString
+    , scenarioArguments :: [BS.ByteString]
+    , scenarioExpected  :: ExpectedRouting
+    }
+
+data ExpectedRouting
+    = ExpectedKeyless
+    | ExpectedKey BS.ByteString
+    | ExpectedCrossSlot
+
+scenarios :: [Scenario]
+scenarios =
+    [ Scenario "keyless" "PING" [] ExpectedKeyless
+    , Scenario "fixed-key" "GET" ["{route}:fixed"] (ExpectedKey "{route}:fixed")
+    , Scenario
+        "movable-key"
+        "EVAL"
+        ["return redis.call('GET', KEYS[1])", "1", "{route}:movable"]
+        (ExpectedKey "{route}:movable")
+    , Scenario
+        "same-slot-multi-key"
+        "MGET"
+        ["{route}:one", "{route}:two", "{route}:three"]
+        (ExpectedKey "{route}:one")
+    , Scenario
+        "rejected-cross-slot"
+        "MGET"
+        ["{route-a}:one", "{route-b}:two"]
+        ExpectedCrossSlot
+    ]
+
+main :: IO ()
+main = do
+    args <- getArgs
+    let iterations =
+            case args of
+                [iterationText] -> read iterationText
+                _               -> 1000000
+    started <- getMonotonicTimeNSec
+    checksum <- loop iterations 0
+    finished <- getMonotonicTimeNSec
+    let operations = iterations * length scenarios
+        seconds = fromIntegral (finished - started) / 1.0e9 :: Double
+    printf
+        "iterations=%d scenarios=%d operations=%d checksum=%d elapsed_s=%.6f throughput_ops_s=%.2f\n"
+        iterations
+        (length scenarios)
+        operations
+        checksum
+        seconds
+        (fromIntegral operations / seconds :: Double)
+
+loop :: Int -> Int -> IO Int
+loop !remaining !checksum
+    | remaining <= 0 = pure checksum
+    | otherwise = do
+        nextChecksum <- foldScenarios scenarios checksum
+        loop (remaining - 1) nextChecksum
+
+foldScenarios :: [Scenario] -> Int -> IO Int
+foldScenarios [] !checksum = pure checksum
+foldScenarios (scenario : remaining) !checksum = do
+    contribution <- runScenario scenario
+    foldScenarios remaining (checksum + contribution)
+
+runScenario :: Scenario -> IO Int
+runScenario scenario =
+    case (scenarioExpected scenario, classifyCommand (scenarioCommand scenario) (scenarioArguments scenario)) of
+        (ExpectedKeyless, KeylessRoute) -> pure 1
+        (ExpectedKey expected, KeyedRoute actual)
+            | actual == expected -> pure (BS.length actual)
+        (ExpectedCrossSlot, CommandError message)
+            | message == "CROSSSLOT Keys in request don't hash to the same slot" ->
+                pure (length message)
+        (_, actual) ->
+            fail $
+                "scenario " <> scenarioName scenario
+                    <> " produced unexpected routing: "
+                    <> renderRouting actual
+
+renderRouting :: CommandRouting -> String
+renderRouting KeylessRoute       = "KeylessRoute"
+renderRouting (KeyedRoute key)   = "KeyedRoute " <> show key
+renderRouting (CommandError err) = "CommandError " <> show err

--- a/hask-redis-mux/hask-redis-mux.cabal
+++ b/hask-redis-mux/hask-redis-mux.cabal
@@ -174,6 +174,15 @@ benchmark GrammarProfile
     build-depends:    bytestring >=0.12 && <0.13
                     , cluster
 
+benchmark SmartProxyRoutingBench
+    import:           defaults
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   bench
+    main-is:          SmartProxyRoutingBench.hs
+    ghc-options:      -threaded -rtsopts
+    build-depends:    bytestring >=0.12 && <0.13
+                    , cluster
+
 -- ---------------------------------------------------------------------------
 -- Test suites
 -- ---------------------------------------------------------------------------
@@ -210,7 +219,8 @@ test-suite PublicApiSpec
     import:           test-defaults
     type:             exitcode-stdio-1.0
     main-is:          PublicApiSpec.hs
-    build-depends:    directory >=1.3 && <1.4
+    build-depends:    cluster
+                    , directory >=1.3 && <1.4
                     , redis
 
 test-suite ClusterSpec

--- a/hask-redis-mux/test/PublicApiSpec.hs
+++ b/hask-redis-mux/test/PublicApiSpec.hs
@@ -4,14 +4,66 @@
 
 module Main (main) where
 
-import           Control.Exception (displayException, toException, try)
-import           Control.Monad     (filterM)
+import           Control.Exception               (displayException, toException,
+                                                  try)
+import           Control.Monad                   (filterM)
 import           Database.Redis
-import           System.Directory  (doesFileExist)
+import qualified Database.Redis.Cluster.Client   as ClusterClient
+import qualified Database.Redis.Cluster.Commands as ClusterCommands
+import           System.Directory                (doesFileExist)
 import           Test.Hspec
 
 main :: IO ()
 main = hspec $ describe "Database.Redis timeout-aware public API" $ do
+  it "keeps Database.Redis cluster call sites source compatible" $ do
+    let createClient
+          :: ClusterConfig
+          -> Connector PlainTextClient
+          -> IO (ClusterClient PlainTextClient)
+        createClient = createClusterClient
+        runCommand
+          :: ClusterClient PlainTextClient
+          -> ClusterCommandClient PlainTextClient value
+          -> IO value
+        runCommand = runClusterCommandClient
+    createClient `seq` runCommand `seq` (pure () :: IO ())
+
+  it "keeps Database.Redis.Cluster.Client call sites source compatible" $ do
+    let createClient
+          :: ClusterConfig
+          -> Connector PlainTextClient
+          -> IO (ClusterClient PlainTextClient)
+        createClient = ClusterClient.createClusterClient
+        runCommand
+          :: ClusterClient PlainTextClient
+          -> ClusterCommandClient PlainTextClient value
+          -> IO value
+        runCommand = ClusterClient.runClusterCommandClient
+        runKeyed
+          :: ClusterClient PlainTextClient
+          -> ByteString
+          -> [ByteString]
+          -> IO (Either ClusterError RespData)
+        runKeyed = ClusterClient.executeKeyedClusterCommand
+        runKeyless
+          :: ClusterClient PlainTextClient
+          -> RedisCommandClient PlainTextClient RespData
+          -> IO (Either ClusterError RespData)
+        runKeyless = ClusterClient.executeKeylessClusterCommand
+    createClient `seq` runCommand `seq` runKeyed `seq` runKeyless
+      `seq` (pure () :: IO ())
+
+  it "keeps Database.Redis.Cluster.Commands routing call sites source compatible" $ do
+    isKeylessRoute (ClusterCommands.classifyCommand "PING" [])
+      `shouldBe` True
+    isKeyedRoute
+      "{api}:key"
+      (ClusterCommands.classifyCommand "GET" ["{api}:key"])
+      `shouldBe` True
+    length
+      (ClusterCommands.keylessCommands <> ClusterCommands.requiresKeyCommands)
+      `shouldBe` 392
+
   it "exports the migration-compatible ordinary cluster error" $ do
     RedisCommandError "ERR full server cause"
       `shouldBe` RedisCommandError "ERR full server cause"
@@ -145,3 +197,11 @@ findSource candidates = do
   case matches of
     path : _ -> return path
     [] -> expectationFailure "Could not locate public API source" >> fail "unreachable"
+
+isKeylessRoute :: ClusterCommands.CommandRouting -> Bool
+isKeylessRoute ClusterCommands.KeylessRoute = True
+isKeylessRoute _                            = False
+
+isKeyedRoute :: ByteString -> ClusterCommands.CommandRouting -> Bool
+isKeyedRoute expected (ClusterCommands.KeyedRoute actual) = actual == expected
+isKeyedRoute _ _                                          = False


### PR DESCRIPTION
Closes #134

Working as Performance (Performance Engineer)

## Summary
- Adds `SmartProxyRoutingBench`, a deterministic full-pipeline benchmark covering metadata lookup, grammar validation, and key extraction for keyless, fixed-key, movable-key, same-slot multi-key, and rejected cross-slot frames.
- Extends `PublicApiSpec` with compile-time call-site witnesses for `Database.Redis`, `Database.Redis.Cluster.Client`, and `Database.Redis.Cluster.Commands`.
- Keeps production routing, metadata, retry semantics, documentation, and public API behavior unchanged.

## Profile evidence

Exact base: `52998813a139c694fc3a6cd07c262854ccc169b4`

Candidate head: `e99602fd7d369cec85cc9d183f64ccaccbb1896a`

The exact same benchmark source was injected into the detached base worktree and used by the candidate (SHA-256 `0e04832ae90a95b3b7a8f944ea44290b8fe77ba143ae10aa487788c784133477`). Each measured run used:

```console
cabal run --enable-profiling bench:SmartProxyRoutingBench -- 2000000 +RTS -p -s -RTS
```

The table reports the median of three warmed, interleaved runs per head. Each run classified 10,000,000 frames.

| Metric | Exact base | Candidate | Delta |
| --- | ---: | ---: | ---: |
| Benchmark elapsed | 16.785812s | 16.527837s | -0.257975s (-1.537%) |
| RTS heap allocation | 64,798,767,024 bytes | 64,798,767,024 bytes | 0 bytes (0.000%) |
| Maximum residency | 102,960 bytes | 102,960 bytes | 0 bytes (0.000%) |

Warm elapsed samples were base `16.358451s`, `16.785812s`, `17.149383s`; candidate `17.022117s`, `16.010898s`, `16.527837s`. The small elapsed improvement is within normal host noise and is not claimed as a production optimization. Allocation and retained memory are unchanged.

The first harness iteration exposed a lazy benchmark checksum that retained about 931 MB on both heads. The committed harness uses strict accumulators; matched reruns reduced maximum residency to 102,960 bytes without changing the routing workload. All `.prof` and profiling build artifacts, plus the detached baseline worktree, were removed.

## Validation
- `nix-build --no-out-link`: passed.
- `nix-shell --run "cabal test test:PublicApiSpec test:CommandGrammarSpec --test-show-details=direct"`: passed (`PublicApiSpec` 11 examples; `CommandGrammarSpec` 27 examples).
- `make test`: passed, including unit, standalone E2E, cluster E2E, authenticated-cluster E2E, and library E2E suites.
- The first full-suite attempt waited for a separately owned Redis E2E fixture to release port 6379; a subsequent run was transiently killed with status 137 during the 1 GB fill cases. After owned cleanup and with no competing Docker workload, the unchanged full suite passed.
- Merged current `origin/main` at `edac7100becc1230841df3774532f3e415749718`. PR #149 changed only `.github/pull_request_template.md`, `.github/tests/test_pull_request_template.py`, and `.github/workflows/runTests.yml`; the benchmark/API diff and production code are unchanged, so profiling was not rerun.

## Review requests
- **Tester:** verify benchmark scenario coverage, source-compatibility witnesses, and full-suite evidence.
- **Lead:** verify the public API compatibility boundary and that the final gate does not expand metadata, routing, or retry semantics.

This PR is intentionally draft and must not be marked ready or merged until both reviews approve the gate.
