### PR TITLE
test: add direct validated TLS end-to-end coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@
 # Detect if nix-shell is available
 HAS_NIX := $(shell command -v nix-shell >/dev/null 2>&1 && echo yes || echo no)
 
-.PHONY: help build test test-unit test-metadata test-credentials test-e2e-runner test-cluster-e2e-runner test-tls-fixtures test-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e clean redis-start redis-stop redis-cluster-start redis-cluster-stop profile setup
+.PHONY: help build test test-unit test-metadata test-credentials test-e2e-runner test-cluster-e2e-runner test-tls-fixtures test-e2e test-direct-tls-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e clean redis-start redis-stop redis-cluster-start redis-cluster-stop profile setup
 
 # Default target
 help:
-	@echo "Targets: setup build test test-unit test-e2e-runner test-e2e test-cluster-e2e test-authenticated-cluster-e2e redis-start redis-stop redis-cluster-start redis-cluster-stop profile clean"
+	@echo "Targets: setup build test test-unit test-e2e-runner test-e2e test-direct-tls-e2e test-cluster-e2e test-authenticated-cluster-e2e redis-start redis-stop redis-cluster-start redis-cluster-stop profile clean"
 
 # Setup dependencies (run once in new environment)
 setup:
@@ -43,7 +43,7 @@ else
 endif
 
 # Run all tests
-test: test-unit test-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e
+test: test-unit test-e2e test-direct-tls-e2e test-cluster-e2e test-authenticated-cluster-e2e test-library-e2e
 
 # Run unit tests (hask-redis-mux tests run via nix dependency build; FillHelpersSpec from redis-client)
 test-unit: test-metadata test-credentials test-e2e-runner test-cluster-e2e-runner
@@ -86,6 +86,18 @@ test-e2e: test-tls-fixtures
 		exit 1; \
 	fi
 	./scripts/run-e2e-tests.sh
+
+# Run direct standalone and cluster TLS end-to-end tests with certificate validation.
+test-direct-tls-e2e: test-tls-fixtures
+	@if ! command -v docker >/dev/null 2>&1; then \
+		echo "Error: docker is not installed or not in PATH"; \
+		exit 1; \
+	fi
+	@if ! command -v nix-build >/dev/null 2>&1; then \
+		echo "Error: nix-build is not installed or not in PATH"; \
+		exit 1; \
+	fi
+	./scripts/run-direct-tls-e2e-tests.sh
 
 # Run cluster end-to-end tests with Docker
 test-cluster-e2e:

--- a/default.nix
+++ b/default.nix
@@ -35,6 +35,12 @@ rec {
     (pkgs.lib.flip pkgs.haskell.lib.setBuildTargets [ "AuthenticatedClusterEndToEnd" ])
   ];
 
+  justStaticDirectTLSEndToEnd = pkgs.lib.pipe e2ePackageWithFlag [
+    pkgs.haskell.lib.justStaticExecutables
+    pkgs.haskell.lib.dontCheck
+    (pkgs.lib.flip pkgs.haskell.lib.setBuildTargets [ "DirectTLSEndToEnd" ])
+  ];
+
   justStaticLibraryEndToEnd = pkgs.lib.pipe e2ePackageWithFlag [
     pkgs.haskell.lib.justStaticExecutables
     pkgs.haskell.lib.dontCheck

--- a/docker/direct-tls-e2e/docker-compose.yml
+++ b/docker/direct-tls-e2e/docker-compose.yml
@@ -1,0 +1,185 @@
+services:
+  standalone:
+    image: redis:7.2.12
+    hostname: standalone-target.local
+    user: "${REDIS_TLS_CERT_UID:?Set REDIS_TLS_CERT_UID}:${REDIS_TLS_CERT_GID:?Set REDIS_TLS_CERT_GID}"
+    volumes:
+      - ${REDIS_TLS_CERT_DIR:?Set REDIS_TLS_CERT_DIR}:/certs:ro
+    command:
+      - redis-server
+      - --save
+      - ""
+      - --appendonly
+      - "no"
+      - --bind
+      - 0.0.0.0
+      - --port
+      - "6379"
+      - --tls-port
+      - "6380"
+      - --tls-cert-file
+      - /certs/redis-server.crt
+      - --tls-key-file
+      - /certs/redis-server.key
+      - --tls-ca-cert-file
+      - /certs/redis-ca.crt
+      - --tls-auth-clients
+      - "no"
+    networks:
+      default:
+        aliases:
+          - standalone-target.local
+          - standalone.redis.test
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -h standalone-target.local -p 6379 ping | grep -qx PONG"]
+      interval: 1s
+      timeout: 1s
+      retries: 30
+      start_period: 2s
+
+  cluster1:
+    image: redis:7.2.12
+    hostname: cluster-node1.local
+    user: "${REDIS_TLS_CERT_UID:?Set REDIS_TLS_CERT_UID}:${REDIS_TLS_CERT_GID:?Set REDIS_TLS_CERT_GID}"
+    volumes:
+      - ${REDIS_TLS_CERT_DIR:?Set REDIS_TLS_CERT_DIR}:/certs:ro
+    tmpfs:
+      - /data:uid=${REDIS_TLS_CERT_UID},gid=${REDIS_TLS_CERT_GID},mode=0700
+    command: &cluster-command
+      - redis-server
+      - --save
+      - ""
+      - --appendonly
+      - "no"
+      - --bind
+      - 0.0.0.0
+      - --port
+      - "6379"
+      - --tls-port
+      - "6380"
+      - --tls-cert-file
+      - /certs/redis-server.crt
+      - --tls-key-file
+      - /certs/redis-server.key
+      - --tls-ca-cert-file
+      - /certs/redis-ca.crt
+      - --tls-auth-clients
+      - "no"
+      - --cluster-enabled
+      - "yes"
+      - --cluster-config-file
+      - /data/nodes.conf
+      - --cluster-node-timeout
+      - "5000"
+      - --cluster-announce-port
+      - "6379"
+      - --cluster-announce-tls-port
+      - "6380"
+      - --cluster-announce-bus-port
+      - "16379"
+    networks:
+      default:
+        aliases:
+          - cluster-node1.local
+    healthcheck: &cluster-healthcheck
+      test: ["CMD-SHELL", "redis-cli --tls --insecure -h \"$${HOSTNAME}\" -p 6380 ping | grep -qx PONG"]
+      interval: 1s
+      timeout: 1s
+      retries: 30
+      start_period: 2s
+
+  cluster2:
+    image: redis:7.2.12
+    hostname: cluster-node2.local
+    user: "${REDIS_TLS_CERT_UID:?Set REDIS_TLS_CERT_UID}:${REDIS_TLS_CERT_GID:?Set REDIS_TLS_CERT_GID}"
+    volumes:
+      - ${REDIS_TLS_CERT_DIR:?Set REDIS_TLS_CERT_DIR}:/certs:ro
+    tmpfs:
+      - /data:uid=${REDIS_TLS_CERT_UID},gid=${REDIS_TLS_CERT_GID},mode=0700
+    command:
+      - redis-server
+      - --save
+      - ""
+      - --appendonly
+      - "no"
+      - --bind
+      - 0.0.0.0
+      - --port
+      - "6379"
+      - --tls-port
+      - "6380"
+      - --tls-cert-file
+      - /certs/redis-server.crt
+      - --tls-key-file
+      - /certs/redis-server.key
+      - --tls-ca-cert-file
+      - /certs/redis-ca.crt
+      - --tls-auth-clients
+      - "no"
+      - --cluster-enabled
+      - "yes"
+      - --cluster-config-file
+      - /data/nodes.conf
+      - --cluster-node-timeout
+      - "5000"
+      - --cluster-announce-port
+      - "6379"
+      - --cluster-announce-tls-port
+      - "6380"
+      - --cluster-announce-bus-port
+      - "16379"
+    networks:
+      default:
+        aliases:
+          - cluster-node2.local
+    healthcheck: *cluster-healthcheck
+
+  cluster3:
+    image: redis:7.2.12
+    hostname: cluster-node3.local
+    user: "${REDIS_TLS_CERT_UID:?Set REDIS_TLS_CERT_UID}:${REDIS_TLS_CERT_GID:?Set REDIS_TLS_CERT_GID}"
+    volumes:
+      - ${REDIS_TLS_CERT_DIR:?Set REDIS_TLS_CERT_DIR}:/certs:ro
+    tmpfs:
+      - /data:uid=${REDIS_TLS_CERT_UID},gid=${REDIS_TLS_CERT_GID},mode=0700
+    command:
+      - redis-server
+      - --save
+      - ""
+      - --appendonly
+      - "no"
+      - --bind
+      - 0.0.0.0
+      - --port
+      - "6379"
+      - --tls-port
+      - "6380"
+      - --tls-cert-file
+      - /certs/redis-server.crt
+      - --tls-key-file
+      - /certs/redis-server.key
+      - --tls-ca-cert-file
+      - /certs/redis-ca.crt
+      - --tls-auth-clients
+      - "no"
+      - --cluster-enabled
+      - "yes"
+      - --cluster-config-file
+      - /data/nodes.conf
+      - --cluster-node-timeout
+      - "5000"
+      - --cluster-announce-port
+      - "6379"
+      - --cluster-announce-tls-port
+      - "6380"
+      - --cluster-announce-bus-port
+      - "16379"
+    networks:
+      default:
+        aliases:
+          - cluster-node3.local
+    healthcheck: *cluster-healthcheck
+
+networks:
+  default:
+    driver: bridge

--- a/nix/direct-tls-e2e-docker.nix
+++ b/nix/direct-tls-e2e-docker.nix
@@ -1,0 +1,21 @@
+{ pkgs ? import <nixpkgs> { }
+, imageName ? "directTlsE2eTests"
+, imageTag ? "latest"
+, imageOwner ? ""
+}:
+let pack = (import ../default.nix { }).justStaticDirectTLSEndToEnd;
+in pkgs.dockerTools.buildImage {
+  name = imageName;
+  tag = imageTag;
+  contents = [ pack pkgs.cacert ];
+  config = {
+    Cmd = [ "${pack}/bin/DirectTLSEndToEnd" ];
+    Env = [
+      "SSL_CERT_FILE=/certs/redis-ca.crt"
+      "SYSTEM_CERTIFICATE_PATH=/certs/redis-ca.crt"
+    ];
+    Labels = {
+      "com.redis-client.e2e.owner" = imageOwner;
+    };
+  };
+}

--- a/redis-client.cabal
+++ b/redis-client.cabal
@@ -138,7 +138,7 @@ test-suite StructuredConcurrencySpec
 -- ---------------------------------------------------------------------------
 
 flag e2e
-    description: Build end-to-end test executables (EndToEnd, ClusterEndToEnd, LibraryE2E)
+    description: Build end-to-end test executables
     default:     False
     manual:      True
 
@@ -200,6 +200,20 @@ executable AuthenticatedClusterEndToEnd
     main-is:          AuthenticatedClusterE2E.hs
     hs-source-dirs:   test
     build-depends:    bytestring
+                    , containers
+                    , hask-redis-mux
+                    , hspec
+                    , mtl
+                    , stm
+
+executable DirectTLSEndToEnd
+    import:           exe-defaults
+    if !flag(e2e)
+        buildable: False
+    main-is:          DirectTLSE2E.hs
+    hs-source-dirs:   test
+    build-depends:    async
+                    , bytestring
                     , containers
                     , hask-redis-mux
                     , hspec

--- a/scripts/generate-test-tls-certs.sh
+++ b/scripts/generate-test-tls-certs.sh
@@ -67,7 +67,7 @@ cat >"$CERT_DIR/redis-server.ext" <<'EOF'
 basicConstraints=critical,CA:FALSE
 keyUsage=critical,digitalSignature,keyEncipherment
 extendedKeyUsage=serverAuth
-subjectAltName=DNS:redis.local
+subjectAltName=DNS:redis.local,DNS:standalone.redis.test,DNS:cluster.redis.test
 EOF
 
 if ! "$OPENSSL_BIN" x509 \
@@ -85,7 +85,22 @@ if ! "$OPENSSL_BIN" x509 \
 fi
 
 rm -f "$CERT_DIR/redis-server.csr" "$CERT_DIR/redis-server.ext" "$CERT_DIR/redis-ca.srl"
+
+if ! "$OPENSSL_BIN" req \
+  -x509 \
+  -newkey rsa:2048 \
+  -sha256 \
+  -nodes \
+  -days 1 \
+  -keyout "$CERT_DIR/untrusted-ca.key" \
+  -out "$CERT_DIR/untrusted-ca.crt" \
+  -subj "/CN=redis-client untrusted ephemeral test CA" >/dev/null 2>&1; then
+  echo "Error: failed to generate the untrusted ephemeral test CA." >&2
+  exit 1
+fi
+
 chmod 600 "$CERT_DIR/redis-ca.key" "$CERT_DIR/redis-server.key"
-chmod 644 "$CERT_DIR/redis-ca.crt" "$CERT_DIR/redis-server.crt"
+chmod 600 "$CERT_DIR/untrusted-ca.key"
+chmod 644 "$CERT_DIR/redis-ca.crt" "$CERT_DIR/redis-server.crt" "$CERT_DIR/untrusted-ca.crt"
 
 printf '%s\n' "$CERT_DIR"

--- a/scripts/run-direct-tls-e2e-tests.sh
+++ b/scripts/run-direct-tls-e2e-tests.sh
@@ -1,0 +1,200 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -p bash openssl coreutils redis gnugrep -i bash
+# shellcheck shell=bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$REPO_ROOT/docker/direct-tls-e2e/docker-compose.yml"
+TLS_RUNTIME_ROOT="$REPO_ROOT/docker/standalone/.runtime"
+TLS_CERT_DIR=""
+RUN_STATE_DIR=""
+RUN_TOKEN=""
+PROJECT_NAME=""
+E2E_IMAGE_NAME=""
+E2E_IMAGE_TAG="latest"
+E2E_IMAGE=""
+IMAGE_OWNER_LABEL="com.redis-client.e2e.owner"
+IMAGE_OWNERSHIP_ESTABLISHED=0
+COMPOSE_OWNERSHIP_ESTABLISHED=0
+COMPOSE=()
+
+reserve_run_identity() {
+  local candidate
+  local attempts=0
+
+  umask 077
+  mkdir -p "$TLS_RUNTIME_ROOT"
+  chmod 700 "$TLS_RUNTIME_ROOT"
+  while [[ "$attempts" -lt 10 ]]; do
+    candidate="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+    if [[ "$candidate" =~ ^[0-9a-f]{32}$ ]] \
+      && mkdir "$TLS_RUNTIME_ROOT/direct-tls.$candidate" 2>/dev/null; then
+      RUN_TOKEN="$candidate"
+      RUN_STATE_DIR="$TLS_RUNTIME_ROOT/direct-tls.$candidate"
+      PROJECT_NAME="redis-client-direct-tls-e2e-$RUN_TOKEN"
+      E2E_IMAGE_NAME="redis-client-direct-tls-e2e-tests-$RUN_TOKEN"
+      E2E_IMAGE="$E2E_IMAGE_NAME:$E2E_IMAGE_TAG"
+      COMPOSE=(docker compose --project-name "$PROJECT_NAME" --file "$COMPOSE_FILE")
+      return 0
+    fi
+    attempts=$((attempts + 1))
+  done
+  echo "Error: failed to reserve a unique direct TLS E2E ownership token." >&2
+  return 1
+}
+
+assert_identities_available() {
+  local project_filter="label=com.docker.compose.project=$PROJECT_NAME"
+  if docker image inspect "$E2E_IMAGE" >/dev/null 2>&1 \
+    || [[ -n "$(docker image ls --quiet --no-trunc --filter "label=$IMAGE_OWNER_LABEL=$RUN_TOKEN")" ]]; then
+    echo "Error: direct TLS E2E image identity already exists; refusing to adopt it." >&2
+    return 1
+  fi
+  IMAGE_OWNERSHIP_ESTABLISHED=1
+  if [[ -n "$(docker container ls --all --quiet --filter "$project_filter")" ]] \
+    || [[ -n "$(docker network ls --quiet --filter "$project_filter")" ]] \
+    || [[ -n "$(docker volume ls --quiet --filter "$project_filter")" ]]; then
+    echo "Error: direct TLS E2E Compose identity already exists; refusing to adopt it." >&2
+    return 1
+  fi
+  COMPOSE_OWNERSHIP_ESTABLISHED=1
+}
+
+cleanup() {
+  local primary_status=$?
+  local cleanup_status=0
+  local command_status
+  local image_id
+
+  trap - EXIT INT TERM HUP
+  set +e
+
+  if [[ "$COMPOSE_OWNERSHIP_ESTABLISHED" -eq 1 ]]; then
+    "${COMPOSE[@]}" down --volumes --remove-orphans >/dev/null 2>&1
+    command_status=$?
+    [[ "$command_status" -eq 0 ]] || cleanup_status=$command_status
+  fi
+
+  if [[ "$IMAGE_OWNERSHIP_ESTABLISHED" -eq 1 ]]; then
+    while IFS= read -r image_id; do
+      [[ -z "$image_id" ]] && continue
+      docker image rm "$image_id" >/dev/null 2>&1
+      command_status=$?
+      [[ "$command_status" -eq 0 ]] || cleanup_status=$command_status
+    done < <(docker image ls --quiet --no-trunc \
+      --filter "label=$IMAGE_OWNER_LABEL=$RUN_TOKEN" 2>/dev/null)
+  fi
+
+  if [[ -n "$TLS_CERT_DIR" ]]; then
+    rm -rf -- "$TLS_CERT_DIR"
+    command_status=$?
+    [[ "$command_status" -eq 0 ]] || cleanup_status=$command_status
+  fi
+  if [[ -n "$RUN_STATE_DIR" ]]; then
+    rmdir "$RUN_STATE_DIR" 2>/dev/null
+    command_status=$?
+    [[ "$command_status" -eq 0 ]] || cleanup_status=$command_status
+  fi
+  rmdir "$TLS_RUNTIME_ROOT" 2>/dev/null
+
+  if [[ "$primary_status" -ne 0 ]]; then
+    exit "$primary_status"
+  fi
+  exit "$cleanup_status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+wait_for_healthy_services() {
+  local service
+  local status
+  local healthy
+  for _ in $(seq 1 30); do
+    healthy=0
+    for service in standalone cluster1 cluster2 cluster3; do
+      status="$("${COMPOSE[@]}" ps --format json "$service" 2>/dev/null \
+        | sed -n 's/.*"Health":"\([^"]*\)".*/\1/p')"
+      [[ "$status" == "healthy" ]] && healthy=$((healthy + 1))
+    done
+    [[ "$healthy" -eq 4 ]] && return 0
+    sleep 1
+  done
+  return 1
+}
+
+wait_for_cluster() {
+  for _ in $(seq 1 30); do
+    if "${COMPOSE[@]}" exec -T cluster1 \
+      redis-cli --tls --insecure -h cluster-node1.local -p 6380 cluster info \
+      2>/dev/null | grep -q '^cluster_state:ok'; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+cd "$REPO_ROOT"
+reserve_run_identity
+TLS_CERT_DIR="$("$SCRIPT_DIR/generate-test-tls-certs.sh" "$RUN_STATE_DIR")"
+export REDIS_TLS_CERT_DIR="$TLS_CERT_DIR"
+export REDIS_TLS_CERT_UID
+export REDIS_TLS_CERT_GID
+REDIS_TLS_CERT_UID="$(id -u)"
+REDIS_TLS_CERT_GID="$(id -g)"
+
+image_archive="$(
+  nix-build --no-out-link nix/direct-tls-e2e-docker.nix \
+    --argstr imageName "$E2E_IMAGE_NAME" \
+    --argstr imageTag "$E2E_IMAGE_TAG" \
+    --argstr imageOwner "$RUN_TOKEN"
+)"
+assert_identities_available
+docker load <"$image_archive"
+
+loaded_owner="$(
+  docker image inspect \
+    --format '{{ index .Config.Labels "com.redis-client.e2e.owner" }}' \
+    "$E2E_IMAGE"
+)"
+[[ "$loaded_owner" == "$RUN_TOKEN" ]] || {
+  echo "Error: loaded direct TLS E2E image has unexpected ownership." >&2
+  exit 1
+}
+
+"${COMPOSE[@]}" up --detach
+if ! wait_for_healthy_services; then
+  echo "Error: direct TLS E2E services did not become healthy." >&2
+  "${COMPOSE[@]}" ps
+  exit 1
+fi
+
+timeout 120 "${COMPOSE[@]}" exec -T cluster1 \
+  redis-cli --cluster create --cluster-replicas 0 --cluster-yes \
+    cluster-node1.local:6379 cluster-node2.local:6379 cluster-node3.local:6379
+if ! wait_for_cluster; then
+  echo "Error: direct TLS E2E cluster did not reach cluster_state:ok." >&2
+  exit 1
+fi
+
+network_name="${PROJECT_NAME}_default"
+network_owner="$(
+  docker network inspect \
+    --format '{{ index .Labels "com.docker.compose.project" }}' \
+    "$network_name"
+)"
+[[ "$network_owner" == "$PROJECT_NAME" ]] || {
+  echo "Error: direct TLS E2E network has unexpected ownership." >&2
+  exit 1
+}
+
+docker run --rm \
+  --network "$network_name" \
+  -v "$TLS_CERT_DIR/redis-ca.crt:/certs/redis-ca.crt:ro" \
+  -v "$TLS_CERT_DIR/untrusted-ca.crt:/certs/untrusted-ca.crt:ro" \
+  "$E2E_IMAGE"

--- a/scripts/test-tls-fixtures.sh
+++ b/scripts/test-tls-fixtures.sh
@@ -24,8 +24,27 @@ CERT_DIR="$("$SCRIPT_DIR/generate-test-tls-certs.sh" "$WORK_DIR/success")"
 [[ "$(stat -c '%a' "$CERT_DIR")" == "700" ]]
 [[ "$(stat -c '%a' "$CERT_DIR/redis-ca.key")" == "600" ]]
 [[ "$(stat -c '%a' "$CERT_DIR/redis-server.key")" == "600" ]]
+[[ "$(stat -c '%a' "$CERT_DIR/untrusted-ca.key")" == "600" ]]
 openssl verify -CAfile "$CERT_DIR/redis-ca.crt" "$CERT_DIR/redis-server.crt" >/dev/null
 openssl x509 -in "$CERT_DIR/redis-server.crt" -noout -checkhost redis.local >/dev/null
+openssl x509 -in "$CERT_DIR/redis-server.crt" -noout -checkhost standalone.redis.test >/dev/null
+openssl x509 -in "$CERT_DIR/redis-server.crt" -noout -checkhost cluster.redis.test >/dev/null
+for advertised_host in cluster-node1.local cluster-node2.local cluster-node3.local; do
+  if openssl x509 -in "$CERT_DIR/redis-server.crt" -noout \
+    -checkhost "$advertised_host" >/dev/null 2>&1; then
+    echo "Error: server certificate unexpectedly validates advertised host $advertised_host." >&2
+    exit 1
+  fi
+done
+if openssl x509 -in "$CERT_DIR/redis-server.crt" -noout \
+  -checkip 172.18.0.2 >/dev/null 2>&1; then
+  echo "Error: server certificate unexpectedly validates an advertised node IP." >&2
+  exit 1
+fi
+if openssl verify -CAfile "$CERT_DIR/untrusted-ca.crt" "$CERT_DIR/redis-server.crt" >/dev/null 2>&1; then
+  echo "Error: server certificate unexpectedly validates against the untrusted CA." >&2
+  exit 1
+fi
 
 rm -rf -- "$CERT_DIR"
 [[ ! -e "$CERT_DIR" ]]

--- a/test/DirectTLSE2E.hs
+++ b/test/DirectTLSE2E.hs
@@ -1,0 +1,345 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import           Control.Concurrent                    (threadDelay)
+import           Control.Concurrent.Async              (mapConcurrently)
+import           Control.Concurrent.STM                (readTVarIO)
+import           Control.Exception                     (SomeException, bracket,
+                                                        bracketOnError, try)
+import           Control.Monad                         (forM_)
+import           Control.Monad.IO.Class                (liftIO)
+import qualified Control.Monad.State                   as State
+import qualified Data.ByteString                       as BS
+import qualified Data.ByteString.Char8                 as BS8
+import qualified Data.ByteString.Lazy                  as LBS
+import           Data.IORef                            (atomicModifyIORef',
+                                                        newIORef)
+import qualified Data.Map.Strict                       as Map
+import           Database.Redis.Client                 (Client (..),
+                                                        ConnectionStatus (Connected),
+                                                        PlainTextClient,
+                                                        TLSClient)
+import           Database.Redis.Cluster                (ClusterNode (..),
+                                                        ClusterTopology (..),
+                                                        NodeAddress (..))
+import           Database.Redis.Cluster.Client         (ClusterClient (..),
+                                                        ClusterCommandClient,
+                                                        ClusterConfig (..),
+                                                        closeClusterClient,
+                                                        createClusterClient,
+                                                        refreshTopology,
+                                                        runClusterCommandClient)
+import           Database.Redis.Cluster.ConnectionPool (PoolConfig (..))
+import           Database.Redis.Command                (ClientState (..),
+                                                        RedisCommandClient (..),
+                                                        RedisCommands (..),
+                                                        encodeCommand,
+                                                        parseWith,
+                                                        runRedisCommandClient,
+                                                        showBS)
+import           Database.Redis.Connector              (clusterTLSConnector,
+                                                        connectPlaintext,
+                                                        connectTLS)
+import           Database.Redis.Resp                   (RespData (..))
+import           Database.Redis.Standalone             (StandaloneClient,
+                                                        StandaloneCommandClient,
+                                                        closeStandaloneClient,
+                                                        createStandaloneClient,
+                                                        runStandaloneClient)
+import           System.Environment                    (lookupEnv, setEnv,
+                                                        unsetEnv)
+import           System.Timeout                        (timeout)
+import           Test.Hspec
+
+main :: IO ()
+main = hspec $ do
+  describe "Direct standalone TLS" $ do
+    it "validates the certificate and supports PING and SET/GET" $
+      bracket (connectTLS "standalone.redis.test" 6380) close $ \connection -> do
+        runDirect connection ping `shouldReturn` RespSimpleString "PONG"
+        runDirect connection (set "direct:tls:key" "value")
+          `shouldReturn` RespSimpleString "OK"
+        runDirect connection (get "direct:tls:key")
+          `shouldReturn` RespBulkString "value"
+
+    it "rejects a wrong certificate hostname" $
+      withEnv "REDIS_CLIENT_TLS_INSECURE" Nothing $ do
+        result <- try $
+          clusterTLSConnector "wrong.redis.test"
+            (NodeAddress "standalone-target.local" 6380)
+          :: IO (Either SomeException (TLSClient 'Connected))
+        result `shouldSatisfyLeft` "wrong-hostname TLS connection unexpectedly succeeded"
+
+    it "rejects a server certificate signed by an untrusted CA" $
+      withEnv "REDIS_CLIENT_TLS_INSECURE" Nothing $
+        withEnv "SSL_CERT_FILE" (Just "/certs/untrusted-ca.crt") $
+          withEnv "SYSTEM_CERTIFICATE_PATH" (Just "/certs/untrusted-ca.crt") $ do
+            result <- try $ connectTLS "standalone.redis.test" 6380
+              :: IO (Either SomeException (TLSClient 'Connected))
+            result `shouldSatisfyLeft` "untrusted-CA TLS connection unexpectedly succeeded"
+
+    it "keeps insecure TLS as an explicit compatibility case" $
+      withEnv "REDIS_CLIENT_TLS_INSECURE" (Just "1") $
+        bracket
+          (clusterTLSConnector "wrong.redis.test"
+            (NodeAddress "standalone-target.local" 6380))
+          close $ \connection ->
+            runDirect connection ping `shouldReturn` RespSimpleString "PONG"
+
+    it "matches plaintext behavior under validated multiplexed concurrency" $
+      bracket createTLSStandalone closeStandaloneClient $ \client -> do
+        runStandalone client ping `shouldReturn` RespSimpleString "PONG"
+        results <- mapConcurrently
+          (\n -> do
+            let key = "standalone:tls:concurrent:" <> showBS n
+                value = "value:" <> showBS n
+            _ <- runStandalone client $ set key value
+            runStandalone client $ get key)
+          [1 .. 50 :: Int]
+        results `shouldBe`
+          [RespBulkString ("value:" <> showBS n) | n <- [1 .. 50 :: Int]]
+
+    it "closes the standalone multiplexer terminally" $ do
+      withPlaintextControls [standaloneControlNode] $ \controls -> do
+        baseline <- establishControlBaseline controls
+        bracketOnError createTLSStandalone closeStandaloneClient $ \client -> do
+          runStandalone client ping `shouldReturn` RespSimpleString "PONG"
+          _ <- waitForNormalClientCounts
+            "standalone TLS connection did not appear in CLIENT LIST"
+            controls
+            (countsAbove baseline)
+          closeStandaloneClient client
+          _ <- waitForNormalClientCounts
+            "standalone TLS connection remained after close"
+            controls
+            (== baseline)
+          assertPostCloseFailure $ runStandalone client ping
+
+  describe "TLS cluster connector" $ do
+    it "discovers advertised node addresses distinct from the certificate hostname" $
+      bracket createTLSCluster closeClusterClient $ \client -> do
+        topology <- readTVarIO $ clusterTopology client
+        let hosts = map (nodeHost . nodeAddress) $ Map.elems $ topologyNodes topology
+        length hosts `shouldBe` 3
+        hosts `shouldSatisfy` all (/= "cluster.redis.test")
+        hosts `shouldSatisfy` all (/= "")
+
+    it "matches plaintext PING and SET/GET behavior" $
+      bracket createTLSCluster closeClusterClient $ \client -> do
+        runCluster client ping `shouldReturn` RespSimpleString "PONG"
+        runCluster client (set "cluster:tls:key" "value")
+          `shouldReturn` RespSimpleString "OK"
+        runCluster client (get "cluster:tls:key")
+          `shouldReturn` RespBulkString "value"
+
+    it "refreshes topology over validated TLS" $
+      bracket createTLSCluster closeClusterClient $ \client -> do
+        initialUpdate <- topologyUpdateTime <$> readTVarIO (clusterTopology client)
+        threadDelay 100000
+        refreshTopology client
+        refreshedUpdate <- topologyUpdateTime <$> readTVarIO (clusterTopology client)
+        refreshedUpdate `shouldSatisfy` (> initialUpdate)
+
+    it "routes concurrent SET/GET operations over validated TLS" $
+      bracket createTLSCluster closeClusterClient $ \client -> do
+        results <- mapConcurrently
+          (\n -> do
+            let key = "cluster:tls:concurrent:" <> showBS n
+                value = "value:" <> showBS n
+            _ <- runCluster client $ set key value
+            runCluster client $ get key)
+          [1 .. 60 :: Int]
+        results `shouldBe`
+          [RespBulkString ("value:" <> showBS n) | n <- [1 .. 60 :: Int]]
+
+    it "closes all cluster transports and rejects later work" $ do
+      withPlaintextControls clusterControlNodes $ \controls -> do
+        baseline <- establishControlBaseline controls
+        bracketOnError createTLSCluster closeClusterClient $ \client -> do
+          establishClusterTLSConnections client controls baseline
+          closeClusterClient client
+          _ <- waitForNormalClientCounts
+            "cluster TLS connections remained after close"
+            controls
+            (== baseline)
+          assertPostCloseFailure $ runCluster client ping
+
+runDirect
+  :: TLSClient 'Connected
+  -> RedisCommandClient TLSClient a
+  -> IO a
+runDirect connection command =
+  State.evalStateT
+    (runRedisCommandClient command)
+    (ClientState connection BS.empty)
+
+standaloneNode :: NodeAddress
+standaloneNode = NodeAddress "standalone-target.local" 6380
+
+standaloneControlNode :: NodeAddress
+standaloneControlNode = NodeAddress "standalone-target.local" 6379
+
+clusterControlNodes :: [NodeAddress]
+clusterControlNodes =
+  [ NodeAddress "cluster-node1.local" 6379
+  , NodeAddress "cluster-node2.local" 6379
+  , NodeAddress "cluster-node3.local" 6379
+  ]
+
+createTLSStandalone :: IO StandaloneClient
+createTLSStandalone =
+  createStandaloneClient
+    (clusterTLSConnector "standalone.redis.test")
+    standaloneNode
+
+runStandalone
+  :: StandaloneClient
+  -> StandaloneCommandClient RespData
+  -> IO RespData
+runStandalone = runStandaloneClient
+
+createTLSCluster :: IO (ClusterClient TLSClient)
+createTLSCluster =
+  createClusterClient config $ clusterTLSConnector "cluster.redis.test"
+  where
+    config = ClusterConfig
+      { clusterSeedNode = NodeAddress "cluster-node1.local" 6380
+      , clusterPoolConfig = PoolConfig
+          { maxConnectionsPerNode = 2
+          , connectionTimeout = 5
+          , maxRetries = 3
+          , useTLS = True
+          }
+      , clusterMaxRetries = 3
+      , clusterRetryDelay = 100000
+      , clusterTopologyRefreshInterval = 600
+      }
+
+runCluster
+  :: ClusterClient TLSClient
+  -> ClusterCommandClient TLSClient RespData
+  -> IO RespData
+runCluster = runClusterCommandClient
+
+withPlaintextControls
+  :: [NodeAddress]
+  -> ([PlainTextClient 'Connected] -> IO a)
+  -> IO a
+withPlaintextControls nodes action = acquire nodes []
+  where
+    acquire [] controls = action $ reverse controls
+    acquire (NodeAddress host port : remaining) controls =
+      bracket
+        (connectPlaintext host port)
+        close
+        (\control -> acquire remaining (control : controls))
+
+establishControlBaseline
+  :: [PlainTextClient 'Connected]
+  -> IO [Int]
+establishControlBaseline controls = do
+  samples <- newIORef Nothing
+  pollUntil
+    "plaintext control connections did not reach a stable baseline" $ do
+      counts <- mapM normalClientCount controls
+      atomicModifyIORef' samples $ \previous ->
+        let stableSamples = case previous of
+              Just (previousCounts, sampleCount)
+                | previousCounts == counts -> sampleCount + 1
+              _ -> 1
+            next = Just (counts, stableSamples)
+            result
+              | stableSamples >= 5 = Just counts
+              | otherwise = Nothing
+        in (next, result)
+
+establishClusterTLSConnections
+  :: ClusterClient TLSClient
+  -> [PlainTextClient 'Connected]
+  -> [Int]
+  -> IO ()
+establishClusterTLSConnections client controls baseline = do
+  forM_ [1 .. 300 :: Int] $ \n -> do
+    let key = "cluster:tls:cleanup:" <> showBS n
+        value = "value:" <> showBS n
+    runCluster client (set key value) `shouldReturn` RespSimpleString "OK"
+    runCluster client (get key) `shouldReturn` RespBulkString value
+  _ <- waitForNormalClientCounts
+    "TLS connections were not established to every cluster node"
+    controls
+    (countsAbove baseline)
+  return ()
+
+countsAbove :: [Int] -> [Int] -> Bool
+countsAbove baseline counts =
+  length counts == length baseline
+    && and (zipWith (>) counts baseline)
+
+waitForNormalClientCounts
+  :: String
+  -> [PlainTextClient 'Connected]
+  -> ([Int] -> Bool)
+  -> IO [Int]
+waitForNormalClientCounts description controls predicate =
+  pollUntil description $ do
+    counts <- mapM normalClientCount controls
+    return $ if predicate counts then Just counts else Nothing
+
+pollUntil :: String -> IO (Maybe a) -> IO a
+pollUntil description check = do
+  result <- timeout 5000000 loop
+  case result of
+    Just value -> return value
+    Nothing    -> expectationFailure description >> fail description
+  where
+    loop = do
+      outcome <- check
+      case outcome of
+        Just value -> return value
+        Nothing    -> threadDelay 20000 >> loop
+
+normalClientCount :: PlainTextClient 'Connected -> IO Int
+normalClientCount connection = do
+  response <- runPlaintextRaw connection ["CLIENT", "LIST", "TYPE", "NORMAL"]
+  case response of
+    RespBulkString payload ->
+      return $ length $ filter (not . BS.null) $ BS8.lines payload
+    other ->
+      fail $ "Unexpected CLIENT LIST response: " ++ show other
+
+runPlaintextRaw
+  :: PlainTextClient 'Connected
+  -> [BS.ByteString]
+  -> IO RespData
+runPlaintextRaw connection arguments =
+  State.evalStateT
+    (runRedisCommandClient $ RedisCommandClient $ do
+      ClientState connected _ <- State.get
+      liftIO $ send connected $ LBS.fromStrict $ encodeCommand arguments
+      parseWith $ liftIO $ receive connected)
+    (ClientState connection BS.empty)
+
+assertPostCloseFailure :: IO RespData -> Expectation
+assertPostCloseFailure command = do
+  outcome <- timeout 2000000 $
+    try command :: IO (Maybe (Either SomeException RespData))
+  outcome `shouldSatisfy` maybe False isLeft
+
+withEnv :: String -> Maybe String -> IO a -> IO a
+withEnv name value action =
+  bracket (lookupEnv name) restore $ \_ -> setRequested >> action
+  where
+    setRequested = maybe (unsetEnv name) (setEnv name) value
+    restore previous = maybe (unsetEnv name) (setEnv name) previous
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _        = False
+
+shouldSatisfyLeft :: Either a b -> String -> Expectation
+shouldSatisfyLeft (Left _) _        = return ()
+shouldSatisfyLeft (Right _) message = expectationFailure message
+
+infix 1 `shouldSatisfyLeft`


### PR DESCRIPTION
Closes #59

## Summary

- Add isolated certificate-validated standalone and Redis Cluster TLS fixtures.
- Exercise direct `connectTLS`, multiplexed standalone TLS, and `clusterTLSConnector` with advertised addresses that are not valid certificate hostnames.
- Prove deterministic wrong-hostname and untrusted-CA failures; retain insecure TLS only as an explicit compatibility case.
- Cover PING, SET/GET, topology discovery/refresh, concurrency, terminal behavior, and physical TLS connection cleanup.

Working as Protocol (Redis Protocol Engineer).

## Path acceptance

- [ ] **Cross-cutting change:** replace every applicable matrix prompt with impact and validation evidence.
- [x] **Narrow or docs-only change:** the entire matrix is **N/A** unless a row is explicitly overridden; no additional N/A explanation is required.

| Path or gate | Impact and evidence, or **N/A** |
| --- | --- |
| Public API and exports | N/A |
| Keyed paths | TLS SET/GET exercised for standalone and cluster clients. |
| Keyless paths | TLS PING and topology discovery/refresh exercised. |
| Standalone paths | Direct `connectTLS`, multiplexing, concurrent commands, certificate failures, and physical socket cleanup covered. |
| Cluster paths | `clusterTLSConnector` validates `cluster.redis.test` while topology advertises distinct node addresses; routed commands, refresh, concurrency, and all-node cleanup covered. |
| Reconnect behavior | N/A |
| Redirect behavior | N/A |
| Live-fixture needs | Isolated token-owned Compose project with one standalone Redis and a three-primary dual-port cluster. |
| Required specialist reviewers | Protocol implementation; independent Tester review approved. |
| Intentionally untested paths | TLS cluster-bus encryption is outside client connector scope; cluster bootstrap/bus uses plaintext while all tested client traffic uses TLS port 6380. |
| Nix-first build | `nix-build --no-out-link` passed at `282dcadaa71b17e3cb87a9347eac2e75b7ffe6d4`. |
| Targeted tests | `./scripts/run-direct-tls-e2e-tests.sh` passed 11 examples; fixture validation passed. |
| Full `make test` | Passed at `282dcadaa71b17e3cb87a9347eac2e75b7ffe6d4`. |
| Profiling | N/A; no production code changed. |

## Cleanup evidence

Cleanup tests poll `CLIENT LIST TYPE NORMAL` until standalone and every cluster node return to independently measured baselines. The runner removes only its token-owned Compose project, image, ephemeral certificates, and state directory; post-run checks found no matching resources.